### PR TITLE
Feature/add flea market get endpoints 196

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,7 @@ import { ItemMoverModule } from './itemMover/itemMover.module';
 import { GameEventsBrokerModule } from './gameEventsBroker/gameEventsBroker.module';
 import { RewarderModule } from './rewarder/rewarder.module';
 import { StatisticsKeeperModule } from './statisticsKeeper/statisticsKeeper.module';
+import { FleaMarketModule } from './fleaMarket/fleaMarket.module';
 
 // Set up database connection
 const mongoUser = envVars.MONGO_USERNAME;
@@ -64,6 +65,7 @@ const redisPort = parseInt(envVars.REDIS_PORT);
       PlayerModule,
 
       ItemMoverModule,
+      FleaMarketModule,
 
       CustomCharacterModule,
       ClanInventoryModule,

--- a/src/common/enum/modelName.enum.ts
+++ b/src/common/enum/modelName.enum.ts
@@ -33,4 +33,5 @@ export enum ModelName {
     ITEMSHOP = 'ItemShop',
     GAME = 'Game',
     PLAYER_TASK = 'PlayerTask',
+    FLEA_MARKET_ITEM = 'FleaMarketItem',
 }

--- a/src/fleaMarket/dto/fleaMarketItem.dto.ts
+++ b/src/fleaMarket/dto/fleaMarketItem.dto.ts
@@ -1,0 +1,39 @@
+import { Expose } from "class-transformer";
+import AddType from "../../common/base/decorator/AddType.decorator";
+import { ExtractField } from "../../common/decorator/response/ExtractField";
+import { ItemName } from "../../clanInventory/item/enum/itemName.enum";
+import { Recycling } from "../../clanInventory/item/enum/recycling.enum";
+import { QualityLevel } from "../../clanInventory/item/enum/qualityLevel.enum";
+import { Status } from "../enum/status.enum";
+
+@AddType("FleaMarketItemDto")
+export class FleaMarketItemDto {
+	@ExtractField()
+	@Expose()
+	_id: string;
+
+	@Expose()
+	name: ItemName;
+
+	@Expose()
+	weight: number;
+
+	@Expose()
+	recycling: Recycling;
+
+	@Expose()
+	qualityLevel: QualityLevel;
+
+	@Expose()
+	unityKey: string;
+
+	@Expose()
+	status: Status;
+
+	@Expose()
+	isFurniture: boolean;
+
+	@ExtractField()
+	@Expose()
+	clan_id: string;
+}

