### PR TITLE
Feature/add get clan leaderboard position 336

### DIFF
--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -76,5 +76,6 @@ ClanSchema.virtual(ModelName.SOULHOME, {
     foreignField: 'clan_id',
     justOne: true
 });
+ClanSchema.index({ points: -1 });
 
 export const publicReferences = [ ModelName.PLAYER, ModelName.STOCK, ModelName.SOULHOME ];

--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from "@nestjs/common";
+import { Controller, Get, Param } from "@nestjs/common";
 import { LeaderboardService } from "./leaderboard.service";
 import { UniformResponse } from "../common/decorator/response/UniformResponse";
 import { ModelName } from "../common/enum/modelName.enum";
@@ -8,26 +8,40 @@ import { OffsetPaginate } from "../common/interceptor/request/offsetPagination.i
 import { Serialize } from "../common/interceptor/response/Serialize";
 import { PlayerDto } from "../player/dto/player.dto";
 import { ClanDto } from "../clan/dto/clan.dto";
-import {NoAuth} from "../auth/decorator/NoAuth.decorator";
+import { NoAuth } from "../auth/decorator/NoAuth.decorator";
+import { LoggedUser } from "../common/decorator/param/LoggedUser.decorator";
+import { User } from "../auth/user";
+import { PlayerService } from "../player/player.service";
 
-@NoAuth()
 @Controller("leaderboard")
 export class LeaderboardController {
-	constructor(private readonly leaderBoardService: LeaderboardService) {}
+	constructor(
+		private readonly leaderBoardService: LeaderboardService,
+		private readonly playerService: PlayerService
+	) {}
 
 	@Get("player")
-    @OffsetPaginate(ModelName.PLAYER)
-    @Serialize(PlayerDto)
-    @UniformResponse(ModelName.PLAYER)
+	@NoAuth()
+	@OffsetPaginate(ModelName.PLAYER)
+	@Serialize(PlayerDto)
+	@UniformResponse(ModelName.PLAYER)
 	async getPlayerLeaderboard(@GetAllQuery() query: IGetAllQuery) {
 		return await this.leaderBoardService.getPlayerLeaderboard(query);
 	}
 
 	@Get("clan")
+	@NoAuth()
 	@OffsetPaginate(ModelName.CLAN)
 	@Serialize(ClanDto)
 	@UniformResponse(ModelName.CLAN)
 	async getClanLeaderboard(@GetAllQuery() query: IGetAllQuery) {
 		return await this.leaderBoardService.getClanLeaderboard(query);
+	}
+
+	@Get("clan/position")
+	@UniformResponse()
+	async getClanPosition(@LoggedUser() user: User) {
+		const clanId = await this.playerService.getPlayerClanId(user.player_id);
+		return await this.leaderBoardService.getClanPosition(clanId);
 	}
 }

--- a/src/player/player.schema.ts
+++ b/src/player/player.schema.ts
@@ -65,6 +65,7 @@ PlayerSchema.virtual(ModelName.ROOM,{
     ref: ModelName.ROOM,
     localField:'_id',
     foreignField:'player_id'
-})
+});
+PlayerSchema.index({ points: -1 });
 
 export const publicReferences = [ModelName.CLAN, ModelName.CUSTOM_CHARACTER, ModelName.ROOM];

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -3607,6 +3607,56 @@
                 "summary": "Get basic info about logged-in user",
                 "description": "Get basic info of the logged-in user:\n\n- Profile\n- Player\n- Clan"
             }
+        },
+        "/leaderboard/clan/position": {
+            "get": {
+                "tags": [
+                    "Leaderboard",
+                    "in-development"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "1": {
+                                        "value": {
+                                            "data": {
+                                                "Object": {
+                                                    "position": 1
+                                                }
+                                            },
+                                            "metaData": {
+                                                "dataKey": "Object",
+                                                "modelName": "Object",
+                                                "dataType": "Object",
+                                                "dataCount": 1
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Clan's position object"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/401_New"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/404_New"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/500_New"
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    }
+                ],
+                "summary": "logged-in user's clan on the leaderboard",
+                "description": "Get the logged-in user's clan position on the leaderboard.\n\nNote that if the logged-in user is not in any clan the 404 will be returned"
+            }
         }
     },
     "components": {


### PR DESCRIPTION
I have added / changed the following:

I added 
 - GET /leaderboard/clan/position endpoint to get the position of the requesters clan on the leaderboard.
 - Service method to get the position data
 - Indexes on Clan and Player schemas points field to make the leaderboard queries faster
