### PR TITLE
Fix bug with /player GET and /chat GET

### DIFF
--- a/src/authorization/rule/playerRules.ts
+++ b/src/authorization/rule/playerRules.ts
@@ -3,7 +3,6 @@ import {AbilityBuilder, createMongoAbility, ExtractSubjectType} from "@casl/abil
 import {Action} from "../enum/action.enum";
 import {InferSubjects, MongoAbility} from "@casl/ability/dist/types";
 import {PlayerDto} from "../../player/dto/player.dto";
-import {UpdatePlayerDto} from "../../player/dto/updatePlayer.dto";
 import {RulesSetterAsync} from "../type/RulesSetter.type";
 import {isClanAdmin} from "../util/isClanAdmin";
 import {ModelName} from "../../common/enum/modelName.enum";
@@ -20,7 +19,7 @@ export const playerRules: RulesSetterAsync<Ability, Subjects> = async (user, sub
     if(action === Action.create || action === Action.read){
         can(Action.create_request, subject);
 
-        const publicFields = ['_id', 'name', 'uniqueIdentifier', 'profile_id'];
+        const publicFields = ['_id', 'name', 'uniqueIdentifier', 'profile_id', 'clan_id', 'Clan', 'CustomCharacter'];
         can(Action.read_request, subject);
         can(Action.read_response, subject, publicFields);
         can(Action.read_response, subject, {_id: user.player_id});

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -43,7 +43,7 @@ export class ChatController {
 
     @Post()
     @BasicPOST(ChatDto)
-    public async create(@Body() body: CreateChatDto) {
+    public create(@Body() body: CreateChatDto) {
         return this.service.createOne(body);
     }
 
@@ -69,7 +69,7 @@ export class ChatController {
 
     @Put()
     @BasicPUT(ModelName.CHAT)
-    public async update(@Body() body: UpdateChatDto) {
+    public update(@Body() body: UpdateChatDto) {
         return this.service.updateOneById(body);
     }
 
@@ -83,7 +83,7 @@ export class ChatController {
     @Post('/:chat_id/messages')
     @HttpCode(204)
     @BasicPOST(ChatDto)
-    public async createMessage(@Param() param: chat_idParam, @Body() body: CreateMessageDto) {
+    public createMessage(@Param() param: chat_idParam, @Body() body: CreateMessageDto) {
         return this.service.createMessage(param.chat_id, body);
     }
 

--- a/src/common/interceptor/request/offsetPagination.interceptor.ts
+++ b/src/common/interceptor/request/offsetPagination.interceptor.ts
@@ -38,8 +38,10 @@ export function OffsetPaginate(modelName: ModelName, minLimit: number=20, maxLim
                 if(!data)
                     return data;
 
-                const dataParsed = data as IResponseShape;
-                if(!dataParsed || dataParsed.metaData.dataType === 'Object')
+                const dataParsed = await data as IResponseShape;
+                if(!dataParsed || !dataParsed.metaData || 
+                    !dataParsed.metaData.dataType || 
+                    dataParsed.metaData.dataType === 'Object')
                     return data;
 
                 const request = context.switchToHttp().getRequest<Request>();


### PR DESCRIPTION
1. Fix bug with /player GET not returning clan_id field. It was due to clan_id was not included as public field in player authorization rules
2. Fix bug with /chat GET returning Server error. It was due to improper data parsing in the @OffsetPaginate() interceptor. If data was a Promise it was not awaited and later the interceptor was trying to access properties of this promise, which were not exist

Closes #124 