### PR TITLE
Feature/player tasks get endpoint 219

### DIFF
--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -216,7 +216,8 @@ export class GameDataService {
 		this.taskService.updateTask(user.player_id, TaskName.PLAY_BATTLE);
 		if (!playerInWinningTeam)
 			return new APIError({ reason: APIErrorReason.NOT_AUTHORIZED, message: "Invalid type field" });
-		
+
+		this.taskService.updateTask(user.player_id, TaskName.WIN_BATTLE);
 		this.playerService.addWonPlayedGame(user.player_id);
 		const [teamIds, teamIdsErrors] = await this.getClanIdForTeams([battleResult.team1[0], battleResult.team2[0]]);
 		if (teamIdsErrors)

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -215,7 +215,7 @@ export class GameDataService {
 		this.playerService.addPlayedGame(user.player_id);
 		this.taskService.updateTask(user.player_id, TaskName.PLAY_BATTLE);
 		if (!playerInWinningTeam)
-			return new APIError({ reason: APIErrorReason.NOT_AUTHORIZED, message: "Invalid type field" });
+			return new APIError({ reason: APIErrorReason.NOT_AUTHORIZED, message: "Player is not in the winning team and therefore is not allowed to steal" });
 
 		this.taskService.updateTask(user.player_id, TaskName.WIN_BATTLE);
 		this.playerService.addWonPlayedGame(user.player_id);

--- a/src/playerTasks/decorator/period.decorator.ts
+++ b/src/playerTasks/decorator/period.decorator.ts
@@ -12,8 +12,6 @@ export const Period = createParamDecorator((_, context: ExecutionContext) => {
 	const period = request.query["period"] ?? "today";
 
 	switch (period) {
-		case "today":
-			return TaskFrequency.DAILY;
 		case "week":
 			return TaskFrequency.WEEKLY;
 		case "month":

--- a/src/playerTasks/decorator/period.decorator.ts
+++ b/src/playerTasks/decorator/period.decorator.ts
@@ -1,0 +1,24 @@
+import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { TaskFrequency } from "../enum/taskFrequency.enum";
+
+/**
+ * Decorator to get the period query parameter from the request.
+ *
+ * @param context - The execution context of the request.
+ * @returns Task frequency and defaults to daily if period is not provided in the query;
+ */
+export const Period = createParamDecorator((_, context: ExecutionContext) => {
+	const request = context.switchToHttp().getRequest();
+	const period = request.query["period"] ?? "today";
+
+	switch (period) {
+		case "today":
+			return TaskFrequency.DAILY;
+		case "week":
+			return TaskFrequency.WEEKLY;
+		case "month":
+			return TaskFrequency.MONTHLY;
+		default:
+			return TaskFrequency.DAILY;
+	}
+});

--- a/src/playerTasks/decorator/period.decorator.ts
+++ b/src/playerTasks/decorator/period.decorator.ts
@@ -9,7 +9,7 @@ import { TaskFrequency } from "../enum/taskFrequency.enum";
  */
 export const Period = createParamDecorator((_, context: ExecutionContext) => {
 	const request = context.switchToHttp().getRequest();
-	const period = request.query["period"] ?? "today";
+	const period = request.query["period"];
 
 	switch (period) {
 		case "week":

--- a/src/playerTasks/playerTasks.controller.ts
+++ b/src/playerTasks/playerTasks.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { PlayerTasksService } from './playerTasks.service';
+import { LoggedUser } from '../common/decorator/param/LoggedUser.decorator';
+import { User } from '../auth/user';
+import { TaskFrequency } from './enum/taskFrequency.enum';
+import { UniformResponse } from '../common/decorator/response/UniformResponse';
+import { ModelName } from '../common/enum/modelName.enum';
+import { Period } from './decorator/period.decorator';
 
 @Controller('playerTasks')
 export class PlayerTasksController {
@@ -8,6 +14,8 @@ export class PlayerTasksController {
 	){}
 
 	@Get()
-	getPlayerTasks() {
+	@UniformResponse(ModelName.PLAYER_TASK)
+	async getPlayerTasks(@Period() period: TaskFrequency, @LoggedUser() user: User) {
+		return await this.playerTasksService.getPlayerTasks(user.player_id, period)
 	}
 }

--- a/src/playerTasks/playerTasks.service.ts
+++ b/src/playerTasks/playerTasks.service.ts
@@ -66,28 +66,31 @@ export class PlayerTasksService implements OnModuleInit {
 		if (errors)
 			return [null, errors];
 
-		// Update the amount in tasks from the database.
-		tasks.forEach((task) => {
-			playerTasks['daily'].forEach((playerTask) => {
-				if (playerTask.id === task.taskId) {
-					playerTask.amount = task.amountLeft;
-				}
-			})
-
-			playerTasks.weekly?.forEach((playerTask) => {
-				if (playerTask.id === task.taskId) {
-					playerTask.amount = task.amountLeft;
-				}
-			})
-
-			playerTasks.monthly?.forEach((playerTask) => {
-				if (playerTask.id === task.taskId) {
-					playerTask.amount = task.amountLeft;
-				}
-			})
-		})
+		playerTasks = this.updateTaskAmounts(tasks, playerTasks);
 
 		return [playerTasks, null];
+	}
+
+	/**
+	 * Updates the amount field on tasks.
+	 * 
+	 * This method iterates over the tasks retrieved from the database and
+	 * updates tasks from the JSON file with the amountLeft from the db document.
+	 * 
+	 * @param dbTasks - Players tasks from the database.
+	 * @param jsonTasks - Tasks from the json file.
+	 * @returns - Json tasks with the updated amount from db tasks.
+	 */
+	private updateTaskAmounts(dbTasks: TaskProgress[], jsonTasks: Partial<PlayerTasks>) {
+		dbTasks.forEach((dbTask) => {
+			for(const period in jsonTasks) {
+				jsonTasks[period].forEach((jsonTask) => {
+					if (jsonTask.id === dbTask.taskId) 
+						jsonTask.amount = dbTask.amountLeft;
+				})
+			}
+		})
+		return jsonTasks;
 	}
 
 	/**

--- a/src/playerTasks/playerTasks.service.ts
+++ b/src/playerTasks/playerTasks.service.ts
@@ -156,7 +156,12 @@ export class PlayerTasksService implements OnModuleInit {
 		if (tasksError && tasksError[0].reason !== SEReason.NOT_FOUND)
 			throw tasksError;
 
-		const task = tasks?.find(task => taskFrequency === this.determineTaskFrequency(task.taskId))
+		const task = tasks?.find(task => {
+			const { type } = this.getTaskDefaultData(task.taskId);
+			const frequency = this.determineTaskFrequency(task.taskId);
+
+			return type === taskName && taskFrequency === frequency;
+		});
 
 		//If there was no task defined in DB, add it to DB, update its amountLeft and send notification
 		if (!task) {
@@ -306,7 +311,7 @@ export class PlayerTasksService implements OnModuleInit {
 			const foundTask = periodTasks.find(task => task.id === taskId);
 
 			if(foundTask)
-				return foundTask;
+				return {...foundTask};
 		}
 	}
 }

--- a/src/playerTasks/playerTasks.service.ts
+++ b/src/playerTasks/playerTasks.service.ts
@@ -53,7 +53,7 @@ export class PlayerTasksService implements OnModuleInit {
 	async getPlayerTasks(playerId: string, taskFrequency: TaskFrequency) {
 		const today = new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(new Date()).toLowerCase();
 		let playerTasks: Partial<PlayerTasks> = {};
-		playerTasks[today] = this.tasks[today];
+		playerTasks['daily'] = this.tasks[today];
 
 		if (taskFrequency === TaskFrequency.MONTHLY) {
 			playerTasks.weekly = this.tasks.weekly;
@@ -68,7 +68,7 @@ export class PlayerTasksService implements OnModuleInit {
 
 		// Update the amount in tasks from the database.
 		tasks.forEach((task) => {
-			playerTasks[today].forEach((playerTask) => {
+			playerTasks['daily'].forEach((playerTask) => {
 				if (playerTask.id === task.taskId) {
 					playerTask.amount = task.amountLeft;
 				}

--- a/src/playerTasks/type/tasks.type.ts
+++ b/src/playerTasks/type/tasks.type.ts
@@ -18,6 +18,7 @@ export type PlayerTasks = {
 	monday: Task[];
 	tuesday: Task[];
 	wednesday: Task[];
+	thursday: Task[];
 	friday: Task[];
 	saturday: Task[];
 	sunday: Task[];

--- a/src/playerTasks/type/tasks.type.ts
+++ b/src/playerTasks/type/tasks.type.ts
@@ -8,6 +8,7 @@ import { Task } from "./task.type";
  * @property monday - The tasks assigned for Monday.
  * @property tuesday - The tasks assigned for Tuesday.
  * @property wednesday - The tasks assigned for Wednesday.
+ * @property thursday - The tasks assigned for Thursday.
  * @property friday - The tasks assigned for Friday.
  * @property saturday - The tasks assigned for Saturday.
  * @property sunday - The tasks assigned for Sunday.


### PR DESCRIPTION
I implemented the logic for GET /playerTasks endpoint.

I created a decorator that gets the period (today, week, month) from the request and defaults to daily if not provided.
The method for getting the tasks adds the tasks (daily, weekly, monthly) based on the period value from the request.
After getting the tasks the method finds the tasks of the player who made the request from the db and updates the amount field on the task based on the task ids and amountLeft field if a task is found in the db and then returns the array of tasks.

I also noticed that the PlayerTasks type was missing Thursday so I added it to the type.