### PR TITLE
Feature/retrieve player tasks 203

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ testAPI/**/*spec.js.map
 
 #IDEs
 .idea/
+.vscode/

--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,12 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": false
+    "deleteOutDir": false,
+    "assets": [
+      {
+        "include": "src/playerTasks/playerTasks.json",
+        "outDir": "dist"
+      }
+    ]
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { ClanVoteModule } from './shop/clanVote/clanVote.module';
 import { ItemShopModule } from './shop/itemShop/itemShop.module';
 import { GameDataModule } from './gameData/gameData.module';
 import { GameAnalyticsModule } from './gameAnalytics/gameAnalytics.module';
+import { PlayerTasksModule } from './playerTasks/playerTasks.module';
 
 // Set up database connection
 const mongoUser = process.env.MONGO_USERNAME || 'rootUser';
@@ -62,7 +63,8 @@ const mongoString = `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mong
       PermissionModule,
       ApiStateModule,
       GameDataModule,
-      GameAnalyticsModule
+      GameAnalyticsModule,
+      PlayerTasksModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/playerTasks/enum/taskName.enum.ts
+++ b/src/playerTasks/enum/taskName.enum.ts
@@ -1,0 +1,27 @@
+/**
+ * Enum used to represent the different types of tasks in the application.
+ *
+ * This enum is used in various parts of the application, such as:
+ * - When defining tasks in the JSON configuration file
+ * - When processing tasks in the service layer
+ * - When returning task data to the client side
+ *
+ * Notice that whenever there is a need to add a new task type, this enum must be updated with the new task name.
+ *
+ * Notice that whenever there is a need to specify a task type, this enum must be used instead of plain text.
+ * @example ```ts
+ * // Do not write it as plain text
+ * const taskType = 'play_battle';
+ * // Use the enum instead
+ * const taskType = TaskName.PLAY_BATTLE;
+ * ```
+ */
+export enum TaskName {
+	PLAY_BATTLE = "play_battle",
+	START_VOTING = "start_voting",
+	COLLECT_DIAMONDS = "collect_diamonds_in_battle",
+	WIN_BATTLE = "win_battle",
+	WRITE_CHAT_MESSAGE = "write_chat_message",
+	START_BATTLE_NEW_CHARACTER = "start_battle_with_new_character",
+	VOTE = "vote",
+}

--- a/src/playerTasks/playerTasks.controller.ts
+++ b/src/playerTasks/playerTasks.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { PlayerTasksService } from './playerTasks.service';
+
+@Controller('playerTasks')
+export class PlayerTasksController {
+	constructor(
+		private readonly playerTasksService: PlayerTasksService
+	){}
+
+	@Get()
+	getPlayerTasks() {
+	}
+}

--- a/src/playerTasks/playerTasks.json
+++ b/src/playerTasks/playerTasks.json
@@ -1,0 +1,433 @@
+{
+	"monday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"tuesday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"wednesday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"thursday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"friday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"saturday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"sunday": [
+		{
+			"id": 1,
+			"title": { "fi": "Pelaa 3 taistelua" },
+			"content": { "fi": "Sun pitää pelata tänään 3 taistelua" },
+			"amount": 3,
+			"type": "play_battle",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 2,
+			"title": { "fi": "Voita 5 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tänään 5 taistelua" },
+			"amount": 5,
+			"type": "win_battle",
+			"coins": 250,
+			"points": 500
+		},
+		{
+			"id": 3,
+			"title": { "fi": "Lähetä 10 viestiä chattiin" },
+			"content": { "fi": "Sun pitää lähettää tänään 10 viestiä chattiin" },
+			"amount": 10,
+			"type": "write_chat_message",
+			"coins": 45,
+			"points": 90
+		},
+		{
+			"id": 4,
+			"title": { "fi": "Aloita taistelu eri hahmolla" },
+			"content": { "fi": "Sun pitää aloittaa taistelu eri hahmolla" },
+			"amount": 3,
+			"type": "start_battle_with_new_character",
+			"coins": 30,
+			"points": 60
+		},
+		{
+			"id": 5,
+			"title": { "fi": "Äänestä 2 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tänään 2 kertaa" },
+			"amount": 2,
+			"type": "vote",
+			"coins": 20,
+			"points": 40
+		}
+	],
+	"weekly": [
+		{
+			"id": 11,
+			"title": { "fi": "Pelaa 20 taistelua" },
+			"content": { "fi": "Sun pitää pelata tällä viikolla 20 taistelua" },
+			"amount": 20,
+			"type": "play_battle",
+			"coins": 200,
+			"points": 400
+		},
+		{
+			"id": 12,
+			"title": { "fi": "Voita 50 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tällä viikolla 50 taistelua" },
+			"amount": 50,
+			"type": "win_battle",
+			"coins": 2500,
+			"points": 5000
+		},
+		{
+			"id": 13,
+			"title": { "fi": "Lähetä 30 viestiä chattiin" },
+			"content": {
+				"fi": "Sun pitää lähettää tällä viikolla 30 viestiä chattiin"
+			},
+			"amount": 30,
+			"type": "write_chat_message",
+			"coins": 450,
+			"points": 900
+		},
+		{
+			"id": 14,
+			"title": { "fi": "Aloita 5 taistelua eri hahmolla" },
+			"content": {
+				"fi": "Sun pitää aloittaa tällä viikolla 5 taistelua eri hahmolla"
+			},
+			"amount": 5,
+			"type": "start_battle_with_new_character",
+			"coins": 50,
+			"points": 100
+		},
+		{
+			"id": 15,
+			"title": { "fi": "Äänestä 10 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tällä viikolla 10 kertaa" },
+			"amount": 10,
+			"type": "vote",
+			"coins": 50,
+			"points": 100
+		}
+	],
+	"monthly": [
+		{
+			"id": 16,
+			"title": { "fi": "Pelaa 100 taistelua" },
+			"content": { "fi": "Sun pitää pelata tässä kuussa 100 taistelua" },
+			"amount": 100,
+			"type": "play_battle",
+			"coins": 1000,
+			"points": 2000
+		},
+		{
+			"id": 17,
+			"title": { "fi": "Voita 100 taistelua" },
+			"content": { "fi": "Sun pitää voittaa tässä kuussa 100 taistelua" },
+			"amount": 100,
+			"type": "win_battle",
+			"coins": 5000,
+			"points": 10000
+		},
+		{
+			"id": 18,
+			"title": { "fi": "Lähetä 500 viestiä chattiin" },
+			"content": {
+				"fi": "Sun pitää lähettää tässä kuussa 500 viestiä chattiin"
+			},
+			"amount": 500,
+			"type": "write_chat_message",
+			"coins": 7500,
+			"points": 15000
+		},
+		{
+			"id": 19,
+			"title": { "fi": "Aloita 30 taistelua eri hahmolla" },
+			"content": {
+				"fi": "Sun pitää aloittaa tässä kuussa 30 taistelua eri hahmolla"
+			},
+			"amount": 30,
+			"type": "start_battle_with_new_character",
+			"coins": 450,
+			"points": 900
+		},
+		{
+			"id": 20,
+			"title": { "fi": "Äänestä 50 kertaa" },
+			"content": { "fi": "Sun pitää äänestää tässä kuussa 50 kertaa" },
+			"amount": 50,
+			"type": "vote",
+			"coins": 2500,
+			"points": 5000
+		}
+	]
+}

--- a/src/playerTasks/playerTasks.module.ts
+++ b/src/playerTasks/playerTasks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { PlayerTasksService } from './playerTasks.service';
+import { PlayerTasksController } from './playerTasks.controller';
+
+@Module({
+  providers: [PlayerTasksService],
+  controllers: [PlayerTasksController],
+  exports: [PlayerTasksService],
+})
+export class PlayerTasksModule {}

--- a/src/playerTasks/playerTasks.service.ts
+++ b/src/playerTasks/playerTasks.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PlayerTasks } from './type/task.type';
+
+@Injectable()
+export class PlayerTasksService implements OnModuleInit {
+	private tasks: PlayerTasks;
+
+	onModuleInit() {
+		const filePath = path.join(__dirname, 'playerTasks.json');
+		const fileContent = fs.readFileSync(filePath, 'utf-8');
+		this.tasks = JSON.parse(fileContent);
+	}
+
+}

--- a/src/playerTasks/playerTasks.service.ts
+++ b/src/playerTasks/playerTasks.service.ts
@@ -1,12 +1,16 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
-import { PlayerTasks } from './type/task.type';
+import { PlayerTasks } from './type/tasks.type';
 
 @Injectable()
 export class PlayerTasksService implements OnModuleInit {
 	private tasks: PlayerTasks;
 
+	/**
+	 * Initializes the tasks by loading and parsing them from a JSON file.
+	 * This method is called once the module has been initialized.
+	 */
 	onModuleInit() {
 		const filePath = path.join(__dirname, 'playerTasks.json');
 		const fileContent = fs.readFileSync(filePath, 'utf-8');

--- a/src/playerTasks/type/task.type.ts
+++ b/src/playerTasks/type/task.type.ts
@@ -1,0 +1,26 @@
+import { TaskName } from "../enum/taskName.enum";
+
+export type Task = {
+	id: number;
+	title: {
+		fi: string;
+	};
+	content: {
+		fi: string;
+	};
+	amount: number;
+	type: TaskName;
+	coins: number;
+	points: number;
+}
+
+export type PlayerTasks = {
+	monday: Task[];
+	tuesday: Task[];
+	wednesday: Task[];
+	friday: Task[];
+	saturday: Task[];
+	sunday: Task[];
+	weekly: Task[];
+	monthly: Task[];
+}

--- a/src/playerTasks/type/task.type.ts
+++ b/src/playerTasks/type/task.type.ts
@@ -1,5 +1,18 @@
 import { TaskName } from "../enum/taskName.enum";
 
+/**
+ * Represents a task with its details.
+ * 
+ * @property id - The unique identifier for the task.
+ * @property title - The title of the task.
+ * @property title.fi - The Finnish title of the task.
+ * @property content - The content/description of the task.
+ * @property content.fi - The Finnish content/description of the task.
+ * @property amount - The amount required to complete the task.
+ * @property type - The type of the task.
+ * @property coins - The number of coins rewarded for completing the task.
+ * @property points - The number of points rewarded for completing the task.
+ */
 export type Task = {
 	id: number;
 	title: {
@@ -12,15 +25,4 @@ export type Task = {
 	type: TaskName;
 	coins: number;
 	points: number;
-}
-
-export type PlayerTasks = {
-	monday: Task[];
-	tuesday: Task[];
-	wednesday: Task[];
-	friday: Task[];
-	saturday: Task[];
-	sunday: Task[];
-	weekly: Task[];
-	monthly: Task[];
 }

--- a/src/playerTasks/type/tasks.type.ts
+++ b/src/playerTasks/type/tasks.type.ts
@@ -1,0 +1,26 @@
+import { Task } from "./task.type";
+
+/**
+ * Represents the tasks that players can complete.
+ * Loaded from playerTasks.json
+ * This type needs to updated if the structure of the JSON file changes.
+ * 
+ * @property monday - The tasks assigned for Monday.
+ * @property tuesday - The tasks assigned for Tuesday.
+ * @property wednesday - The tasks assigned for Wednesday.
+ * @property friday - The tasks assigned for Friday.
+ * @property saturday - The tasks assigned for Saturday.
+ * @property sunday - The tasks assigned for Sunday.
+ * @property weekly - The tasks assigned for the week.
+ * @property monthly - The tasks assigned for the month.
+ */
+export type PlayerTasks = {
+	monday: Task[];
+	tuesday: Task[];
+	wednesday: Task[];
+	friday: Task[];
+	saturday: Task[];
+	sunday: Task[];
+	weekly: Task[];
+	monthly: Task[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,5 +99,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+  },
+  "include": ["src/**/*.ts", "src/playerTasks/playerTasks.json"],
 }


### PR DESCRIPTION
The json file now has separate arrays for days from Monday to Sunday, weekly and monthly.
I wasn't sure if the Saturday and Sunday were supposed to be combined into weekend and should there already be the different options for weeks and months like week1, week2.
The PlayerTasks type is configured for the current layout of the json file but those can be easily altered later on if needed.

I also added enum for the task types. I figured that will be useful later.

The PlayerTasksService holds the tasks and loads them from the json file on module init.