### PR TITLE
Add PasswordGenerator class to generate user readable passwords

### DIFF
--- a/src/__tests__/box/modules/box.module.ts
+++ b/src/__tests__/box/modules/box.module.ts
@@ -9,6 +9,7 @@ import {BoxHelper} from "../../../box/util/boxHelper";
 import BoxCreator from "../../../box/boxCreator";
 import BoxAuthHandler from "../../../box/auth/BoxAuthHandler";
 import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
+import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
 
 export default class BoxModule {
     private constructor() {
@@ -50,5 +51,10 @@ export default class BoxModule {
     static async getDailyTaskService() {
         const module = await BoxCommonModule.getModule();
         return module.resolve(DailyTaskService);
+    }
+
+    static async getPasswordGenerator() {
+        const module = await BoxCommonModule.getModule();
+        return module.resolve(PasswordGenerator);
     }
 }

--- a/src/__tests__/box/modules/boxCommon.ts
+++ b/src/__tests__/box/modules/boxCommon.ts
@@ -22,6 +22,8 @@ import BoxCreator from "../../../box/boxCreator";
 import {JwtModule} from "@nestjs/jwt";
 import BoxAuthHandler from "../../../box/auth/BoxAuthHandler";
 import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
+import {GroupAdminGuard} from "../../../box/auth/decorator/groupAdmin.guard";
+import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
 
 
 export default class BoxCommonModule {
@@ -53,8 +55,10 @@ export default class BoxCommonModule {
                     JwtModule
                 ],
                 providers: [
-                    BoxService, GroupAdminService, BoxHelper, BoxCreator, BoxAuthHandler,
-                    DailyTaskService
+                    BoxService, GroupAdminService, BoxHelper, BoxCreator,
+                    DailyTaskService,
+                    BoxAuthHandler, GroupAdminGuard,
+                    PasswordGenerator
                 ]
             }).compile();
 

--- a/src/__tests__/box/tester/PasswordGenerator/generatePassword.test.ts
+++ b/src/__tests__/box/tester/PasswordGenerator/generatePassword.test.ts
@@ -1,0 +1,23 @@
+import {PasswordGenerator} from "../../../../box/tester/passwordGenerator";
+import BoxModule from "../../modules/box.module";
+
+describe('PasswordGenerator.generatePassword() test suite', () => {
+    let passwordGenerator: PasswordGenerator;
+    beforeEach(async () => {
+        passwordGenerator = await BoxModule.getPasswordGenerator();
+    });
+
+    it('Should generate a new password', () => {
+        const password = passwordGenerator.generatePassword('fi');
+        expect(password).not.toBeNull();
+        expect(password).not.toBeUndefined();
+        expect(password).not.toBe('');
+    });
+
+    it('Should not generate 2 same passwords in a row', () => {
+        const password1 = passwordGenerator.generatePassword('fi');
+        const password2 = passwordGenerator.generatePassword('fi');
+
+        expect(password1).not.toBe(password2);
+    });
+});

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -23,6 +23,7 @@ import BoxAuthHandler from "./auth/BoxAuthHandler";
 import {DailyTaskController} from "./dailyTask/dailyTask.controller";
 import {DailyTaskService} from "./dailyTask/dailyTask.service";
 import {GroupAdminGuard} from "./auth/decorator/groupAdmin.guard";
+import {PasswordGenerator} from "./tester/passwordGenerator";
 
 @Module({
     imports: [
@@ -48,7 +49,8 @@ import {GroupAdminGuard} from "./auth/decorator/groupAdmin.guard";
     providers: [
         BoxService, GroupAdminService, BoxHelper, BoxCreator,
         DailyTaskService,
-        BoxAuthHandler, GroupAdminGuard
+        BoxAuthHandler, GroupAdminGuard,
+        PasswordGenerator
     ],
     exports: [
         BoxService, GroupAdminGuard

--- a/src/box/tester/passwordGenerator.ts
+++ b/src/box/tester/passwordGenerator.ts
@@ -1,0 +1,178 @@
+import {Injectable} from "@nestjs/common";
+
+/**
+ * Language of the password
+ */
+type PasswordLanguage = 'fi';
+
+/**
+ * Type of the password
+ */
+type PasswordType = 'sentence' | 'place';
+
+
+/**
+ * Base data of which the password can be generated, which is
+ * a record of words, where
+ * the key is a position in the password starting with zero and
+ * array of possible words for this position
+ */
+type PasswordBase = Record<number, PasswordWord[]>
+type PasswordWord = Record<PasswordLanguage, string>;
+
+@Injectable()
+export class PasswordGenerator {
+
+    private readonly sentencePasswordBase: PasswordBase = {
+        0: [
+            {fi: "kettu"}, {fi: "panda"}, {fi: "varis"}, {fi: "hevonen"}, {fi: "apina"},
+            {fi: "gorilla"}, {fi: "strutsi"}, {fi: "lehmä"}, {fi: "pupu"}, {fi: "pöllö"},
+            {fi: "ilves"}, {fi: "vuohi"}, {fi: "norsu"}, {fi: "sammakko"}, {fi: "hirvi"},
+            {fi: "mäyrä"}, {fi: "karhu"}, {fi: "karppi"}, {fi: "orava"}, {fi: "pingviini"},
+            {fi: "poro"}, {fi: "kissa"}, {fi: "peura"}, {fi: "haukka"}, {fi: "krokotiili"},
+            {fi: "sarvikuono"}, {fi: "lintu"}, {fi: "ahma"}, {fi: "kana"}, {fi: "marsu"},
+            {fi: "sika"}, {fi: "sorsa"}, {fi: "myyrä"}, {fi: "käärme"}, {fi: "hiiri"},
+            {fi: "lammas"}, {fi: "kotka"}, {fi: "jänis"}, {fi: "hylje"}, {fi: "koira"}
+        ],
+        1: [
+            {fi: "keräilee"}, {fi: "soutaa"}, {fi: "sukeltaa"}, {fi: "purjehtii"}, {fi: "näkee"},
+            {fi: "kaivaa"}, {fi: "miettii"}, {fi: "ostaa"}, {fi: "kaataa"}, {fi: "laulaa"},
+            {fi: "rakentaa"}, {fi: "hyppää"}, {fi: "juoksee"}, {fi: "ratsastaa"}, {fi: "syö"},
+            {fi: "lentää"}, {fi: "kävelee"}, {fi: "leikkii"}, {fi: "katsoo"}, {fi: "lukee"},
+            {fi: "kirjoittaa"}, {fi: "vilkuttaa"}, {fi: "itkee"}, {fi: "kuuntelee"}, {fi: "soittaa"},
+            {fi: "juo"}, {fi: "tanssii"}, {fi: "haistaa"}, {fi: "tanssii"}, {fi: "viljelee"},
+            {fi: "nukkuu"}, {fi: "pyöräilee"}, {fi: "piirtää"}, {fi: "metsästää"}, {fi: "nauraa"},
+            {fi: "leipoo"}, {fi: "kierii"}, {fi: "maalasi"}, {fi: "huutaa"}, {fi: "ui"}
+        ],
+        2: [
+            {fi: "salaattia"}, {fi: "kermaa"}, {fi: "suolaa"}, {fi: "pähkinöitä"}, {fi: "pähkinöitä"},
+            {fi: "riisiä"}, {fi: "suklaata"}, {fi: "teetä"}, {fi: "marjoja"}, {fi: "limonadia"},
+            {fi: "omenaa"}, {fi: "sieniä"}, {fi: "herneitä"}, {fi: "mehua"}, {fi: "banaania"},
+            {fi: "omenamehua"}, {fi: "juustoa"}, {fi: "lihaa"}, {fi: "sämpylää"}, {fi: "puuroa"},
+            {fi: "kahvia"}, {fi: "pippuria"}, {fi: "maitoa"}, {fi: "jäätelöä"}, {fi: "makkaraa"},
+            {fi: "heinää"}, {fi: "sipulia"}, {fi: "porkkanaa"}, {fi: "mansikoita"}, {fi: "sokeria"},
+            {fi: "leipää"}, {fi: "vadelmia"}, {fi: "vettä"}, {fi: "muroja"}, {fi: "kaurapuuroa"},
+            {fi: "jäätelöä"}, {fi: "mustikoita"}, {fi: "kirsikoita"}, {fi: "kalaa"}, {fi: "hunajaa"}
+        ]
+    }
+
+    private readonly placePasswordBase: PasswordBase = {
+        0: [
+            {fi: "surullinen"}, {fi: "meluisa"}, {fi: "viisas"}, {fi: "iloinen"}, {fi: "lyhyt"},
+            {fi: "ystävällinen"}, {fi: "karvainen"}, {fi: "nuori"}, {fi: "vahva"}, {fi: "väsynyt"},
+            {fi: "onnellinen"}, {fi: "nälkäinen"}, {fi: "pieni"}, {fi: "rohkea"}, {fi: "ystävällinen"},
+            {fi: "hauska"}, {fi: "reipas"}, {fi: "laiska"}, {fi: "kiireinen"}, {fi: "tyhmä"},
+            {fi: "arvokas"}, {fi: "peloton"}, {fi: "näyttävä"}, {fi: "ihana"}, {fi: "lempeä"},
+            {fi: "utelias"}, {fi: "valoisa"}, {fi: "upea"}, {fi: "iso"}, {fi: "ahkera"},
+            {fi: "nopea"}, {fi: "upea"}, {fi: "pitkä"}, {fi: "heikko"}, {fi: "vanha"},
+            {fi: "vakava"}, {fi: "hiljainen"}, {fi: "hidas"}, {fi: "kaunis"}, {fi: "pimeä"}
+        ],
+        1: [
+            {fi: "peura"}, {fi: "kettu"}, {fi: "kotka"}, {fi: "koala"}, {fi: "myyrä"},
+            {fi: "marsu"}, {fi: "karppi"}, {fi: "hevonen"}, {fi: "krokotiili"}, {fi: "lintu"},
+            {fi: "pöllö"}, {fi: "sika"}, {fi: "pingviini"}, {fi: "haukka"}, {fi: "sarvikuono"},
+            {fi: "karhu"}, {fi: "lammas"}, {fi: "kissa"}, {fi: "sammakko"}, {fi: "susi"},
+            {fi: "varis"}, {fi: "käärme"}, {fi: "strutsi"}, {fi: "kana"}, {fi: "tapiri"},
+            {fi: "hiiri"}, {fi: "ahma"}, {fi: "vuohi"}, {fi: "poro"}, {fi: "ilves"},
+            {fi: "mäyrä"}, {fi: "jänis"}, {fi: "sorsa"}, {fi: "pupu"}, {fi: "hirvi"},
+            {fi: "koira"}, {fi: "panda"}, {fi: "hylje"}, {fi: "gorilla"}, {fi: "norsu"}
+        ],
+        2: [
+            {fi: "kylpyhuoneessa"}, {fi: "portilla"}, {fi: "tuolilla"}, {fi: "koulussa"}, {fi: "kadun-varrella"},
+            {fi: "kadulla"}, {fi: "kaupungissa"}, {fi: "saarella"}, {fi: "kivellä"}, {fi: "metsässä"},
+            {fi: "oven-edessä"}, {fi: "järvellä"}, {fi: "satamassa"}, {fi: "teatterissa"}, {fi: "kirjastossa"},
+            {fi: "huoneessa"}, {fi: "keittiössä"}, {fi: "autossa"}, {fi: "rannalla"}, {fi: "kaapissa"},
+            {fi: "puussa"}, {fi: "asemalla"}, {fi: "pellolla"}, {fi: "pihalla"}, {fi: "sillalla"},
+            {fi: "teltassa"}, {fi: "kaupassa"}, {fi: "vieressä"}, {fi: "sairaalassa"}, {fi: "torilla"},
+            {fi: "puutarhassa"}, {fi: "kellarissa"}, {fi: "mökissä"}, {fi: "vuorella"}, {fi: "kellarissa"},
+            {fi: "parvekkeella"}, {fi: "tornissa"}, {fi: "pöydällä"}, {fi: "sängyssä"}, {fi: "talossa"}
+        ]
+    }
+
+    /**
+     * Generates a random words password, which is easy to remember.
+     *
+     * @param language language of the password
+     *
+     * @returns generated password
+     */
+    generatePassword(language: PasswordLanguage): string {
+        const type = this.getRandomPasswordType();
+        const base = this.getPasswordBase(type);
+        const wordsCount = Object.keys(base).length;
+
+        let password = '';
+
+        for (let i = 0; i < wordsCount; i++) {
+            const word = this.getShuffledWord(base[i])[language];
+            password += word + '-';
+        }
+        password = password.slice(0, password.length - 1);
+
+        return password;
+    }
+
+    /**
+     * Shuffles an array and gets the first word from a shuffled array
+     * @param words array of words
+     * @private
+     * @returns random word
+     */
+    private getShuffledWord(words: PasswordWord[]): PasswordWord {
+        if (!words.length)
+            return words[0];
+        return this.shuffleArray(words)[0];
+    }
+
+    /**
+     * Shuffles a provided array
+     * @param array array to shuffle
+     * @private
+     * @returns shuffled array
+     */
+    private shuffleArray<T>(array: T[]): T[] {
+        const newArray = [...array];
+        for (let i = newArray.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+        }
+        return newArray;
+    }
+
+    /**
+     * Gets the required base for the password type
+     * @param type type of the password
+     * @private
+     * @returns the required password base, sentence type is a default
+     */
+    private getPasswordBase(type: PasswordType): PasswordBase {
+        switch (type) {
+            case 'sentence':
+                return this.sentencePasswordBase;
+            case 'place':
+                return this.placePasswordBase;
+            default:
+                return this.sentencePasswordBase;
+        }
+    }
+
+    /**
+     * Chooses a random password type
+     * @private
+     * @returns random password type
+     */
+    private getRandomPasswordType(): PasswordType {
+        return Math.random() < 0.49 ? 'place' : 'sentence';
+    }
+
+    /**
+     * Get a random number within the specified range
+     * @param min minimum number
+     * @param max maximum number
+     * @private
+     * @returns generated int number
+     */
+    private getRandomNumber(min: number, max: number) {
+        return min + (Math.random() * (max - min + 1)) | 0;
+    }
+}


### PR DESCRIPTION
### Brief description

The `PasswordGenerator` class generates passwords, which is easier to remember and read for a human

### Change list

- Add `PasswordGenerator` class
- Add `generatePassword()` method, which can generate two types of passwords. One type is a "sentence", which will generate something like _koira-syö-makkaraa_ or "place" type, such as _iso-karhu-keittiössä_
- Add unit tests for the `generatePassword()` method
