### PR TITLE
Feature/add clan logo data 326

### DIFF
--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -6,6 +6,7 @@ import { ClanLabel } from './enum/clanLabel.enum';
 import { AgeRange } from './enum/ageRange.enum';
 import { Language } from '../common/enum/language.enum';
 import { Goal } from './enum/goal.enum';
+import { ClanLogo } from './clanLogo.schema';
 
 export type ClanDocument = HydratedDocument<Clan>;
 
@@ -16,6 +17,9 @@ export class Clan {
 
     @Prop({ type: String })
     tag: string;
+
+    @Prop({ type: ClanLogo })
+    clanLogo: ClanLogo;
 
     @Prop({ type: [String], enum: ClanLabel, required: true })
     labels: string[];

--- a/src/clan/clanLogo.schema.ts
+++ b/src/clan/clanLogo.schema.ts
@@ -1,0 +1,14 @@
+import { Prop } from "@nestjs/mongoose";
+import { LogoType } from "./enum/logoType.enum";
+import { IsHexColor } from "class-validator";
+
+class ClanLogo {
+	@Prop({ type: String, enum: LogoType, required: true })
+	logoType: LogoType;
+
+	@Prop({ type: [String], required: true })
+	@IsHexColor({ each: true })
+	pieceColors: string[];
+}
+
+export { ClanLogo };

--- a/src/clan/dto/clan.dto.ts
+++ b/src/clan/dto/clan.dto.ts
@@ -7,6 +7,8 @@ import { AgeRange } from "../enum/ageRange.enum";
 import { Goal } from "../enum/goal.enum";
 import { StockDto } from "../../clanInventory/stock/dto/stock.dto";
 import { SoulHomeDto } from "../../clanInventory/soulhome/dto/soulhome.dto";
+import { ClanLogo } from "../clanLogo.schema";
+import { ClanLogoDto } from "./clanLogo.dto";
 
 @AddType('ClanDto')
 export class ClanDto {
@@ -19,6 +21,10 @@ export class ClanDto {
 
     @Expose()
     tag: string;
+
+    @Type(() => ClanLogoDto)
+    @Expose()
+    clanLogo: ClanLogoDto;
 
     @Expose()
     labels: string[];

--- a/src/clan/dto/clanLogo.dto.ts
+++ b/src/clan/dto/clanLogo.dto.ts
@@ -1,0 +1,16 @@
+import { IsArray, IsEnum, IsHexColor } from "class-validator";
+import { LogoType } from "../enum/logoType.enum";
+import AddType from "../../common/base/decorator/AddType.decorator";
+import { Expose } from "class-transformer";
+
+@AddType("ClanLogoDto")
+export class ClanLogoDto {
+	@Expose()
+	@IsEnum(LogoType)
+	logoType: LogoType;
+
+	@Expose()
+	@IsArray()
+	@IsHexColor({ each: true })
+	pieceColors: string[];
+}

--- a/src/clan/dto/createClan.dto.ts
+++ b/src/clan/dto/createClan.dto.ts
@@ -1,9 +1,12 @@
-import { IsArray, ArrayMaxSize, IsEnum, IsInt, IsBoolean, IsOptional, IsString } from "class-validator";
+import { IsArray, ArrayMaxSize, IsEnum, IsBoolean, IsOptional, IsString, ValidateNested } from "class-validator";
 import AddType from "../../common/base/decorator/AddType.decorator";
 import { ClanLabel } from '../enum/clanLabel.enum';
 import { AgeRange } from "../enum/ageRange.enum";
 import { Language } from "../../common/enum/language.enum";
 import { Goal } from "../enum/goal.enum";
+import { Type } from "class-transformer";
+import { ClanLogoDto } from "./clanLogo.dto";
+import { ClanLogo } from "../clanLogo.schema";
 
 @AddType('CreateClanDto')
 export class CreateClanDto {
@@ -12,6 +15,11 @@ export class CreateClanDto {
 
     @IsString()
     tag: string;
+
+    @Type(() => ClanLogoDto)
+    @IsOptional()
+    @ValidateNested()
+    clanLogo: ClanLogoDto;
 
     @IsArray()
     @ArrayMaxSize(5)

--- a/src/clan/dto/updateClan.dto.ts
+++ b/src/clan/dto/updateClan.dto.ts
@@ -1,10 +1,12 @@
-import { ArrayNotEmpty, IsArray, ArrayMaxSize, IsEnum, IsBoolean, IsInt, IsMongoId, IsOptional, IsString, Validate } from 'class-validator';import {IsClanExists} from "../decorator/validation/IsClanExists.decorator";
+import { ArrayNotEmpty, IsArray, ArrayMaxSize, IsEnum, IsBoolean, IsInt, IsMongoId, IsOptional, IsString, Validate, ValidateNested } from 'class-validator';import {IsClanExists} from "../decorator/validation/IsClanExists.decorator";
 import { IsPlayerExists } from "../../player/decorator/validation/IsPlayerExists.decorator";
 import AddType from "../../common/base/decorator/AddType.decorator";
 import { ClanLabel } from '../enum/clanLabel.enum';
 import { AgeRange } from '../enum/ageRange.enum';
 import { Goal } from '../enum/goal.enum';
 import { Language } from '../../common/enum/language.enum';
+import { ClanLogoDto } from './clanLogo.dto';
+import { Type } from 'class-transformer';
 
 @AddType('UpdateClanDto')
 export class UpdateClanDto {
@@ -19,6 +21,11 @@ export class UpdateClanDto {
     @IsString()
     @IsOptional()
     tag?: string;
+
+    @ValidateNested()
+    @Type(() => ClanLogoDto)
+    @IsOptional()
+    clanLogo: ClanLogoDto;
 
     @IsArray()
     @ArrayMaxSize(5)

--- a/src/clan/enum/logoType.enum.ts
+++ b/src/clan/enum/logoType.enum.ts
@@ -1,0 +1,6 @@
+/**
+ * Enum for LogoType in the clanLogo schema.
+ */
+export enum LogoType {
+	HEART = 'Heart',
+}


### PR DESCRIPTION
This pull request introduces a new `ClanLogo` schema and integrates it into the existing clan-related DTOs and schemas. The changes include defining the `ClanLogo` schema, adding it to the `Clan` model, and updating the relevant DTOs to include the new schema.

Schema and DTO updates:

* [`src/clan/clan.schema.ts`](diffhunk://#diff-2b0a6d9aa16122d4b8f08d8ea3430f94dce5476a904154c3f90f19b5127e0147R9): Added `ClanLogo` schema and integrated it into the `Clan` model. [[1]](diffhunk://#diff-2b0a6d9aa16122d4b8f08d8ea3430f94dce5476a904154c3f90f19b5127e0147R9) [[2]](diffhunk://#diff-2b0a6d9aa16122d4b8f08d8ea3430f94dce5476a904154c3f90f19b5127e0147R21-R23)
* [`src/clan/clanLogo.schema.ts`](diffhunk://#diff-a0a19a87d3eeb779c78e76aafc60ac180f038cac8bafeed4f7a976c023b57cb5R1-R14): Created the `ClanLogo` schema with properties `logoType` and `pieceColors`.
* [`src/clan/dto/clan.dto.ts`](diffhunk://#diff-26311f6109344700557727975d3ddc99a3e62a7277526604e19c236abeaf212aR10-R11): Updated `ClanDto` to include the `ClanLogoDto` property. [[1]](diffhunk://#diff-26311f6109344700557727975d3ddc99a3e62a7277526604e19c236abeaf212aR10-R11) [[2]](diffhunk://#diff-26311f6109344700557727975d3ddc99a3e62a7277526604e19c236abeaf212aR25-R28)
* [`src/clan/dto/clanLogo.dto.ts`](diffhunk://#diff-cc63c1fcd36a11276807fb077c066ce95304c924674d3741759b5ad419955ccbR1-R16): Created `ClanLogoDto` with validation decorators.
* [`src/clan/dto/createClan.dto.ts`](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dL1-R9): Updated `CreateClanDto` to include the optional `ClanLogoDto` property with nested validation. [[1]](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dL1-R9) [[2]](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dR19-R23)
* [`src/clan/dto/updateClan.dto.ts`](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecL1-R9): Updated `UpdateClanDto` to include the optional `ClanLogoDto` property with nested validation. [[1]](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecL1-R9) [[2]](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecR25-R29)

Enum definition:

* [`src/clan/enum/logoType.enum.ts`](diffhunk://#diff-ebd6a90855bb65e99cd72839572db5cea3a13915e49b63ada4d0e1b9d5ea73acR1-R6): Added `LogoType` enum for the `ClanLogo` schema.