### PR TITLE
Feature/add task generating mechanism 376

### DIFF
--- a/src/dailyTasks/consts/taskConstants.ts
+++ b/src/dailyTasks/consts/taskConstants.ts
@@ -1,0 +1,13 @@
+export const TASK_CONSTS = {
+	AMOUNT: {
+		MIN: 2,
+		MAX: 20,
+	},
+	POINTS: {
+		MIN: 5,
+		MAX: 100,
+	},
+	COINS: {
+		FACTOR: 0.5, // Coins are calculated as points * FACTOR
+	},
+};

--- a/src/dailyTasks/dailyTasks.service.ts
+++ b/src/dailyTasks/dailyTasks.service.ts
@@ -7,6 +7,7 @@ import DailyTaskNotifier from "./dailyTask.notifier";
 import { DailyTask } from "./dailyTasks.schema";
 import { TaskName } from "./enum/taskName.enum";
 import { Task } from "./type/task.type";
+import { TASK_CONSTS } from "./consts/taskConstants";
 
 @Injectable()
 export class DailyTasksService {
@@ -60,9 +61,15 @@ export class DailyTasksService {
 	 * @returns A partial Task missing the ids and startedAt fields and object containing randomly generated values.
 	 */
 	private createTaskRandomValues(): Partial<Task> {
-		const amount = Math.floor(Math.random() * 20) + 1;
-		const points = Math.floor(Math.random() * 100) + 1;
-		const coins = Math.floor(points / 2);
+		const amount =
+			Math.floor(
+				Math.random() * (TASK_CONSTS.AMOUNT.MAX - TASK_CONSTS.AMOUNT.MIN + 1)
+			) + TASK_CONSTS.AMOUNT.MIN;
+		const points =
+			Math.floor(
+				Math.random() * (TASK_CONSTS.POINTS.MAX - TASK_CONSTS.POINTS.MIN + 1)
+			) + TASK_CONSTS.POINTS.MIN;
+		const coins = Math.floor(points * TASK_CONSTS.COINS.FACTOR);
 		const taskType = this.getRandomTaskType();
 		const title = this.getTaskTitle(taskType, amount);
 

--- a/src/dailyTasks/dailyTasks.service.ts
+++ b/src/dailyTasks/dailyTasks.service.ts
@@ -5,6 +5,8 @@ import BasicService from "../common/service/basicService/BasicService";
 import { ModelName } from "../common/enum/modelName.enum";
 import DailyTaskNotifier from "./dailyTask.notifier";
 import { DailyTask } from "./dailyTasks.schema";
+import { TaskName } from "./enum/taskName.enum";
+import { Task } from "./type/task.type";
 
 @Injectable()
 export class DailyTasksService {
@@ -19,4 +21,59 @@ export class DailyTasksService {
 	public readonly modelName: ModelName;
 	private readonly basicService: BasicService;
 	public readonly refsInModel: ModelName[];
+
+	/**
+	 * Retrieves a random task type from the available task names enum.
+	 *
+	 * @returns A randomly selected task name.
+	 */
+	private getRandomTaskType(): TaskName {
+		const taskTypes = Object.values(TaskName);
+		const randomIndex = Math.floor(Math.random() * taskTypes.length);
+		return taskTypes[randomIndex];
+	}
+
+	/**
+	 * Generates a task title based on the task type and amount.
+	 *
+	 * @param type - The type of the task.
+	 * @param amount - The number associated with the task.
+	 * @returns The generated task title as a string.
+	 * @throws Will throw an error if the task type is unknown.
+	 */
+	private getTaskTitle(type: TaskName, amount: number): string {
+		switch (type) {
+			case TaskName.PLAY_BATTLE:
+				return `Pelaa ${amount} taistelua`;
+			case TaskName.WIN_BATTLE:
+				return `Voita ${amount} taistelua`;
+			case TaskName.WRITE_CHAT_MESSAGE:
+				return `Lähetä ${amount} viestiä chattiin`;
+			default:
+				throw new Error("Unknown task type");
+		}
+	}
+
+	/**
+	 * Generates a random task with random values for amount, points, coins, type, and title.
+	 *
+	 * @returns A partial Task missing the ids and startedAt fields and object containing randomly generated values.
+	 */
+	private createTaskRandomValues(): Partial<Task> {
+		const amount = Math.floor(Math.random() * 20) + 1;
+		const points = Math.floor(Math.random() * 100) + 1;
+		const coins = Math.floor(points / 2);
+		const taskType = this.getRandomTaskType();
+		const title = this.getTaskTitle(taskType, amount);
+
+		const task: Partial<Task> = {
+			amount,
+			points,
+			coins,
+			type: taskType,
+			title: { fi: title },
+		};
+
+		return task;
+	}
 }


### PR DESCRIPTION
I decided to do a milestone branch since the individual issues would've broken the dev branch. I will merge all the milestone issues to this branch and let's merge this into the dev once the milestone is complete.

So in the milestone branch I renamed playerTasks to dailyTasks, removed most of the old logic and refactored the schema. 
I added the clanId to the task schema and made playerId optional. I also added the points and coins to the schema since they are now randomly generated.

In this PR I added the required methods to generate values for new random tasks.

I added taskConstants where the min and max values for the tasks can easily bet set.

The task type is generated based on the TaskName enum so the types of tasks the api doesn't yet support need to be commented out before we take this in use.

