### PR TITLE
Feature/add sent messages reward 208

### DIFF
--- a/src/authorization/rule/playerRules.ts
+++ b/src/authorization/rule/playerRules.ts
@@ -19,7 +19,11 @@ export const playerRules: RulesSetterAsync<Ability, Subjects> = async (user, sub
     if(action === Action.create || action === Action.read){
         can(Action.create_request, subject);
 
-        const publicFields = ['_id', 'name', 'uniqueIdentifier', 'profile_id', 'clan_id', 'Clan', 'CustomCharacter', 'above13', 'parentalAuth'];
+        const publicFields = [
+            '_id', 'name', 'uniqueIdentifier', 'profile_id', 'clan_id', 
+            'Clan', 'CustomCharacter', 'above13', 'parentalAuth', 'gameStatistics',
+            'points'
+        ];
         can(Action.read_request, subject);
         can(Action.read_response, subject, publicFields);
         can(Action.read_response, subject, {_id: user.player_id});

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -7,12 +7,14 @@ import {isChatExists} from "./decorator/validation/IsChatExists.decorator";
 import {ModelName} from "../common/enum/modelName.enum";
 import {RequestHelperModule} from "../requestHelper/requestHelper.module";
 import { PlayerTasksModule } from '../playerTasks/playerTasks.module';
+import { PlayerModule } from '../player/player.module';
 
 @Module({
     imports: [
         MongooseModule.forFeature([ {name: ModelName.CHAT, schema: ChatSchema} ]),
         RequestHelperModule,
         PlayerTasksModule,
+        PlayerModule,
     ],
     controllers: [ChatController],
     providers: [ ChatService, isChatExists ],

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -17,6 +17,7 @@ import {IResponseShape} from "../common/interface/IResponseShape";
 import {ObjectId} from "mongodb";
 import { PlayerTasksService } from "../playerTasks/playerTasks.service";
 import { TaskName } from "../playerTasks/enum/taskName.enum";
+import { PlayerService } from "../player/player.service";
 
 @Injectable()
 @AddBasicService()
@@ -25,6 +26,7 @@ export class ChatService extends BasicServiceDummyAbstract<Chat> implements IBas
         @InjectModel(Chat.name) public readonly model: Model<Chat>,
         private readonly requestHelperService: RequestHelperService,
         private readonly playerTaskService: PlayerTasksService,
+        private readonly playerService: PlayerService,
     ){
         super();
         this.refsInModel = [];
@@ -44,8 +46,10 @@ export class ChatService extends BasicServiceDummyAbstract<Chat> implements IBas
      */
     async handleCreateMessage(chat_id: string, input: CreateMessageDto, player_id: string) {
         const messageCreated = await this.createMessage(chat_id, input);
-        if (messageCreated)
+        if (messageCreated) {
             this.playerTaskService.updateTask(player_id, TaskName.WRITE_CHAT_MESSAGE);
+            this.playerService.trackPlayerMessageCount(player_id);
+        }
     }
 
     public createMessage = async (chat_id: string, input: CreateMessageDto): Promise<boolean> => {

--- a/src/player/dto/gameStatistics.dto.ts
+++ b/src/player/dto/gameStatistics.dto.ts
@@ -1,0 +1,20 @@
+import {Expose} from "class-transformer";
+import AddType from "../../common/base/decorator/AddType.decorator";
+
+@AddType('GameStatisticsDto')
+export class GameStatisticsDto {
+    @Expose()
+    playedBattles?: number;
+
+	@Expose()
+	wonBattles?: number;
+
+	@Expose()
+	diamondsAmount?: number;
+
+	@Expose()
+	startedVotings?: number;
+
+	@Expose()
+	participatedVotings?: number;
+}

--- a/src/player/dto/player.dto.ts
+++ b/src/player/dto/player.dto.ts
@@ -3,7 +3,7 @@ import {ClanDto} from "../../clan/dto/clan.dto";
 import {ExtractField} from "../../common/decorator/response/ExtractField";
 import {CustomCharacterDto} from "../../customCharacter/dto/customCharacter.dto";
 import AddType from "../../common/base/decorator/AddType.decorator";
-import { GameStatistics } from "../gameStatistics.schema";
+import { GameStatisticsDto } from "./gameStatistics.dto";
 
 @AddType('PlayerDto')
 export class PlayerDto {
@@ -29,8 +29,9 @@ export class PlayerDto {
     @Expose()
     parentalAuth: boolean | null;
 
+    @Type(() => GameStatisticsDto)
     @Expose()
-    gameStatistics: GameStatistics;
+    gameStatistics: GameStatisticsDto;
 
     @ExtractField()
     @Expose()

--- a/src/player/gameStatistics.schema.ts
+++ b/src/player/gameStatistics.schema.ts
@@ -1,5 +1,6 @@
 import { Prop } from "@nestjs/mongoose";
 import { Document } from "mongoose";
+import { Message } from "./message.schema";
 
 
 /**
@@ -36,4 +37,10 @@ export class GameStatistics extends Document {
 	 */
 	@Prop({ type: Number, default: 0 })
 	participatedVotings: number;
+
+	/**
+	 * Array of messages
+	 */
+	@Prop({ type: [Message], default: [] })
+	messages: Message[];
 }

--- a/src/player/message.schema.ts
+++ b/src/player/message.schema.ts
@@ -1,0 +1,22 @@
+import { Prop } from "@nestjs/mongoose";
+import { Document } from "mongoose";
+
+/**
+ * Represents a message in the game statistics.
+ * 
+ * This class is used for tracking the amount of player message
+ * in order to grant points to the player.
+ */
+export class Message extends Document {
+	/**
+	 * The date of the messages.
+	 */
+	@Prop({ type: Date, required: true })
+	date: Date;
+
+	/**
+	 * The count of messages on the given date.
+	 */
+	@Prop({ type: Number, default: 1 })
+	count: number;
+}

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -176,7 +176,7 @@ export class PlayerService
             todaysMessage.count += 1;
         } else {
             const newMessage = { date: today, count: 1 } as Message;
-            player.gameStatistics.messages.push(newMessage);
+            messages.push(newMessage);
             todaysMessage = newMessage;
         }
 

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -1,7 +1,7 @@
 import {BadRequestException, Injectable} from "@nestjs/common";
-import {Model, MongooseError, Types} from "mongoose";
+import {Model, Types} from "mongoose";
 import {InjectModel} from "@nestjs/mongoose";
-import {Player, publicReferences} from "./player.schema";
+import {Player, PlayerDocument, publicReferences} from "./player.schema";
 import {RequestHelperService} from "../requestHelper/requestHelper.service";
 import {IBasicService} from "../common/base/interface/IBasicService";
 import {IgnoreReferencesType} from "../common/type/ignoreReferences.type";
@@ -15,8 +15,8 @@ import {UpdatePlayerDto} from "./dto/updatePlayer.dto";
 import { PlayerDto } from "./dto/player.dto";
 import BasicService from "../common/service/basicService/BasicService";
 import { TIServiceReadManyOptions, TReadByIdOptions } from "../common/service/basicService/IService";
-import { IGetAllQuery } from "../common/interface/IGetAllQuery";
-import { IResponseShape } from "../common/interface/IResponseShape";
+import { Message } from "./message.schema";
+import ServiceError from "../common/service/basicService/ServiceError";
 
 @Injectable()
 @AddBasicService()
@@ -150,5 +150,44 @@ export class PlayerService
         const [_, updateErrors] = await this.basicService.updateOneById(playerId, update);
         if (updateErrors)
             throw updateErrors
+    }
+
+    /**
+     * Tracks the daily amount of messages sent by a player.
+     * 
+     * Finds the player from db and updates or creates a message for that player.
+     * If the message count is 3 increments player points by 20.
+     * 
+     * @param playerId - ID of the player whose messages to track.
+     * @returns - A promise that resolves in to a tuple where first value is boolean that
+     * indicates if the update was successful and the second value is an array of errors.
+     */
+    async trackPlayerMessageCount(playerId: string): Promise<[boolean, ServiceError[]]> {
+        const today = new Date();
+    
+        const [player, errors] = await this.basicService.readOneById<PlayerDocument>(playerId);
+        if (errors)
+            return [false, errors];
+    
+        const messages: Message[] = player.gameStatistics.messages || [];
+        let todaysMessage: Message = messages.find(message => message.date.toDateString() === today.toDateString());
+    
+        if (todaysMessage) {
+            todaysMessage.count += 1;
+        } else {
+            const newMessage = { date: today, count: 1 } as Message;
+            player.gameStatistics.messages.push(newMessage);
+            todaysMessage = newMessage;
+        }
+
+        if (todaysMessage.count === 3)
+            player.points += 20;
+    
+        player.gameStatistics.messages = messages;
+        const [update, updateErrors] = await this.basicService.updateOneById(playerId, player);
+        if (updateErrors)
+            return [false, updateErrors]
+
+        return [update, null];
     }
 }


### PR DESCRIPTION
Created a message schema to track the dates and amount of player messages and extended the gameStatistics with it.

Created a method to player service that gets the player with id and finds todays messages and increments the count by one.
If the message is not found a new one is created and if the amount is 3 player is granted 20 points.

Added a call to this new function from chat services create message handler.