### PR TITLE
Feature/endpoint to reset test session 422

### DIFF
--- a/src/common/function/cancelTransaction.ts
+++ b/src/common/function/cancelTransaction.ts
@@ -1,0 +1,19 @@
+import { ClientSession } from "mongoose";
+import ServiceError from "../service/basicService/ServiceError";
+
+	/**
+	 * Aborts the database transaction and ends the session.
+	 *
+	 * @param session - Started database session.
+	 * @param error - The error to be thrown.
+	 * 
+	 * @throws Will throw an unexpected service error.
+	 */
+	export async function  cancelTransaction(
+		session: ClientSession,
+		error: ServiceError[]
+	) {
+		await session.abortTransaction();
+		await session.endSession();
+		throw error;
+	}


### PR DESCRIPTION
### Brief description

Added endpoint and service method to reset a testing box. The reset endpoint can be used by the group admin only. The method finds the box of the admin and deletes the old one and then creates a new one based on the info of the old one and creates a new access token. This way the boxCreator can be used for resetting and no new logic is required.

### Change list

- enabled the BoxAuthGuard in box controller
- added the reset endpoint
- added cancelTransaction method to common module functions
- changed deleteBoxReferences to use a transaction.
- added getBoxResetData method to box service to get data from old box to the new one.
