### PR TITLE
Feature/add won battles reward 209

### DIFF
--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -212,13 +212,12 @@ export class GameDataService {
 		const currentTime = new Date();
 		const winningTeam = battleResult.winnerTeam === 1 ? battleResult.team1 : battleResult.team2;
 		const playerInWinningTeam = winningTeam.includes(user.player_id);
-		this.playerService.addPlayedGame(user.player_id);
+		this.playerService.handlePlayedBattle(user.player_id, playerInWinningTeam);
 		this.taskService.updateTask(user.player_id, TaskName.PLAY_BATTLE);
 		if (!playerInWinningTeam)
 			return new APIError({ reason: APIErrorReason.NOT_AUTHORIZED, message: "Player is not in the winning team and therefore is not allowed to steal" });
 
 		this.taskService.updateTask(user.player_id, TaskName.WIN_BATTLE);
-		this.playerService.addWonPlayedGame(user.player_id);
 		const [teamIds, teamIdsErrors] = await this.getClanIdForTeams([battleResult.team1[0], battleResult.team2[0]]);
 		if (teamIdsErrors)
 			return teamIdsErrors

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -115,30 +115,21 @@ export class PlayerService
 
         return true;
     }
-    
-    /**
-     * Increments the playedBattles field in the gameStatistics object for the specified player.
-     * 
-     * @param playerId - The ID of the player whose playedBattles field should be incremented.
-     * @throws Will throw an error if the update operation fails.
-     */
-    async addPlayedGame(playerId: string) {
-        const update = { $inc: { 'gameStatistics.playedBattles': 1 } };
-        const [_, updateError] = await this.basicService.updateOneById(playerId, update);
-        if (updateError)
-            throw updateError;
-    }
 
     /**
-     * Increments the wonBattles field in the gameStatistics object for the specified player.
+     * Increments the points, played and won battles of a specified player based on the battle outcome.
      * 
-     * @param playerId - The ID of the player whose wonBattles field should be incremented.
-     * @throws Will throw an error if the update operation fails.
+     * @param playerId - ID of the player to be updated.
+     * @param playerWon - A boolean indicating whether the player won or not.
      */
-    async addWonPlayedGame(playerId: string) {
-        const update = { $inc: { 'gameStatistics.wonBattles': 1 } };
-        const [_, updateError] = await this.basicService.updateOneById(playerId, update);
-        if (updateError)
-            throw updateError;
+    async handlePlayedBattle(playerId: string, playerWon: boolean) {
+        const points = playerWon ? 50 : 10;
+        let update = { $inc: { 'gameStatistics.playedBattles': 1 , 'points': points } };
+        if (playerWon)
+            update.$inc['gameStatistics.wonBattles'] = 1
+
+        const [_, updateErrors] = await this.basicService.updateOneById(playerId, update);
+        if (updateErrors)
+            throw updateErrors
     }
 }

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -121,6 +121,7 @@ export class PlayerService
      * 
      * @param playerId - ID of the player to be updated.
      * @param playerWon - A boolean indicating whether the player won or not.
+     * @throws - Will throw if the update operation fails.
      */
     async handlePlayedBattle(playerId: string, playerWon: boolean) {
         const points = playerWon ? 50 : 10;


### PR DESCRIPTION
I combined the addPlayedBattles and addWonBattles to a handlePlayedBattle method.
The method now checks if the player won the battle and increments the points, played and won battles.
This simplifies the necessary method calls in the gameDataService.

This method will work when the leaderboard PR is merged since the points updating relies on the points field of the player schema that is added in that PR.

This PR also closes the issue 210 handle played battle reward for player.