### PR TITLE
Feature/add endpoint to get all clan votings 344

### DIFF
--- a/src/voting/voting.controller.ts
+++ b/src/voting/voting.controller.ts
@@ -14,6 +14,13 @@ import { noPermissionError } from "./error/noPermission.error";
 export class VotingController {
 	constructor(private readonly service: VotingService) {}
 
+	@Get()
+	@Serialize(VotingDto)
+	@UniformResponse(ModelName.VOTING)
+	async getClanVotings(@LoggedUser() user: User) {
+		return this.service.getClanVotings(user.player_id);
+	}
+
 	@Get("/:_id")
 	@Serialize(VotingDto)
 	@UniformResponse(ModelName.VOTING)


### PR DESCRIPTION
In this PR I added the controller endpoint and service method to get all the votings related to the requester.

The issue described to get all the poll objects that the clan has but since the votings document has clan_id and player_id in the organizer prop I made the query filter so that it returns if either of those ids match.

Would you like me to add the swagger documentation for this endpoint or do you want to it yourself?