### PR TITLE
feat(BoxService): include box_id in JWT access token payload

### DIFF
--- a/src/box/box.service.ts
+++ b/src/box/box.service.ts
@@ -92,6 +92,7 @@ export class BoxService {
 		const accessToken = await this.jwtService.signAsync({
 			player_id: account.player_id,
 			profile_id: account.profile_id,
+			box_id: box._id,
 		});
 
         const response: ClaimAccountResponseDto = {


### PR DESCRIPTION
This pull request includes a small change to the `BoxService` class in the `src/box/box.service.ts` file. The change adds the `box_id` to the payload of the JWT token.

* [`src/box/box.service.ts`](diffhunk://#diff-8bf43102f5c273643f01c13636469c8020763bd83535865026637de5933798e8R95): Added `box_id` to the JWT token payload in the `BoxService` class.