### PR TITLE
Feature/add flea market sell endpoint 197

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { GameEventsBrokerModule } from './gameEventsBroker/gameEventsBroker.modu
 import { RewarderModule } from './rewarder/rewarder.module';
 import { StatisticsKeeperModule } from './statisticsKeeper/statisticsKeeper.module';
 import { FleaMarketModule } from './fleaMarket/fleaMarket.module';
+import { VotingModule } from './voting/voting.module';
 
 // Set up database connection
 const mongoUser = envVars.MONGO_USERNAME;
@@ -66,6 +67,7 @@ const redisPort = parseInt(envVars.REDIS_PORT);
 
       ItemMoverModule,
       FleaMarketModule,
+      VotingModule,
 
       CustomCharacterModule,
       ClanInventoryModule,

--- a/src/common/enum/modelName.enum.ts
+++ b/src/common/enum/modelName.enum.ts
@@ -34,4 +34,5 @@ export enum ModelName {
     GAME = 'Game',
     PLAYER_TASK = 'PlayerTask',
     FLEA_MARKET_ITEM = 'FleaMarketItem',
+    VOTING = 'Voting',
 }

--- a/src/fleaMarket/dto/createFleaMarketItem.dto.ts
+++ b/src/fleaMarket/dto/createFleaMarketItem.dto.ts
@@ -1,0 +1,39 @@
+import { IsBoolean, IsEnum, IsInt, IsMongoId, IsNumber, IsOptional, IsString } from "class-validator";
+import AddType from "../../common/base/decorator/AddType.decorator";
+import { ItemName } from "../../clanInventory/item/enum/itemName.enum";
+import { Recycling } from "../../clanInventory/item/enum/recycling.enum";
+import { QualityLevel } from "../../clanInventory/item/enum/qualityLevel.enum";
+import { Status } from "../enum/status.enum";
+import { IsClanExists } from "../../clan/decorator/validation/IsClanExists.decorator";
+
+@AddType('CreateFleaMarketItemDto')
+export class CreateFleaMarketItemDto {
+    @IsString()
+    name: ItemName;
+
+    @IsInt()
+    weight: number;
+
+    @IsEnum(Recycling)
+    recycling: Recycling;
+
+    @IsEnum(QualityLevel)
+    qualityLevel: QualityLevel;
+
+    @IsString()
+    unityKey: string;
+
+	@IsEnum(Status)
+	@IsOptional()
+	status: Status = Status.SHIPPING;
+
+    @IsInt()
+    price: number;
+
+    @IsBoolean()
+    @IsOptional()
+    isFurniture: boolean;
+
+	@IsClanExists()
+	clan_id: string;
+}

--- a/src/fleaMarket/dto/fleaMarketItem.dto.ts
+++ b/src/fleaMarket/dto/fleaMarketItem.dto.ts
@@ -33,6 +33,9 @@ export class FleaMarketItemDto {
 	@Expose()
 	isFurniture: boolean;
 
+	@Expose()
+	price: number;
+
 	@ExtractField()
 	@Expose()
 	clan_id: string;

--- a/src/fleaMarket/dto/sellItem.dto.ts
+++ b/src/fleaMarket/dto/sellItem.dto.ts
@@ -1,0 +1,9 @@
+import { IsMongoId, IsString } from "class-validator";
+import AddType from "../../common/base/decorator/AddType.decorator";
+
+@AddType('SellItemDto')
+export class SellItemDto {
+	@IsString()
+	@IsMongoId()
+	item_id: string;
+}

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -11,7 +11,6 @@ import { IGetAllQuery } from "../common/interface/IGetAllQuery";
 import { LoggedUser } from "../common/decorator/param/LoggedUser.decorator";
 import { User } from "../auth/user";
 import { SellItemDto } from "./dto/sellItem.dto";
-import { VotingType } from "../voting/enum/VotingType.enum";
 import { APIError } from "../common/controller/APIError";
 import { APIErrorReason } from "../common/controller/APIErrorReason";
 
@@ -51,8 +50,7 @@ export class FleaMarketController {
 		await this.service.handleSellItem(
 			sellItemDto.item_id,
 			clanId,
-			user.player_id,
-			VotingType.SELLING_ITEM
+			user.player_id
 		);
 	}
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param } from "@nestjs/common";
+import { Body, Controller, Get, Param, Post } from "@nestjs/common";
 import { FleaMarketService } from "./fleaMarket.service";
 import { UniformResponse } from "../common/decorator/response/UniformResponse";
 import { ModelName } from "../common/enum/modelName.enum";