--- a/src/fleaMarket/dto/fleaMarketItem.dto.ts
+++ b/src/fleaMarket/dto/fleaMarketItem.dto.ts
@@ -33,6 +33,9 @@ export class FleaMarketItemDto {
 	@Expose()
 	isFurniture: boolean;
 
+	@Expose()
+	price: number;
+
 	@ExtractField()
 	@Expose()
 	clan_id: string;

--- a/src/fleaMarket/enum/status.enum.ts
+++ b/src/fleaMarket/enum/status.enum.ts
@@ -1,0 +1,10 @@
+/**
+ * Enum for flea market items.
+ *
+ * Used in the status field.
+ */
+export enum Status {
+	AVAILABLE = "available",
+	SHIPPING = "shipping",
+	BOOKED = "booked",
+}

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -16,7 +16,7 @@ export class FleaMarketController {
 	@Get("/:_id")
 	@Serialize(FleaMarketItemDto)
 	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
-	public async getOne(@Param() param: _idDto) {
+	async getOne(@Param() param: _idDto) {
 		return await this.service.readOneById(param._id);
 	}
 
@@ -24,7 +24,7 @@ export class FleaMarketController {
 	@OffsetPaginate(ModelName.FLEA_MARKET_ITEM)
 	@Serialize(FleaMarketItemDto)
 	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
-	public async getAll(@GetAllQuery() query: IGetAllQuery) {
+	async getAll(@GetAllQuery() query: IGetAllQuery) {
 		return await this.service.readMany(query);
 	}
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -14,6 +14,7 @@ export class FleaMarketController {
 	constructor(private readonly service: FleaMarketService) {}
 
 	@Get("/:_id")
+	@Serialize(FleaMarketItemDto)
 	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
 	public async getOne(@Param() param: _idDto) {
 		return await this.service.readOneById(param._id);

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Param } from "@nestjs/common";
+import { FleaMarketService } from "./fleaMarket.service";
+import { UniformResponse } from "../common/decorator/response/UniformResponse";
+import { ModelName } from "../common/enum/modelName.enum";
+import { _idDto } from "../common/dto/_id.dto";
+import { OffsetPaginate } from "../common/interceptor/request/offsetPagination.interceptor";
+import { Serialize } from "../common/interceptor/response/Serialize";
+import { FleaMarketItemDto } from "./dto/fleaMarketItem.dto";
+import { GetAllQuery } from "../common/decorator/param/GetAllQuery";
+import { IGetAllQuery } from "../common/interface/IGetAllQuery";
+
+@Controller("fleaMarket")
+export class FleaMarketController {
+	constructor(private readonly service: FleaMarketService) {}
+
+	@Get("/:_id")
+	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
+	public async getOne(@Param() param: _idDto) {
+		return await this.service.readOneById(param._id);
+	}
+
+	@Get()
+	@OffsetPaginate(ModelName.FLEA_MARKET_ITEM)
+	@Serialize(FleaMarketItemDto)
+	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
+	public async getAll(@GetAllQuery() query: IGetAllQuery) {
+		return await this.service.readMany(query);
+	}
+}

--- a/src/fleaMarket/fleaMarket.module.ts
+++ b/src/fleaMarket/fleaMarket.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common";
+import { MongooseModule } from "@nestjs/mongoose";
+import { ModelName } from "../common/enum/modelName.enum";
+import { FleaMarketItemSchema } from "./fleaMarketItem.schema";
+import { FleaMarketController } from "./fleaMarket.controller";
+import { FleaMarketService } from "./fleaMarket.service";
+import { RequestHelperModule } from "../requestHelper/requestHelper.module";
+
+@Module({
+	imports: [
+		MongooseModule.forFeature([
+			{ name: ModelName.FLEA_MARKET_ITEM, schema: FleaMarketItemSchema },
+		]),
+		RequestHelperModule,
+	],
+	controllers: [FleaMarketController],
+	providers: [FleaMarketService],
+	exports: [],
+})
+export class FleaMarketModule {}

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { FleaMarketItem, publicReferences } from "./fleaMarketItem.schema";
+import BasicService from "../common/service/basicService/BasicService";
+import { Model } from "mongoose";
+import {
+	TIServiceReadManyOptions,
+	TReadByIdOptions,
+} from "../common/service/basicService/IService";
+import { FleaMarketItemDto } from "./dto/fleaMarketItem.dto";
+
+@Injectable()
+export class FleaMarketService {
+	constructor(
+		@InjectModel(FleaMarketItem.name)
+		public readonly model: Model<FleaMarketItem>
+	) {
+		this.basicService = new BasicService(model);
+	}
+
+	public readonly basicService: BasicService;
+
+	/**
+	 * Reads an Item by its _id in DB.
+	 *
+	 * @param _id - The mongo _id of the item to read.
+	 * @param options - Options for reading the item.
+	 * @returns A promise that resolves into an item with the given _id or array of service errors.
+	 */
+	async readOneById(_id: string, options?: TReadByIdOptions) {
+		let optionsToApply = options;
+		if (optionsToApply?.includeRefs)
+			optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
+				publicReferences.includes(ref)
+			);
+		return this.basicService.readOneById<FleaMarketItemDto>(
+			_id,
+			optionsToApply
+		);
+	}
+
+	/**
+	 * Reads multiple items from the database with the given options.
+	 *
+	 * @param options - Optional settings for the read operation.
+	 * @returns A promise that resolves into an array of found objects or service errors.
+	 */
+	async readMany(options?: TIServiceReadManyOptions) {
+		return this.basicService.readMany<FleaMarketItemDto>(options);
+	}
+}

--- a/src/fleaMarket/fleaMarketItem.schema.ts
+++ b/src/fleaMarket/fleaMarketItem.schema.ts
@@ -1,0 +1,57 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, Schema as MongooseSchema } from "mongoose";
+import { ModelName } from "../common/enum/modelName.enum";
+import { ItemName } from "../clanInventory/item/enum/itemName.enum";
+import { Recycling } from "../clanInventory/item/enum/recycling.enum";
+import { QualityLevel } from "../clanInventory/item/enum/qualityLevel.enum";
+import { Clan } from "../clan/clan.schema";
+import { Status } from "./enum/status.enum";
+
+export type FleaMarketItemDocument = HydratedDocument<FleaMarketItem>;
+
+@Schema({ toJSON: { virtuals: true }, toObject: { virtuals: true } })
+export class FleaMarketItem {
+	@Prop({ type: String, enum: ItemName, required: true })
+	name: ItemName;
+
+	@Prop({ type: Number, required: true })
+	weight: number;
+
+	@Prop({ type: String, enum: Recycling, required: true })
+	recycling: Recycling;
+
+	@Prop({ type: String, enum: QualityLevel, required: true })
+	qualityLevel: QualityLevel;
+
+	@Prop({ type: String, required: true })
+	unityKey: string;
+
+	@Prop({
+		type: String,
+		enum: Status,
+		required: true,
+		default: Status.AVAILABLE,
+	})
+	status: Status;
+
+	@Prop({ type: Number, required: true })
+	price: number;
+
+	@Prop({ type: Boolean, required: true, default: false })
+	isFurniture: boolean;
+
+	@Prop({ type: MongooseSchema.Types.ObjectId, ref: ModelName.CLAN })
+	clan_id: Clan;
+}
+
+export const FleaMarketItemSchema =
+	SchemaFactory.createForClass(FleaMarketItem);
+FleaMarketItemSchema.set("collection", ModelName.FLEA_MARKET_ITEM);
+FleaMarketItemSchema.virtual(ModelName.CLAN, {
+	ref: ModelName.CLAN,
+	localField: "clan_id",
+	foreignField: "_id",
+	justOne: true,
+});
+
+export const publicReferences = [ModelName.CLAN];


### PR DESCRIPTION
In this PR I added the Flea Market module, controller, service, and related DTOs, ENUMs and schemas.

### New Flea Market Module:

* **Module and Controller Setup:**
  * Added the `FleaMarketModule` and imported it in the main application module (`src/app.module.ts`). [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R29) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R68)
  * Created `FleaMarketController` to handle HTTP requests related to flea market items.

* **Service Implementation:**
  * Implemented `FleaMarketService` with readOneById and readMany methods.

### Data Models and Enums:

* **DTO and Schema:**
  * Added `FleaMarketItemDto` to define the data transfer object for flea market items.
  * Created `FleaMarketItem` schema to define the MongoDB schema for flea market items.

* **Enums:**
  * Introduced `Status` enum to represent the status of flea market items.
  * Updated `ModelName` enum to include `FLEA_MARKET_ITEM`.