### PR TITLE
add tests for APIErrorFilter

### DIFF
--- a/src/test/common/exceptionFilter/APIErrorFilter/APIErrorFilter.catch.test.ts
+++ b/src/test/common/exceptionFilter/APIErrorFilter/APIErrorFilter.catch.test.ts
@@ -1,0 +1,39 @@
+import { APIErrorFilter } from "../../../../common/exceptionFilter/APIErrorFilter";
+import TestUtilDataFactory from "../../../test_utils/data/TestUtilsDataFactory";
+
+describe('APIErrorFilter.catch() class test suite', () => {
+    let filter = new APIErrorFilter();
+    const apiErrorBuilder = TestUtilDataFactory.getBuilder('APIError');
+    const apiError = apiErrorBuilder
+        .setMessage('Something is not right')
+        .setStatusCode(400).setValue(null)
+        .setField('name').build();
+
+    const jsonMock = jest.fn();
+    const responseMock = {
+        status: jest.fn((statusCode: number) => {
+            return {
+                json: jsonMock
+            }
+        })
+    }
+
+    const hostBuilder = TestUtilDataFactory.getBuilder('ArgumentsHost');
+    const host = hostBuilder.setHttpResponse(responseMock).build();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        filter.catch(apiError, host);
+    });
+
+
+    it('Should set status code to response same as in the provided error', () => {
+        const expectedCode = apiError.statusCode;
+
+        expect(responseMock.status).toHaveBeenCalledWith(expectedCode);
+    });
+
+    it('Should set provided error to json() of response', () => {
+        expect(jsonMock).toHaveBeenCalledWith(apiError);
+    });
+});