@@ -8,6 +8,12 @@ import { Serialize } from "../common/interceptor/response/Serialize";
 import { FleaMarketItemDto } from "./dto/fleaMarketItem.dto";
 import { GetAllQuery } from "../common/decorator/param/GetAllQuery";
 import { IGetAllQuery } from "../common/interface/IGetAllQuery";
+import { LoggedUser } from "../common/decorator/param/LoggedUser.decorator";
+import { User } from "../auth/user";
+import { SellItemDto } from "./dto/sellItem.dto";
+import { VotingType } from "../voting/enum/VotingType.enum";
+import { APIError } from "../common/controller/APIError";
+import { APIErrorReason } from "../common/controller/APIErrorReason";
 
 @Controller("fleaMarket")
 export class FleaMarketController {
@@ -26,5 +32,27 @@ export class FleaMarketController {
 	@UniformResponse(ModelName.FLEA_MARKET_ITEM)
 	async getAll(@GetAllQuery() query: IGetAllQuery) {
 		return await this.service.readMany(query);
+	}
+
+	@Post("sell")
+	@UniformResponse()
+	async sell(@Body() sellItemDto: SellItemDto, @LoggedUser() user: User) {
+		const clanId = await this.service.getClanId(
+			sellItemDto.item_id,
+			user.player_id
+		);
+
+		if (!clanId)
+			throw new APIError({
+				reason: APIErrorReason.NOT_AUTHORIZED,
+				message: "The item does not belong to the clan of logged in player",
+			});
+
+		await this.service.handleSellItem(
+			sellItemDto.item_id,
+			clanId,
+			user.player_id,
+			VotingType.SELLING_ITEM
+		);
 	}
 }

--- a/src/fleaMarket/fleaMarket.module.ts
+++ b/src/fleaMarket/fleaMarket.module.ts
@@ -5,12 +5,18 @@ import { FleaMarketItemSchema } from "./fleaMarketItem.schema";
 import { FleaMarketController } from "./fleaMarket.controller";
 import { FleaMarketService } from "./fleaMarket.service";
 import { RequestHelperModule } from "../requestHelper/requestHelper.module";
+import { PlayerModule } from "../player/player.module";
+import { ClanInventoryModule } from "../clanInventory/clanInventory.module";
+import { VotingModule } from "../voting/voting.module";
 
 @Module({
 	imports: [
 		MongooseModule.forFeature([
 			{ name: ModelName.FLEA_MARKET_ITEM, schema: FleaMarketItemSchema },
 		]),
+		ClanInventoryModule,
+		PlayerModule,
+		VotingModule,
 		RequestHelperModule,
 	],
 	controllers: [FleaMarketController],

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -2,23 +2,49 @@ import { Injectable } from "@nestjs/common";
 import { InjectModel } from "@nestjs/mongoose";
 import { FleaMarketItem, publicReferences } from "./fleaMarketItem.schema";
 import BasicService from "../common/service/basicService/BasicService";
-import { Model } from "mongoose";
+import { ClientSession, Model } from "mongoose";
 import {
 	TIServiceReadManyOptions,
 	TReadByIdOptions,
 } from "../common/service/basicService/IService";
 import { FleaMarketItemDto } from "./dto/fleaMarketItem.dto";
+import { ItemHelperService } from "../clanInventory/item/itemHelper.service";
+import { PlayerService } from "../player/player.service";
+import { CreateFleaMarketItemDto } from "./dto/createFleaMarketItem.dto";
+import { ItemService } from "../clanInventory/item/item.service";
+import { Status } from "./enum/status.enum";
+import ServiceError from "../common/service/basicService/ServiceError";
+import { SEReason } from "../common/service/basicService/SEReason";
+import { VotingType } from "../voting/enum/VotingType.enum";
+import { VotingService } from "../voting/voting.service";
 
 @Injectable()
 export class FleaMarketService {
 	constructor(
 		@InjectModel(FleaMarketItem.name)
-		public readonly model: Model<FleaMarketItem>
+		public readonly model: Model<FleaMarketItem>,
+		private readonly itemHelperService: ItemHelperService,
+		private readonly playerService: PlayerService,
+		private readonly itemService: ItemService,
+		private readonly votingService: VotingService
 	) {
 		this.basicService = new BasicService(model);
 	}
 
 	public readonly basicService: BasicService;
+
+	/**
+	 * Creates an new Item in DB.
+	 *
+	 * @param item - The Item data to create.
+	 * @returns  created Item or an array of service errors if any occurred.
+	 */
+	async createOne(item: CreateFleaMarketItemDto) {
+		return this.basicService.createOne<
+			CreateFleaMarketItemDto,
+			FleaMarketItemDto
+		>(item);
+	}
 
 	/**
 	 * Reads an Item by its _id in DB.
@@ -47,5 +73,114 @@ export class FleaMarketService {
 	 */
 	async readMany(options?: TIServiceReadManyOptions) {
 		return this.basicService.readMany<FleaMarketItemDto>(options);
+	}
+
+	/**
+	 * Reads and compares the clan ID of the given player and item.
+	 *
+	 * @param itemId - The ID of the item.
+	 * @param playerId - The ID of the player.
+	 * @returns The clan ID if player and item clan_id fields match, or null otherwise.
+	 * @throws Will throw if there is an error getting the item or player information.
+	 */
+	async getClanId(itemId: string, playerId: string) {
+		const [itemClanId, itemError] = await this.itemHelperService.getItemClanId(
+			itemId
+		);
+		if (itemError) throw itemError;
+
+		const [player, playerError] = await this.playerService.getPlayerById(
+			playerId
+		);
+		if (playerError) throw playerError;
+
+		return itemClanId === player.clan_id.toString() ? itemClanId : null;
+	}
+
+	/**
+	 * Handles the process of moving an item to the flea market and starting a voting process.
+	 *
+	 * @param itemId - The ID of the item to be moved.
+	 * @param clanId - The ID of the clan to which the item belongs to.
+	 * @param playerId - The ID of the player starting the process.
+	 * @param votingType - The type of voting to be started.
+	 */
+	async handleSellItem(
+		itemId: string,
+		clanId: string,
+		playerId: string,
+		votingType: VotingType
+	) {
+		const newItem = await this.createFleaMarketItem(itemId, clanId);
+		await this.moveItemToFleaMarket(newItem, itemId);
+		await this.votingService.startItemVoting(
+			playerId,
+			itemId,
+			clanId,
+			votingType
+		);
+	}
+
+	/**
+	 * Reads an item from DB and creates a flea market item based on that information.
+	 *
+	 * @param itemId - The ID of the item to copy information from.
+	 * @param clanId - The ID of the clan
+	 * @returns A create flea market item dto.
+	 * @throws If there is an error reading from db or if the item is not in stock.
+	 */
+	private async createFleaMarketItem(itemId: string, clanId: string) {
+		const [item, itemErrors] = await this.itemService.readOneById(itemId);
+		if (itemErrors) throw itemErrors;
+		if (!item.stock_id)
+			throw new ServiceError({
+				reason: SEReason.NOT_ALLOWED,
+				message: "Item is not in stock",
+			});
+
+		const newFleaMarketItem: CreateFleaMarketItemDto = {
+			name: item.name,
+			weight: item.weight,
+			recycling: item.recycling,
+			qualityLevel: item.qualityLevel,
+			unityKey: item.unityKey,
+			price: item.price,
+			isFurniture: item.isFurniture,
+			clan_id: clanId,
+			status: Status.SHIPPING,
+		};
+
+		return newFleaMarketItem;
+	}
+
+	/**
+	 * Moves an item to the flea market by creating a new flea market item
+	 * and deleting the original item.
+	 *
+	 * @param newItem - The new flea market item to be created.
+	 * @param oldItemId - The ID of the original item to be deleted.
+	 * @throws Will throw if there is an error reading from DB.
+	 */
+	private async moveItemToFleaMarket(
+		newItem: CreateFleaMarketItemDto,
+		oldItemId: string
+	) {
+		const session: ClientSession = await this.model.db.startSession();
+		session.startTransaction();
+
+		try {
+			const [__, createErrors] = await this.createOne(newItem);
+			if (createErrors) throw createErrors;
+
+			const [_, deleteErrors] = await this.itemService.deleteOneById(oldItemId);
+			if (deleteErrors) throw deleteErrors;
+
+			await session.commitTransaction();
+		} catch (error) {
+			await session.abortTransaction();
+			throw error;
+		} finally {
+			session.endSession();
+		}
 	}
 }

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -103,22 +103,16 @@ export class FleaMarketService {
 	 * @param itemId - The ID of the item to be moved.
 	 * @param clanId - The ID of the clan to which the item belongs to.
 	 * @param playerId - The ID of the player starting the process.
-	 * @param votingType - The type of voting to be started.
 	 */
-	async handleSellItem(
-		itemId: string,
-		clanId: string,
-		playerId: string,
-		votingType: VotingType
-	) {
+	async handleSellItem(itemId: string, clanId: string, playerId: string) {
 		const newItem = await this.createFleaMarketItem(itemId, clanId);
 		await this.moveItemToFleaMarket(newItem, itemId);
-		await this.votingService.startItemVoting(
+		await this.votingService.startItemVoting({
 			playerId,
 			itemId,
 			clanId,
-			votingType
-		);
+			type: VotingType.SELLING_ITEM,
+		});
 	}
 
 	/**

--- a/src/voting/dto/createVoting.dto.ts
+++ b/src/voting/dto/createVoting.dto.ts
@@ -25,7 +25,7 @@ export class CreateVotingDto {
 
 	@IsMongoId()
 	@IsOptional()
-	item_id?: string;
+	entity_id?: string;
 
 	@IsArray()
 	@IsMongoId({ each: true })

--- a/src/voting/dto/createVoting.dto.ts
+++ b/src/voting/dto/createVoting.dto.ts
@@ -1,0 +1,38 @@
+import { IsArray, IsDate, IsEnum, IsInt, IsMongoId, IsOptional } from "class-validator";
+import AddType from "../../common/base/decorator/AddType.decorator";
+import { VotingType } from "../enum/VotingType.enum";
+import { Vote } from "../vote.schema";
+
+@AddType("CreateVotingDto")
+export class CreateVotingDto {
+	@IsMongoId()
+	organizer_id: string;
+
+	@IsDate()
+	@IsOptional()
+	startedAt?: Date;
+
+	@IsDate()
+	@IsOptional()
+	endsOn?: Date;
+
+	@IsEnum(VotingType)
+	type: string;
+
+	@IsInt()
+	@IsOptional()
+	minPercentage?: number;
+
+	@IsMongoId()
+	@IsOptional()
+	item_id?: string;
+
+	@IsArray()
+	@IsMongoId({ each: true })
+	@IsOptional()
+	player_ids?: string[];
+
+	@IsArray()
+	@IsOptional()
+	votes?: Vote[];
+}

--- a/src/voting/enum/VotingType.enum.ts
+++ b/src/voting/enum/VotingType.enum.ts
@@ -1,0 +1,10 @@
+/**
+ * Enum representing the types of voting in the voting schema.
+ * 
+ * This enum is used to specify the type of voting action being performed,
+ * such as voting for selling an item or buying an item.
+ */
+export enum VotingType {
+	SELLING_ITEM = "selling_item",
+	BUYING_ITEM = "buying_item",
+}

--- a/src/voting/enum/choiceType.enum.ts
+++ b/src/voting/enum/choiceType.enum.ts
@@ -1,0 +1,14 @@
+/**
+ * Enum for item vote choices.
+ */
+export enum ItemVoteChoice {
+    /**
+     * Represents a vote to accept the item.
+     */
+    YES = 'accept',
+
+    /**
+     * Represents a vote to reject the item.
+     */
+    NO = 'reject',
+}

--- a/src/voting/type/choice.type.ts
+++ b/src/voting/type/choice.type.ts
@@ -1,0 +1,9 @@
+import { ItemVoteChoice } from "../enum/choiceType.enum";
+
+/**
+ * Represents the possible choices for a vote.
+ *
+ * This type is used to define the choices that a player can make when voting.
+ * It is an alias and should contain all the possible voting option enums.
+ */
+export type Choice = ItemVoteChoice;

--- a/src/voting/type/startItemVoting.type.ts
+++ b/src/voting/type/startItemVoting.type.ts
@@ -1,0 +1,8 @@
+import { VotingType } from "../enum/VotingType.enum";
+
+export type StartItemVotingParams = {
+	playerId: string;
+	itemId: string;
+	clanId: string;
+	type: VotingType.BUYING_ITEM | VotingType.SELLING_ITEM;
+};

--- a/src/voting/vote.schema.ts
+++ b/src/voting/vote.schema.ts
@@ -1,7 +1,6 @@
 import { Schema as MongooseSchema } from "mongoose";
 import { ModelName } from "../common/enum/modelName.enum";
 import { Prop } from "@nestjs/mongoose";
-import { ItemVoteChoice } from "./enum/choiceType.enum";
 import { Choice } from "./type/choice.type";
 
 export class Vote {
@@ -15,13 +14,6 @@ export class Vote {
 	@Prop({
 		type: String,
 		required: true,
-		validate: {
-			validator: function (value: any) {
-				const validChoices = [...Object.values(ItemVoteChoice)];
-				return validChoices.includes(value);
-			},
-			message: (props) => `${props.value} is not a valid choice`,
-		},
 	})
 	choice: Choice;
 }

--- a/src/voting/vote.schema.ts
+++ b/src/voting/vote.schema.ts
@@ -1,7 +1,8 @@
 import { Schema as MongooseSchema } from "mongoose";
 import { ModelName } from "../common/enum/modelName.enum";
 import { Prop } from "@nestjs/mongoose";
-import { Choice, ItemVoteChoice } from "./enum/choiceType.enum";
+import { ItemVoteChoice } from "./enum/choiceType.enum";
+import { Choice } from "./type/choice.type";
 
 export class Vote {
 	@Prop({

--- a/src/voting/vote.schema.ts
+++ b/src/voting/vote.schema.ts
@@ -1,0 +1,26 @@
+import { Schema as MongooseSchema } from "mongoose";
+import { ModelName } from "../common/enum/modelName.enum";
+import { Prop } from "@nestjs/mongoose";
+import { Choice, ItemVoteChoice } from "./enum/choiceType.enum";
+
+export class Vote {
+	@Prop({
+		type: MongooseSchema.Types.ObjectId,
+		ref: ModelName.PLAYER,
+		required: true,
+	})
+	player_id: string;
+
+	@Prop({
+		type: String,
+		required: true,
+		validate: {
+			validator: function (value: any) {
+				const validChoices = [...Object.values(ItemVoteChoice)];
+				return validChoices.includes(value);
+			},
+			message: (props) => `${props.value} is not a valid choice`,
+		},
+	})
+	choice: Choice;
+}

--- a/src/voting/voting.module.ts
+++ b/src/voting/voting.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { Voting, VotingSchema } from "./voting.schema";
+import { MongooseModule } from "@nestjs/mongoose";
+import { VotingService } from "./voting.service";
+import VotingNotifier from "./voting.notifier";
+import { Vote } from "./vote.schema";
+
+@Module({
+	imports: [
+		MongooseModule.forFeature([
+			{ name: Voting.name, schema: VotingSchema },
+		]),
+	],
+	providers: [VotingService, VotingNotifier],
+	controllers: [],
+	exports: [VotingService],
+})
+export class VotingModule {}

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -6,35 +6,59 @@ import NotificationSender from "../common/service/notificator/NotificationSender
 import { VotingType } from "./enum/VotingType.enum";
 import { Voting } from "./voting.schema";
 
+/**
+ * Class for sending voting notifications
+ */
 export default class VotingNotifier {
-	private readonly group = NotificationGroup.CLAN;
-	private readonly resource = NotificationResource.VOTING;
+    private readonly group = NotificationGroup.CLAN;
+    private readonly resource = NotificationResource.VOTING;
 
-	newVoting(clan_id: string, voting: Voting) {
-		NotificationSender.buildNotification<Voting>()
-			.addGroup(this.group, clan_id)
-			.addResource(this.resource, voting.type)
-			.send(NotificationStatus.NEW, voting);
-	}
+    /**
+     * Sends a notification for a new voting
+     * @param clan_id - The ID of the clan associated with the voting
+     * @param voting - The voting details
+     */
+    newVoting(clan_id: string, voting: Voting) {
+        NotificationSender.buildNotification<Voting>()
+            .addGroup(this.group, clan_id)
+            .addResource(this.resource, voting.type)
+            .send(NotificationStatus.NEW, voting);
+    }
 
-	votingUpdated(clan_id: string, voting: Voting) {
-		NotificationSender.buildNotification<Voting>()
-			.addGroup(this.group, clan_id)
-			.addResource(this.resource, voting.type)
-			.send(NotificationStatus.UPDATE, voting);
-	}
+    /**
+     * Sends a notification for an updated voting
+     * @param clan_id - The ID of the clan associated with the voting
+     * @param voting - The updated voting details
+     */
+    votingUpdated(clan_id: string, voting: Voting) {
+        NotificationSender.buildNotification<Voting>()
+            .addGroup(this.group, clan_id)
+            .addResource(this.resource, voting.type)
+            .send(NotificationStatus.UPDATE, voting);
+    }
 
-	votingError(clan_id: string, votingType: VotingType, error: APIError) {
-		NotificationSender.buildNotification<APIError>()
-			.addGroup(this.group, clan_id)
-			.addResource(this.resource, votingType)
-			.send(NotificationStatus.ERROR, error);
-	}
+    /**
+     * Sends a notification for a voting error
+     * @param clan_id - The ID of the clan associated with the voting
+     * @param votingType - The type of voting
+     * @param error - The error details
+     */
+    votingError(clan_id: string, votingType: VotingType, error: APIError) {
+        NotificationSender.buildNotification<APIError>()
+            .addGroup(this.group, clan_id)
+            .addResource(this.resource, votingType)
+            .send(NotificationStatus.ERROR, error);
+    }
 
-	votingCompleted(clan_id: string, voting: Voting) {
-		NotificationSender.buildNotification<Voting>()
-			.addGroup(this.group, clan_id)
-			.addResource(this.resource, voting.type)
-			.send(NotificationStatus.END, voting);
-	}
+    /**
+     * Sends a notification for a completed voting
+     * @param clan_id - The ID of the clan associated with the voting
+     * @param voting - The completed voting details
+     */
+    votingCompleted(clan_id: string, voting: Voting) {
+        NotificationSender.buildNotification<Voting>()
+            .addGroup(this.group, clan_id)
+            .addResource(this.resource, voting.type)
+            .send(NotificationStatus.END, voting);
+    }
 }

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -1,0 +1,40 @@
+import { APIError } from "../common/controller/APIError";
+import { NotificationGroup } from "../common/service/notificator/enum/NotificationGroup.enum";
+import { NotificationResource } from "../common/service/notificator/enum/NotificationResource.enum";
+import { NotificationStatus } from "../common/service/notificator/enum/NotificationStatus.enum";
+import NotificationSender from "../common/service/notificator/NotificationSender";
+import { VotingType } from "./enum/VotingType.enum";
+import { Voting } from "./voting.schema";
+
+export default class VotingNotifier {
+	private readonly group = NotificationGroup.CLAN;
+	private readonly resource = NotificationResource.VOTING;
+
+	newVoting(clan_id: string, voting: Voting) {
+		NotificationSender.buildNotification<Voting>()
+			.addGroup(this.group, clan_id)
+			.addResource(this.resource, voting.type)
+			.send(NotificationStatus.NEW, voting);
+	}
+
+	votingUpdated(clan_id: string, voting: Voting) {
+		NotificationSender.buildNotification<Voting>()
+			.addGroup(this.group, clan_id)
+			.addResource(this.resource, voting.type)
+			.send(NotificationStatus.UPDATE, voting);
+	}
+
+	votingError(clan_id: string, votingType: VotingType, error: APIError) {
+		NotificationSender.buildNotification<APIError>()
+			.addGroup(this.group, clan_id)
+			.addResource(this.resource, votingType)
+			.send(NotificationStatus.ERROR, error);
+	}
+
+	votingCompleted(clan_id: string, voting: Voting) {
+		NotificationSender.buildNotification<Voting>()
+			.addGroup(this.group, clan_id)
+			.addResource(this.resource, voting.type)
+			.send(NotificationStatus.END, voting);
+	}
+}

--- a/src/voting/voting.schema.ts
+++ b/src/voting/voting.schema.ts
@@ -1,0 +1,74 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument, Schema as MongooseSchema } from "mongoose";
+import { ModelName } from "../common/enum/modelName.enum";
+import { Player } from "../player/player.schema";
+import { VotingType } from "./enum/VotingType.enum";
+import { Vote } from "./vote.schema";
+
+export type VotingDocument = HydratedDocument<Voting>;
+
+@Schema({ toJSON: { virtuals: true }, toObject: { virtuals: true } })
+export class Voting {
+	@Prop({
+		type: MongooseSchema.Types.ObjectId,
+		ref: ModelName.PLAYER,
+		required: true,
+	})
+	organizer_id: string;
+
+	@Prop({ type: Date })
+	endedAt: Date;
+
+	@Prop({ type: Date, default: Date.now })
+	startedAt: Date;
+
+	@Prop({ type: Date })
+	endsOn: Date;
+
+	@Prop({ type: String, enum: VotingType, required: true })
+	type: VotingType;
+
+	@Prop({
+		type: [MongooseSchema.Types.ObjectId],
+		ref: ModelName.PLAYER,
+		required: true,
+	})
+	player_ids: string[];
+
+	@Prop({ type: Number, default: 51 })
+	minPercentage: number;
+
+	@Prop({ type: [Vote], default: [] })
+	votes: Vote[];
+
+	@Prop({
+		type: MongooseSchema.Types.ObjectId,
+		ref: ModelName.ITEM,
+		required: true,
+	})
+	item_id?: string;
+}
+
+export const VotingSchema = SchemaFactory.createForClass(Voting);
+VotingSchema.set("collection", ModelName.VOTING);
+VotingSchema.virtual(ModelName.PLAYER, {
+	ref: ModelName.PLAYER,
+	localField: "organizer_id",
+	foreignField: "_id",
+	justOne: true,
+});
+
+VotingSchema.pre("save", function (next) {
+	if (
+		(this.type === VotingType.BUYING_ITEM ||
+			this.type === VotingType.SELLING_ITEM) &&
+		!this.item_id
+	) {
+		return next(
+			new Error(
+				"item_id is required for SELLING_ITEM and BUYING_ITEM voting types"
+			)
+		);
+	}
+	next();
+});

--- a/src/voting/voting.schema.ts
+++ b/src/voting/voting.schema.ts
@@ -1,7 +1,6 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 import { HydratedDocument, Schema as MongooseSchema } from "mongoose";
 import { ModelName } from "../common/enum/modelName.enum";
-import { Player } from "../player/player.schema";
 import { VotingType } from "./enum/VotingType.enum";
 import { Vote } from "./vote.schema";
 
@@ -41,12 +40,8 @@ export class Voting {
 	@Prop({ type: [Vote], default: [] })
 	votes: Vote[];
 
-	@Prop({
-		type: MongooseSchema.Types.ObjectId,
-		ref: ModelName.ITEM,
-		required: true,
-	})
-	item_id?: string;
+	@Prop({ type: MongooseSchema.Types.ObjectId })
+	entity_id?: string;
 }
 
 export const VotingSchema = SchemaFactory.createForClass(Voting);
@@ -56,19 +51,4 @@ VotingSchema.virtual(ModelName.PLAYER, {
 	localField: "organizer_id",
 	foreignField: "_id",
 	justOne: true,
-});
-
-VotingSchema.pre("save", function (next) {
-	if (
-		(this.type === VotingType.BUYING_ITEM ||
-			this.type === VotingType.SELLING_ITEM) &&
-		!this.item_id
-	) {
-		return next(
-			new Error(
-				"item_id is required for SELLING_ITEM and BUYING_ITEM voting types"
-			)
-		);
-	}
-	next();
 });

--- a/src/voting/voting.schema.ts
+++ b/src/voting/voting.schema.ts
@@ -30,14 +30,14 @@ export class Voting {
 	@Prop({
 		type: [MongooseSchema.Types.ObjectId],
 		ref: ModelName.PLAYER,
-		required: true,
+		required: true
 	})
 	player_ids: string[];
 
 	@Prop({ type: Number, default: 51 })
 	minPercentage: number;
 
-	@Prop({ type: [Vote], default: [] })
+	@Prop({ type: Array<Vote>, default: [] })
 	votes: Vote[];
 
 	@Prop({ type: MongooseSchema.Types.ObjectId })

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -6,9 +6,6 @@ import BasicService from "../common/service/basicService/BasicService";
 import { CreateVotingDto } from "./dto/createVoting.dto";
 import { ItemVoteChoice } from "./enum/choiceType.enum";
 import { VotingType } from "./enum/VotingType.enum";
-import { validate } from "class-validator";
-import ServiceError from "../common/service/basicService/ServiceError";
-import { SEReason } from "../common/service/basicService/SEReason";
 import VotingNotifier from "./voting.notifier";
 
 @Injectable()
@@ -52,24 +49,16 @@ export class VotingService {
 		const newVoting: CreateVotingDto = {
 			organizer_id: playerId,
 			type: type,
-			item_id: itemId,
+			entity_id: itemId,
 		};
 
-		if (type === VotingType.SELLING_ITEM) {
-			const newVote = {
-				player_id: playerId,
-				choice: ItemVoteChoice.YES,
-			};
+		const newVote = {
+			player_id: playerId,
+			choice: ItemVoteChoice.YES,
+		};
 
-			newVoting.player_ids = [playerId];
-			newVoting.votes = [newVote];
-		}
-
-		const validationErrors = await validate(newVoting);
-		if (validationErrors.length > 0) {
-			console.error(validationErrors);
-			throw new ServiceError({ reason: SEReason.VALIDATION });
-		}
+		newVoting.player_ids = [playerId];
+		newVoting.votes = [newVote];
 
 		const [voting, errors] = await this.createOne(newVoting);
 		if (errors) throw errors;

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from "@nestjs/common";
+import { InjectModel } from "@nestjs/mongoose";
+import { Voting } from "./voting.schema";
+import { Model } from "mongoose";
+import BasicService from "../common/service/basicService/BasicService";
+import { CreateVotingDto } from "./dto/createVoting.dto";
+import { ItemVoteChoice } from "./enum/choiceType.enum";
+import { VotingType } from "./enum/VotingType.enum";
+import { validate } from "class-validator";
+import ServiceError from "../common/service/basicService/ServiceError";
+import { SEReason } from "../common/service/basicService/SEReason";
+import VotingNotifier from "./voting.notifier";
+
+@Injectable()
+export class VotingService {
+	constructor(
+		@InjectModel(Voting.name) public readonly model: Model<Voting>,
+		private readonly notifier: VotingNotifier
+	) {
+		this.basicService = new BasicService(model);
+	}
+
+	public readonly basicService: BasicService;
+
+	/**
+	 * Creates a new voting entry.
+	 *
+	 * @param voting - The data transfer object containing the details of the voting to be created.
+	 * @returns A promise that resolves to the created voting entity.
+	 */
+	async createOne(voting: CreateVotingDto) {
+		return this.basicService.createOne<CreateVotingDto, Voting>(voting);
+	}
+
+	/**
+	 * Initiates a new voting process for an item.
+	 * Creates a new voting entry and sends a MQTT notification.
+	 *
+	 * @param playerId - The ID of the player initiating the voting.
+	 * @param itemId - The ID of the item being voted on.
+	 * @param clanId - The ID of the clan associated with the voting.
+	 * @param type - The type of voting, either for selling or buying an item.
+	 *
+	 * @throws - Throws an error if validation fails or if there are errors creating the voting.
+	 */
+	async startItemVoting(
+		playerId: string,
+		itemId: string,
+		clanId: string,
+		type: VotingType.SELLING_ITEM | VotingType.BUYING_ITEM
+	) {
+		const newVoting: CreateVotingDto = {
+			organizer_id: playerId,
+			type: type,
+			item_id: itemId,
+		};
+
+		if (type === VotingType.SELLING_ITEM) {
+			const newVote = {
+				player_id: playerId,
+				choice: ItemVoteChoice.YES,
+			};
+
+			newVoting.player_ids = [playerId];
+			newVoting.votes = [newVote];
+		}
+
+		const validationErrors = await validate(newVoting);
+		if (validationErrors.length > 0) {
+			console.error(validationErrors);
+			throw new ServiceError({ reason: SEReason.VALIDATION });
+		}
+
+		const [voting, errors] = await this.createOne(newVoting);
+		if (errors) throw errors;
+
+		this.notifier.newVoting(clanId, voting);
+	}
+}

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -5,8 +5,8 @@ import { Model } from "mongoose";
 import BasicService from "../common/service/basicService/BasicService";
 import { CreateVotingDto } from "./dto/createVoting.dto";
 import { ItemVoteChoice } from "./enum/choiceType.enum";
-import { VotingType } from "./enum/VotingType.enum";
 import VotingNotifier from "./voting.notifier";
+import { StartItemVotingParams } from "./type/startItemVoting.type";
 
 @Injectable()
 export class VotingService {
@@ -33,6 +33,7 @@ export class VotingService {
 	 * Initiates a new voting process for an item.
 	 * Creates a new voting entry and sends a MQTT notification.
 	 *
+	 * @param params - The parameters for starting the item voting.
 	 * @param playerId - The ID of the player initiating the voting.
 	 * @param itemId - The ID of the item being voted on.
 	 * @param clanId - The ID of the clan associated with the voting.
@@ -40,12 +41,9 @@ export class VotingService {
 	 *
 	 * @throws - Throws an error if validation fails or if there are errors creating the voting.
 	 */
-	async startItemVoting(
-		playerId: string,
-		itemId: string,
-		clanId: string,
-		type: VotingType.SELLING_ITEM | VotingType.BUYING_ITEM
-	) {
+	async startItemVoting(params: StartItemVotingParams) {
+		const { playerId, itemId, clanId, type } = params;
+
 		const newVoting: CreateVotingDto = {
 			organizer_id: playerId,
 			type: type,


### PR DESCRIPTION
I have added / changed the following:

1. Added sell endpoint to flea market controller.
2. Added methods to flea market service to handle the item selling logic.
3. Added voting module.
4. Added voting service with logic to start new votings.
5. Added voting and vote schemas.
6. Added voting notifier.
7. Added DTOs, enums and types.

Like we discussed in the issue comments the voting schema now has entity_id prop that is not in the ERD so that needs to be updated when this PR is merged. The entity_id is ObjectId type but since the entity can be anything I did not add a ref field to it. So now we would need to check the type of the voting to know what type of entity id it is. If you think this is not a good solution I could add a another prop. entityType with type of ModelName and specify there the entity type and with that I think it would be possible to create the virtual ref as well.
I also removed the validations from the schemas and the validation will be handled in the service layer.