--- a/src/test/common/function/addUniqueArrayElements/addUniqueArrayElements.test.ts
+++ b/src/test/common/function/addUniqueArrayElements/addUniqueArrayElements.test.ts
@@ -1,0 +1,30 @@
+import { addUniqueArrayElements } from "../../../../common/function/addUniqueArrayElements";
+
+describe('addUniqueArrayElements() test suite', () => {
+    it('Should add unique elements to the array', () => {
+        const arr = [1, 2, 3];
+        const elems = [3, 4, 5];
+        const result = addUniqueArrayElements(arr, elems);
+        expect(result).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('Should return the original array if elems is null', () => {
+        const arr = [1, 2, 3];
+        const result = addUniqueArrayElements(arr, null);
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('Should return the original array if elems is empty', () => {
+        const arr = [1, 2, 3];
+        const elems: number[] = [];
+        const result = addUniqueArrayElements(arr, elems);
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('Should not add duplicate elements', () => {
+        const arr = [1, 2, 3];
+        const elems = [1, 2];
+        const result = addUniqueArrayElements(arr, elems);
+        expect(result).toEqual([1, 2, 3]);
+    });
+});

--- a/src/test/common/function/deleteArrayElements/deleteArrayElements.test.ts
+++ b/src/test/common/function/deleteArrayElements/deleteArrayElements.test.ts
@@ -1,0 +1,30 @@
+import { deleteArrayElements } from "../../../../common/function/deleteArrayElements";
+
+describe('deleteArrayElements() test suite', () => {
+    it('Should remove elements from the array', () => {
+        const arr = [1, 2, 3, 4];
+        const elems = [2, 4];
+        const result = deleteArrayElements(arr, elems);
+        expect(result).toEqual([1, 3]);
+    });
+
+    it('Should return the original array if elems is null', () => {
+        const arr = [1, 2, 3];
+        const result = deleteArrayElements(arr, null);
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('Should return the original array if elems is empty', () => {
+        const arr = [1, 2, 3];
+        const elems: number[] = [];
+        const result = deleteArrayElements(arr, elems);
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('Should return the original array if no elements are found to remove', () => {
+        const arr = [1, 2, 3];
+        const elems = [4, 5];
+        const result = deleteArrayElements(arr, elems);
+        expect(result).toEqual([1, 2, 3]);
+    });
+});

--- a/src/test/common/function/deleteNotUniqueArrayElements/deleteNotUniqueArrayElements.test.ts
+++ b/src/test/common/function/deleteNotUniqueArrayElements/deleteNotUniqueArrayElements.test.ts
@@ -1,0 +1,26 @@
+import { deleteNotUniqueArrayElements } from "../../../../common/function/deleteNotUniqueArrayElements";
+
+describe('deleteNotUniqueArrayElements() test suite', () => {
+    it('Should remove duplicates and keep the first occurrence', () => {
+        const arr = [1, 2, 2, 3, 1];
+        const result = deleteNotUniqueArrayElements(arr);
+        expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('Should return an empty array if the input array is null', () => {
+        const result = deleteNotUniqueArrayElements(null);
+        expect(result).toEqual([]);
+    });
+
+    it('Should return an empty array if the input array is empty', () => {
+        const arr: number[] = [];
+        const result = deleteNotUniqueArrayElements(arr);
+        expect(result).toEqual([]);
+    });
+
+    it('Should return the same array if no duplicates exist', () => {
+        const arr = [1, 2, 3];
+        const result = deleteNotUniqueArrayElements(arr);
+        expect(result).toEqual([1, 2, 3]);
+    });
+});

--- a/src/test/common/function/timeUtils/timeUtils.test.ts
+++ b/src/test/common/function/timeUtils/timeUtils.test.ts
@@ -1,0 +1,41 @@
+import { getTimeSince, passed } from "../../../../common/function/timeUtils";
+
+describe('timeUtils test suite', () => {
+    describe('getTimeSince()', () => {
+        it('Should return the correct elapsed time since the timestamp', () => {
+            const now = Date.now();
+            const pastTime = now - 1000; // 1 second in the past
+            const result = getTimeSince(pastTime);
+            expect(result).toBeGreaterThanOrEqual(1000);
+        });
+    
+        it('Should return a small number when timestamp is very recent', () => {
+            const now = Date.now();
+            const result = getTimeSince(now);
+            expect(result).toBeGreaterThanOrEqual(0);
+        });
+    });
+
+    describe('passed()', () => {
+        it('Should return true if the specified time has passed since the timestamp', () => {
+            const now = Date.now();
+            const pastTime = now - 2000; // 2 seconds in the past
+            const result = passed(pastTime, 1000); // Check if 1 second has passed
+            expect(result).toBe(true);
+        });
+    
+        it('Should return false if the specified time has not passed since the timestamp', () => {
+            const now = Date.now();
+            const pastTime = now - 500; // 0.5 seconds in the past
+            const result = passed(pastTime, 1000); // Check if 1 second has passed
+            expect(result).toBe(false);
+        });
+    
+        it('Should return true if the exact time has passed', () => {
+            const now = Date.now();
+            const pastTime = now - 1000; // 1 second in the past
+            const result = passed(pastTime, 1000); // Check if 1 second has passed
+            expect(result).toBe(true);
+        });
+    });
+});

--- a/src/test/test_utils/data/APIErrorBuilder.ts
+++ b/src/test/test_utils/data/APIErrorBuilder.ts
@@ -1,0 +1,54 @@
+import { APIError } from "../../../common/controller/APIError";
+import { APIErrorReason } from "../../../common/controller/APIErrorReason";
+
+export default class APIErrorBuilder {
+    private readonly base: Partial<APIError> = {
+        reason: APIErrorReason.UNEXPECTED,
+        statusCode: null,
+        message: null,
+        field: null,
+        value: null,
+        additional: null,
+    };
+
+    build(): APIError {
+        return new APIError({
+            reason: this.base.reason!,
+            statusCode: this.base.statusCode,
+            message: this.base.message,
+            field: this.base.field,
+            value: this.base.value,
+            additional: this.base.additional,
+        });
+    }
+
+    setReason(reason: APIErrorReason) {
+        this.base.reason = reason;
+        return this;
+    }
+
+    setStatusCode(statusCode: number) {
+        this.base.statusCode = statusCode;
+        return this;
+    }
+
+    setMessage(message: string) {
+        this.base.message = message;
+        return this;
+    }
+
+    setField(field: string) {
+        this.base.field = field;
+        return this;
+    }
+
+    setValue(value: string) {
+        this.base.value = value;
+        return this;
+    }
+
+    setAdditional(additional: any) {
+        this.base.additional = additional;
+        return this;
+    }
+}

--- a/src/test/test_utils/data/ArgumentsHostBuilder.ts
+++ b/src/test/test_utils/data/ArgumentsHostBuilder.ts
@@ -1,0 +1,123 @@
+import { ArgumentsHost } from '@nestjs/common';
+import { HttpArgumentsHost, RpcArgumentsHost, WsArgumentsHost } from '@nestjs/common/interfaces';
+
+export default class ArgumentsHostBuilder {
+    private readonly base: Partial<ArgumentsHost> = {
+        getArgs: function () {
+            return [] as any;
+        },
+
+        getArgByIndex: function (index: number) {
+            return this.getArgs()[index];
+        },
+
+        switchToHttp: function () {
+            return {
+                getRequest: () => ({}),
+                getResponse: () => ({}),
+                getNext: () => ({}),
+            } as HttpArgumentsHost;
+        },
+
+        switchToRpc: function () {
+            return {
+                getContext: () => ({}),
+            } as RpcArgumentsHost;
+        },
+
+        switchToWs: function () {
+            return {
+                getClient: () => ({}),
+                getData: () => ({}),
+            } as WsArgumentsHost;
+        },
+
+        getType: function () {
+            return 'http' as any;
+        },
+    };
+
+    build(): ArgumentsHost {
+        return { ...this.base } as ArgumentsHost;
+    }
+
+    setArgs(args: any[]) {
+        this.base.getArgs = function () {
+            return args as any;
+        };
+        return this;
+    }
+
+    setArgByIndex(index: number, arg: any) {
+        const args = this.base.getArgs();
+        args[index] = arg;
+        this.base.getArgs = function () {
+            return args as any;
+        };
+        return this;
+    }
+
+    setHttpRequest(request: any) {
+        const baseSwitchToHttp = this.base.switchToHttp();
+
+        this.base.switchToHttp = function () {
+            return {
+                ...baseSwitchToHttp,
+                getRequest: () => request
+            };
+        };
+        return this;
+    }
+
+    setHttpResponse(response: any) {
+        const baseSwitchToHttp = this.base.switchToHttp();
+
+        this.base.switchToHttp = function () {
+            return {
+                ...baseSwitchToHttp,
+                getResponse: () => response
+            };
+        };
+        return this;
+    }
+
+    setRpcContext(context: any) {
+        this.base.switchToRpc = function () {
+            return {
+                getContext: () => context,
+            } as RpcArgumentsHost;
+        };
+        return this;
+    }
+
+    setWsClient(client: any) {
+        const baseSwitchToWs = this.base.switchToWs();
+
+        this.base.switchToWs = function () {
+            return {
+                ...baseSwitchToWs,
+                getClient: () => client
+            };
+        };
+        return this;
+    }
+
+    setWsData(data: any) {
+        const baseSwitchToWs = this.base.switchToWs();
+
+        this.base.switchToWs = function () {
+            return {
+                ...baseSwitchToWs,
+                getData: () => data,
+            };
+        };
+        return this;
+    }
+
+    setType(type: 'http' | 'rpc' | 'ws') {
+        this.base.getType = function () {
+            return type as any;
+        };
+        return this;
+    }
+}

--- a/src/test/test_utils/data/TestUtilsDataFactory.ts
+++ b/src/test/test_utils/data/TestUtilsDataFactory.ts
@@ -1,3 +1,4 @@
+import APIErrorBuilder from "./APIErrorBuilder";
 import ArgumentsHostBuilder from "./ArgumentsHostBuilder";
 import BodyBuilder from "./BodyBuilder";
 import CallHandlerBuilder from "./CallHandlerBuilder";
@@ -7,7 +8,8 @@ import RequestBuilder from "./RequestBuilder";
 
 type BuilderName = 
     'Body' | 'Request' | 
-    'ExecutionContext' | 'CallHandler' | 'ArgumentsHost';
+    'ExecutionContext' | 'CallHandler' | 'ArgumentsHost' |
+    'APIError';
 
 type BuilderMap = {
     Body: BodyBuilder,
@@ -15,7 +17,9 @@ type BuilderMap = {
 
     ExecutionContext: ExecutionContextBuilder,
     CallHandler: CallHandlerBuilder,
-    ArgumentsHost: ArgumentsHostBuilder
+    ArgumentsHost: ArgumentsHostBuilder,
+
+    APIError: APIErrorBuilder
 };
 
 export default class TestUtilDataFactory {
@@ -25,12 +29,16 @@ export default class TestUtilDataFactory {
                 return new BodyBuilder() as BuilderMap[T];
             case 'Request':
                 return new RequestBuilder() as BuilderMap[T];
+
             case 'ExecutionContext':
                 return new ExecutionContextBuilder() as BuilderMap[T];
             case 'CallHandler':
                 return new CallHandlerBuilder() as BuilderMap[T];
             case 'ArgumentsHost':
                 return new ArgumentsHostBuilder() as BuilderMap[T];
+
+            case 'APIError':
+                return new APIErrorBuilder() as BuilderMap[T];
 
             default:
                 throw new Error(`Unknown builder name: ${builderName}`);

--- a/src/test/test_utils/data/TestUtilsDataFactory.ts
+++ b/src/test/test_utils/data/TestUtilsDataFactory.ts
@@ -1,3 +1,4 @@
+import ArgumentsHostBuilder from "./ArgumentsHostBuilder";
 import BodyBuilder from "./BodyBuilder";
 import CallHandlerBuilder from "./CallHandlerBuilder";
 import ExecutionContextBuilder from "./ExecutionContextBuilder";
@@ -6,14 +7,15 @@ import RequestBuilder from "./RequestBuilder";
 
 type BuilderName = 
     'Body' | 'Request' | 
-    'ExecutionContext' | 'CallHandler';
+    'ExecutionContext' | 'CallHandler' | 'ArgumentsHost';
 
 type BuilderMap = {
     Body: BodyBuilder,
     Request: RequestBuilder,
 
     ExecutionContext: ExecutionContextBuilder,
-    CallHandler: CallHandlerBuilder
+    CallHandler: CallHandlerBuilder,
+    ArgumentsHost: ArgumentsHostBuilder
 };
 
 export default class TestUtilDataFactory {
@@ -27,6 +29,9 @@ export default class TestUtilDataFactory {
                 return new ExecutionContextBuilder() as BuilderMap[T];
             case 'CallHandler':
                 return new CallHandlerBuilder() as BuilderMap[T];
+            case 'ArgumentsHost':
+                return new ArgumentsHostBuilder() as BuilderMap[T];
+
             default:
                 throw new Error(`Unknown builder name: ${builderName}`);
         }


### PR DESCRIPTION
I have added / changed the following:

1. Builder for NestJS ArgumentsHost class
2. Builder for APIError class
3. tests for APIErrorFilter catch() method


I did check that:

- My code works
- There are JSDocs for my code
- There are no `console.log()` for debugging statements left
- There are no commented out code pieces left
