### PR TITLE
Endpoint for defining amount of testers in the box

### DIFF
--- a/src/__tests__/box/modules/box.module.ts
+++ b/src/__tests__/box/modules/box.module.ts
@@ -10,6 +10,7 @@ import BoxCreator from "../../../box/boxCreator";
 import BoxAuthHandler from "../../../box/auth/BoxAuthHandler";
 import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
 import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
+import {TesterService} from "../../../box/tester/tester.service";
 
 export default class BoxModule {
     private constructor() {
@@ -56,5 +57,10 @@ export default class BoxModule {
     static async getPasswordGenerator() {
         const module = await BoxCommonModule.getModule();
         return module.resolve(PasswordGenerator);
+    }
+
+    static async getTesterService() {
+        const module = await BoxCommonModule.getModule();
+        return module.resolve(TesterService);
     }
 }

--- a/src/__tests__/box/modules/boxCommon.ts
+++ b/src/__tests__/box/modules/boxCommon.ts
@@ -24,6 +24,7 @@ import BoxAuthHandler from "../../../box/auth/BoxAuthHandler";
 import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
 import {GroupAdminGuard} from "../../../box/auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
+import {TesterService} from "../../../box/tester/tester.service";
 
 
 export default class BoxCommonModule {
@@ -38,15 +39,15 @@ export default class BoxCommonModule {
                 imports: [
                     MongooseModule.forRoot(mongoString, mongooseOptions),
                     MongooseModule.forFeature([
-                        { name: ModelName.BOX, schema: BoxSchema },
-                        { name: ModelName.GROUP_ADMIN, schema: GroupAdminSchema },
-                        { name: ModelName.PROFILE, schema: ProfileSchema },
-                        { name: ModelName.PLAYER, schema: PlayerSchema },
-                        { name: ModelName.CLAN, schema: ClanSchema },
-                        { name: ModelName.SOULHOME, schema: SoulhomeSchema },
-                        { name: ModelName.ROOM, schema: RoomSchema },
-                        { name: ModelName.STOCK, schema: StockSchema },
-                        { name: ModelName.CHAT, schema: ChatSchema }
+                        {name: ModelName.BOX, schema: BoxSchema},
+                        {name: ModelName.GROUP_ADMIN, schema: GroupAdminSchema},
+                        {name: ModelName.PROFILE, schema: ProfileSchema},
+                        {name: ModelName.PLAYER, schema: PlayerSchema},
+                        {name: ModelName.CLAN, schema: ClanSchema},
+                        {name: ModelName.SOULHOME, schema: SoulhomeSchema},
+                        {name: ModelName.ROOM, schema: RoomSchema},
+                        {name: ModelName.STOCK, schema: StockSchema},
+                        {name: ModelName.CHAT, schema: ChatSchema}
                     ]),
                     ClanModule,
                     ChatModule,
@@ -58,7 +59,7 @@ export default class BoxCommonModule {
                     BoxService, GroupAdminService, BoxHelper, BoxCreator,
                     DailyTaskService,
                     BoxAuthHandler, GroupAdminGuard,
-                    PasswordGenerator
+                    PasswordGenerator, TesterService
                 ]
             }).compile();
 

--- a/src/__tests__/box/tester/TesterService/addTestersToBox.test.ts
+++ b/src/__tests__/box/tester/TesterService/addTestersToBox.test.ts
@@ -1,0 +1,115 @@
+import {TesterService} from "../../../../box/tester/tester.service";
+import BoxModule from "../../modules/box.module";
+import {Box} from "../../../../box/schemas/box.schema";
+import {ObjectId} from "mongodb";
+import BoxBuilderFactory from "../../data/boxBuilderFactory";
+import {getNonExisting_id} from "../../../test_utils/util/getNonExisting_id";
+
+describe('TesterService.addTestersToBox() test suite', () => {
+    let service: TesterService;
+    const testerBuilder = BoxBuilderFactory.getBuilder('Tester');
+    const tester1 = testerBuilder.setProfileId(new ObjectId()).setPlayerId(new ObjectId()).build();
+    const tester2 = testerBuilder.setProfileId(new ObjectId()).setPlayerId(new ObjectId()).build();
+    const testersToAdd = [tester1, tester2];
+
+    const boxModel = BoxModule.getBoxModel();
+    const boxBuilder = BoxBuilderFactory.getBuilder('Box');
+    let existingBox: Box;
+
+    beforeEach(async () => {
+        service = await BoxModule.getTesterService();
+
+        existingBox = boxBuilder
+            .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
+            .setChatId(new ObjectId())
+            .build();
+        const boxResp = await boxModel.create(existingBox);
+        existingBox._id = boxResp._id;
+    });
+
+    it('Should add testers data to the box and return true', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, testersToAdd);
+
+        const boxInDB = await boxModel.findById(existingBox._id);
+
+        expect(errors).toBeNull();
+        expect(areAdded).toBeTruthy();
+        expect(boxInDB.testers).toContain(testersToAdd);
+    });
+
+    it('Should not remove any old testers data from the box', async () => {
+        const anotherTester = testerBuilder.setProfileId(new ObjectId()).setPlayerId(new ObjectId()).build();
+        await boxModel.findByIdAndUpdate(existingBox._id, {$push: {testers: anotherTester}})
+
+        await service.addTestersToBox(existingBox._id, testersToAdd);
+
+        const boxInDB = await boxModel.findById(existingBox._id);
+
+        expect(boxInDB.testers).toHaveLength(1 + testersToAdd.length);
+        expect(boxInDB.testers).toContain(anotherTester);
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is null', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(null, testersToAdd);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is undefined', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(undefined, testersToAdd);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is an empty string', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(undefined, testersToAdd);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe('');
+    });
+
+    it('Should return REQUIRED ServiceError if testersToRegister is null', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, null);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if testersToRegister is undefined', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, undefined);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if testersToRegister is an empty array', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, []);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toEqual([]);
+    });
+
+    it('Should return NOT_FOUND ServiceError if box with provided _id does not exists', async () => {
+        const nonExisting_id = new ObjectId(getNonExisting_id());
+        const [areAdded, errors] = await service.addTestersToBox(nonExisting_id, testersToAdd);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toEqual(nonExisting_id);
+    });
+});

--- a/src/__tests__/box/tester/TesterService/addTestersToClans.test.ts
+++ b/src/__tests__/box/tester/TesterService/addTestersToClans.test.ts
@@ -1,0 +1,191 @@
+import {TesterService} from "../../../../box/tester/tester.service";
+import BoxModule from "../../modules/box.module";
+import {Box} from "../../../../box/schemas/box.schema";
+import ProfileModule from "../../../profile/modules/profile.module";
+import PlayerModule from "../../../player/modules/player.module";
+import ClanModule from "../../../clan/modules/clan.module";
+import {Clan} from "../../../../clan/clan.schema";
+import {ObjectId} from "mongodb";
+import BoxBuilderFactory from "../../data/boxBuilderFactory";
+import ClanBuilderFactory from "../../../clan/data/clanBuilderFactory";
+import {getNonExisting_id} from "../../../test_utils/util/getNonExisting_id";
+import PlayerBuilderFactory from "../../../player/data/playerBuilderFactory";
+import {Tester} from "../../../../box/schemas/tester.schema";
+
+describe('TesterService.addTestersToClans() test suite', () => {
+    let service: TesterService;
+    const testerBuilder = BoxBuilderFactory.getBuilder('Tester');
+    let tester1: Tester;
+    let tester2: Tester;
+    let tester3: Tester;
+    let tester4: Tester;
+    let tester5: Tester;
+
+    const boxModel = BoxModule.getBoxModel();
+    const boxBuilder = BoxBuilderFactory.getBuilder('Box');
+    let existingBox: Box;
+
+    const profileModel = ProfileModule.getProfileModel();
+    const playerModel = PlayerModule.getPlayerModel();
+    const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
+    const clanModel = ClanModule.getClanModel();
+    const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+    let boxClan1: Clan, boxClan2: Clan;
+
+    beforeEach(async () => {
+        service = await BoxModule.getTesterService();
+
+        boxClan1 = clanBuilder.setName('clan1').build();
+        const clan1Resp = await clanModel.create(boxClan1);
+        boxClan1._id = clan1Resp._id;
+        boxClan2 = clanBuilder.setName('clan2').build();
+        const clan2Resp = await clanModel.create(boxClan2);
+        boxClan2._id = clan2Resp._id;
+
+        const testersToCreate: Tester[] = []
+        for (let i = 0; i < 5; i++) {
+            const playerToCreate = playerBuilder
+                .setName(`player${i}`).setUniqueIdentifier(`player${i}`)
+                .setProfileId(new ObjectId())
+                .build();
+            const playerResp = await playerModel.create(playerToCreate);
+
+            testersToCreate.push(testerBuilder.setProfileId(new ObjectId()).setPlayerId(playerResp._id as any).build());
+        }
+        [tester1, tester2, tester3, tester4, tester5] = testersToCreate;
+
+        existingBox = boxBuilder
+            .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
+            .setClanIds([boxClan1._id as any, boxClan2._id as any])
+            .setChatId(new ObjectId())
+            .build();
+        const boxResp = await boxModel.create(existingBox);
+        existingBox._id = boxResp._id;
+    });
+
+    it('Should add specified testers to the box clans and return true', async () => {
+        const testersToAdd = [tester1, tester2];
+        const [areAdded, errors] = await service.addTestersToClans(existingBox._id, testersToAdd);
+
+        const player1InDB = await playerModel.findById(tester1.player_id);
+        const player2InDB = await playerModel.findById(tester2.player_id);
+
+        expect(errors).toBeNull();
+        expect(areAdded).toBeTruthy();
+
+        const player1HasRightClan_id =
+            player1InDB.clan_id?.toString() === boxClan1._id.toString() ||
+            player1InDB.clan_id?.toString() === boxClan2._id.toString();
+        expect(player1HasRightClan_id).toBeTruthy();
+
+        const player2HasRightClan_id =
+            player2InDB.clan_id.toString() === boxClan1._id.toString() ||
+            player2InDB.clan_id.toString() === boxClan2._id.toString();
+        expect(player2HasRightClan_id).toBeTruthy();
+    });
+
+    it('Should add testers evenly to the box clans if the amount of testers is even', async () => {
+        const testersToAdd = [tester1, tester2, tester3, tester4];
+        await service.addTestersToClans(existingBox._id, testersToAdd);
+
+        const testerPlayer_ids = testersToAdd.map((tester) => tester.player_id);
+        const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
+
+        const amountOfPlayersInClan1 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const amountOfPlayersInClan2 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        expect(amountOfPlayersInClan1).toBe(amountOfPlayersInClan2);
+    });
+
+    it('Should add on 1 tester more to one of the box clans if the amount of testers is odd', async () => {
+        const testersToAdd = [tester1, tester2, tester3, tester4, tester5];
+        await service.addTestersToClans(existingBox._id, testersToAdd);
+
+        const testerPlayer_ids = testersToAdd.map((tester) => tester.player_id);
+        const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
+
+        const amountOfPlayersInClan1 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const amountOfPlayersInClan2 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const playerAmountDifference = Math.abs(amountOfPlayersInClan1-amountOfPlayersInClan2);
+        expect(playerAmountDifference).toBe(1);
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is null', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(null, [tester1]);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is undefined', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(undefined, [tester1]);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is an empty string', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(undefined, [tester1]);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe('');
+    });
+
+    it('Should return REQUIRED ServiceError if testers is null', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, null);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if testers is undefined', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, undefined);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if testers is an empty array', async () => {
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, []);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('testers');
+        expect(errors[0].value).toEqual([]);
+    });
+
+    it('Should return NOT_FOUND ServiceError if box with provided _id does not exists', async () => {
+        const nonExisting_id = new ObjectId(getNonExisting_id());
+        const [areAdded, errors] = await service.addTestersToBox(nonExisting_id, [tester1]);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toEqual(nonExisting_id);
+    });
+});

--- a/src/__tests__/box/tester/TesterService/addTestersToClans.test.ts
+++ b/src/__tests__/box/tester/TesterService/addTestersToClans.test.ts
@@ -58,6 +58,7 @@ describe('TesterService.addTestersToClans() test suite', () => {
             .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
             .setClanIds([boxClan1._id as any, boxClan2._id as any])
             .setChatId(new ObjectId())
+            .setTesters([tester1, tester2, tester3, tester4, tester5])
             .build();
         const boxResp = await boxModel.create(existingBox);
         existingBox._id = boxResp._id;
@@ -187,5 +188,15 @@ describe('TesterService.addTestersToClans() test suite', () => {
         expect(errors).toContainSE_NOT_FOUND();
         expect(errors[0].field).toBe('box_id');
         expect(errors[0].value).toEqual(nonExisting_id);
+    });
+
+    it('Should return NOT_FOUND ServiceError if box does not have 2 clans', async () => {
+        await boxModel.findByIdAndUpdate(existingBox._id, { clan_ids: [boxClan1._id] });
+        const [areAdded, errors] = await service.addTestersToBox(existingBox._id, [tester1]);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+        expect(errors[0].field).toBe('clan_ids');
+        expect(errors[0].value).toEqual([]);
     });
 });

--- a/src/__tests__/box/tester/TesterService/createTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/createTesters.test.ts
@@ -1,0 +1,122 @@
+import {TesterService} from "../../../../box/tester/tester.service";
+import BoxModule from "../../modules/box.module";
+import {Box} from "../../../../box/schemas/box.schema";
+import ProfileModule from "../../../profile/modules/profile.module";
+import PlayerModule from "../../../player/modules/player.module";
+import {ObjectId} from "mongodb";
+import BoxBuilderFactory from "../../data/boxBuilderFactory";
+
+describe('TesterService.createTesters() test suite', () => {
+    let service: TesterService;
+
+    const boxModel = BoxModule.getBoxModel();
+    const boxBuilder = BoxBuilderFactory.getBuilder('Box');
+    let existingBox: Box;
+
+    const profileModel = ProfileModule.getProfileModel();
+    const playerModel = PlayerModule.getPlayerModel();
+
+    beforeEach(async () => {
+        service = await BoxModule.getTesterService();
+
+        existingBox = boxBuilder
+            .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
+            .setChatId(new ObjectId())
+            .build();
+        const boxResp = await boxModel.create(existingBox);
+        existingBox._id = boxResp._id;
+    });
+
+    it('Should create specified amount of profiles in DB', async () => {
+        const amount = 5;
+
+        await service.createTesters(amount);
+
+        const profilesInDB = await profileModel.find();
+
+        expect(profilesInDB).toHaveLength(amount + 1);
+    });
+
+    it('Should create specified amount of players in DB', async () => {
+        const amount = 5;
+
+        await service.createTesters(amount);
+
+        const playersInDB = await playerModel.find();
+
+        expect(playersInDB).toHaveLength(amount + 1);
+    });
+
+    it('Should return created testers', async () => {
+        const amount = 5;
+
+        const [createdTesters, errors] = await service.createTesters(amount);
+
+        expect(errors).toBeNull();
+        expect(createdTesters).toHaveLength(amount + 1);
+    });
+
+    it('Should return ServiceError NOT_ALLOWED if amount is a negative number', async () => {
+        const amount = -5;
+
+        const [createdTesters, errors] = await service.createTesters(amount);
+
+        expect(createdTesters).toBeNull();
+        expect(errors).toContainSE_NOT_ALLOWED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(amount);
+    });
+
+    it('Should not created and profiles and players if amount is a negative number', async () => {
+        const amount = -5;
+
+        await service.createTesters(amount);
+
+        const profilesInDB = await profileModel.find();
+        const playersInDB = await playerModel.find();
+
+        expect(profilesInDB).toHaveLength(1);
+        expect(playersInDB).toHaveLength(1);
+    });
+
+    it('Should return ServiceError NOT_ALLOWED if amount is zero', async () => {
+        const amount = 0;
+
+        const [createdTesters, errors] = await service.createTesters(amount);
+
+        expect(createdTesters).toBeNull();
+        expect(errors).toContainSE_NOT_ALLOWED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(amount);
+    });
+
+    it('Should not created and profiles and players if amount is zero', async () => {
+        const amount = 0;
+
+        await service.createTesters(amount);
+
+        const profilesInDB = await profileModel.find();
+        const playersInDB = await playerModel.find();
+
+        expect(profilesInDB).toHaveLength(1);
+        expect(playersInDB).toHaveLength(1);
+    });
+
+    it('Should return ServiceError REQUIRED if amount is null', async () => {
+        const [createdTesters, errors] = await service.createTesters(null);
+
+        expect(createdTesters).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return ServiceError REQUIRED if amount is undefined', async () => {
+        const [createdTesters, errors] = await service.createTesters(undefined);
+
+        expect(createdTesters).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBeNull();
+    });
+});

--- a/src/__tests__/box/tester/TesterService/createTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/createTesters.test.ts
@@ -5,19 +5,26 @@ import ProfileModule from "../../../profile/modules/profile.module";
 import PlayerModule from "../../../player/modules/player.module";
 import {ObjectId} from "mongodb";
 import BoxBuilderFactory from "../../data/boxBuilderFactory";
+import {PasswordGenerator} from "../../../../box/tester/passwordGenerator";
+import ProfileBuilderFactory from "../../../profile/data/profileBuilderFactory";
+import PlayerBuilderFactory from "../../../player/data/playerBuilderFactory";
 
 describe('TesterService.createTesters() test suite', () => {
     let service: TesterService;
+    let passwordGenerator: PasswordGenerator;
 
     const boxModel = BoxModule.getBoxModel();
     const boxBuilder = BoxBuilderFactory.getBuilder('Box');
     let existingBox: Box;
 
     const profileModel = ProfileModule.getProfileModel();
+    const profileBuilder = ProfileBuilderFactory.getBuilder('Profile');
     const playerModel = PlayerModule.getPlayerModel();
+    const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
 
     beforeEach(async () => {
         service = await BoxModule.getTesterService();
+        passwordGenerator = await BoxModule.getPasswordGenerator();
 
         existingBox = boxBuilder
             .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
@@ -47,13 +54,142 @@ describe('TesterService.createTesters() test suite', () => {
         expect(playersInDB).toHaveLength(amount + 1);
     });
 
+    it('Should create profile in DB if there are already profiles with the generated username', async () => {
+        const existingUsername1 = 'existing-username';
+        const existingProfile1 = profileBuilder.setUsername(existingUsername1).build();
+        const existingUsername2 = 'existing-username-1';
+        const existingProfile2 = profileBuilder.setUsername(existingUsername2).build();
+        await profileModel.create(existingProfile1);
+        await profileModel.create(existingProfile2);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingUsername1);
+
+        const amount = 1;
+
+        const profilesInDBBefore = await profileModel.find();
+        await service.createTesters(amount);
+        const profilesInDBAfter = await profileModel.find();
+
+        expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + amount);
+    });
+
+    it('Should create profile in DB if there are already one profile with the generated username', async () => {
+        const existingUsername = 'existing-username';
+        const existingProfile = profileBuilder.setUsername(existingUsername).build();
+        await profileModel.create(existingProfile);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingUsername);
+
+        const amount = 1;
+
+        const profilesInDBBefore = await profileModel.find();
+        await service.createTesters(amount);
+        const profilesInDBAfter = await profileModel.find();
+
+        expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + amount);
+    });
+
+    it('Should create player in DB if there are already players with the generated name', async () => {
+        const existingName1 = 'existing-name';
+        const existingPlayer1 = playerBuilder.setName(existingName1).setUniqueIdentifier(existingName1).build();
+        const existingName2 = 'existing-name-1';
+        const existingPlayer2 = playerBuilder.setName(existingName2).setUniqueIdentifier(existingName2).build();
+        await playerModel.create(existingPlayer1);
+        await playerModel.create(existingPlayer2);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingName1);
+
+        const amount = 1;
+
+        const playersInDBBefore = await playerModel.find();
+        await service.createTesters(amount);
+        const playersInDBAfter = await playerModel.find();
+
+        expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + amount);
+    });
+
+    it('Should create player in DB if there are already one player with the generated name', async () => {
+        const existingName = 'existing-name';
+        const existingPlayer = playerBuilder.setName(existingName).setUniqueIdentifier(existingName).build();
+        await playerModel.create(existingPlayer);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingName);
+
+        const amount = 1;
+
+        const playersInDBBefore = await playerModel.find();
+        await service.createTesters(amount);
+        const playersInDBAfter = await playerModel.find();
+
+        expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + amount);
+    });
+
+    it('Should create player in DB if there are already players with the generated uniqueIdentifier', async () => {
+        const existingId1 = 'existing-name';
+        const existingPlayer1 = playerBuilder.setName('some-name-1').setUniqueIdentifier(existingId1).build();
+        const existingId2 = 'existing-name-1';
+        const existingPlayer2 = playerBuilder.setName('some-name-2').setUniqueIdentifier(existingId2).build();
+        await playerModel.create(existingPlayer1);
+        await playerModel.create(existingPlayer2);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingId1);
+
+        const amount = 1;
+
+        const playersInDBBefore = await playerModel.find();
+        await service.createTesters(amount);
+        const playersInDBAfter = await playerModel.find();
+
+        expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + amount);
+    });
+
+    it('Should create player in DB if there are already one player with the generated uniqueIdentifier', async () => {
+        const existingId = 'existing-name';
+        const existingPlayer = playerBuilder.setName('some-name-1').setUniqueIdentifier(existingId).build();
+        await playerModel.create(existingPlayer);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(existingId);
+
+        const amount = 1;
+
+        const playersInDBBefore = await playerModel.find();
+        await service.createTesters(amount);
+        const playersInDBAfter = await playerModel.find();
+
+        expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + amount);
+    });
+
+    it('Should create profiles in DB if all generated usernames are the same', async () => {
+        const sameUsername = 'same-username';
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameUsername);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameUsername);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameUsername);
+
+        const amount = 3;
+
+        const profilesInDBBefore = await profileModel.find();
+        await service.createTesters(amount);
+        const profilesInDBAfter = await profileModel.find();
+
+        expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + amount);
+    });
+
+    it('Should create players in DB if all generated player names are the same', async () => {
+        const sameName = 'same-name';
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameName);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameName);
+        jest.spyOn(passwordGenerator, 'generatePassword').mockReturnValueOnce(sameName);
+
+        const amount = 3;
+
+        const playersInDBBefore = await playerModel.find();
+        await service.createTesters(amount);
+        const playersInDBAfter = await playerModel.find();
+
+        expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + amount);
+    });
+
     it('Should return created testers', async () => {
         const amount = 5;
 
         const [createdTesters, errors] = await service.createTesters(amount);
 
         expect(errors).toBeNull();
-        expect(createdTesters).toHaveLength(amount + 1);
+        expect(createdTesters).toHaveLength(amount);
     });
 
     it('Should return ServiceError NOT_ALLOWED if amount is a negative number', async () => {
@@ -69,6 +205,29 @@ describe('TesterService.createTesters() test suite', () => {
 
     it('Should not create any profiles and players if amount is a negative number', async () => {
         const amount = -5;
+
+        await service.createTesters(amount);
+
+        const profilesInDB = await profileModel.find();
+        const playersInDB = await playerModel.find();
+
+        expect(profilesInDB).toHaveLength(1);
+        expect(playersInDB).toHaveLength(1);
+    });
+
+    it('Should return ServiceError NOT_ALLOWED if amount is more than 100', async () => {
+        const amount = 100;
+
+        const [createdTesters, errors] = await service.createTesters(amount);
+
+        expect(createdTesters).toBeNull();
+        expect(errors).toContainSE_NOT_ALLOWED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(amount);
+    });
+
+    it('Should not create any profiles and players if amount is more than 100', async () => {
+        const amount = 100;
 
         await service.createTesters(amount);
 

--- a/src/__tests__/box/tester/TesterService/createTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/createTesters.test.ts
@@ -67,7 +67,7 @@ describe('TesterService.createTesters() test suite', () => {
         expect(errors[0].value).toBe(amount);
     });
 
-    it('Should not created and profiles and players if amount is a negative number', async () => {
+    it('Should not create any profiles and players if amount is a negative number', async () => {
         const amount = -5;
 
         await service.createTesters(amount);
@@ -90,7 +90,7 @@ describe('TesterService.createTesters() test suite', () => {
         expect(errors[0].value).toBe(amount);
     });
 
-    it('Should not created and profiles and players if amount is zero', async () => {
+    it('Should not create any profiles and players if amount is zero', async () => {
         const amount = 0;
 
         await service.createTesters(amount);

--- a/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
@@ -8,9 +8,18 @@ import {Clan} from "../../../../clan/clan.schema";
 import {ObjectId} from "mongodb";
 import BoxBuilderFactory from "../../data/boxBuilderFactory";
 import ClanBuilderFactory from "../../../clan/data/clanBuilderFactory";
+import {getNonExisting_id} from "../../../test_utils/util/getNonExisting_id";
+import {Tester} from "../../../../box/schemas/tester.schema";
+import PlayerBuilderFactory from "../../../player/data/playerBuilderFactory";
 
 describe('TesterService.deleteTesters() test suite', () => {
     let service: TesterService;
+    const testerBuilder = BoxBuilderFactory.getBuilder('Tester');
+    let tester1: Tester;
+    let tester2: Tester;
+    let tester3: Tester;
+    let tester4: Tester;
+    let tester5: Tester;
 
     const boxModel = BoxModule.getBoxModel();
     const boxBuilder = BoxBuilderFactory.getBuilder('Box');
@@ -18,6 +27,7 @@ describe('TesterService.deleteTesters() test suite', () => {
 
     const profileModel = ProfileModule.getProfileModel();
     const playerModel = PlayerModule.getPlayerModel();
+    const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
     const clanModel = ClanModule.getClanModel();
     const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
     let boxClan1: Clan, boxClan2: Clan;
@@ -32,19 +42,246 @@ describe('TesterService.deleteTesters() test suite', () => {
         const clan2Resp = await clanModel.create(boxClan2);
         boxClan2._id = clan2Resp._id;
 
+        const testersToCreate: Tester[] = [];
+        for (let i = 0; i < 5; i++) {
+            const playerToCreate = playerBuilder
+                .setName(`player${i}`).setUniqueIdentifier(`player${i}`)
+                .setProfileId(new ObjectId())
+                .build();
+            const playerResp = await playerModel.create(playerToCreate);
+
+            testersToCreate.push(testerBuilder.setProfileId(new ObjectId()).setPlayerId(playerResp._id as any).build());
+        }
+        [tester1, tester2, tester3, tester4, tester5] = testersToCreate;
+
         existingBox = boxBuilder
             .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
             .setClanIds([boxClan1._id as any, boxClan2._id as any])
-            .setSoulHomeIds([new ObjectId(), new ObjectId()]).setRoomIds([new ObjectId(), new ObjectId()])
-            .setStockIds([new ObjectId(), new ObjectId()])
             .setChatId(new ObjectId())
+            .setTesters([tester1, tester2, tester3, tester4, tester5])
             .build();
         const boxResp = await boxModel.create(existingBox);
         existingBox._id = boxResp._id;
     });
 
-    it('Should ', async () => {
+    it('Should remove the specified amount of testers from box and return true', async () => {
+        const amountBefore = existingBox.testers.length;
+        const amount = 2;
 
+        const [wasRemoved, errors] = await service.deleteTesters(existingBox._id, amount);
+
+        expect(errors).toBeNull();
+        expect(wasRemoved).toBeTruthy();
+
+        const boxInDB = await boxModel.findById(existingBox._id);
+        const amountAfter = boxInDB.testers.length;
+
+        expect(amountAfter).toBe(amountBefore-amount);
     });
 
+    it('Should remove the specified amount of testers profiles and players from DB', async () => {
+        const amountBefore = existingBox.testers.length;
+        const amount = 2;
+
+        await service.deleteTesters(existingBox._id, amount);
+
+        const profilesInDB = await profileModel.find();
+        const profilesAfter = profilesInDB.length - 1;
+        expect(profilesAfter).toBe(amountBefore-amount);
+
+        const playersInDB = await playerModel.find();
+        const playersAfter = playersInDB.length - 1;
+        expect(playersAfter).toBe(amountBefore-amount);
+    });
+
+    it('Should remove the same amount of testers from each clan if amount is an even number', async () => {
+        await addTestersToClans([tester1, tester2], [tester3, tester4]);
+        const testersAdded = [tester1, tester2, tester3, tester4];
+        await service.deleteTesters(existingBox._id, 2);
+
+        const testerPlayer_ids = testersAdded.map((tester) => tester.player_id);
+        const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
+
+        const amountOfPlayersInClan1 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const amountOfPlayersInClan2 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        expect(amountOfPlayersInClan1).toBe(amountOfPlayersInClan2);
+    });
+
+    it('Should remove on one tester more in one of the clans if amount is an odd number', async () => {
+        await addTestersToClans([tester1, tester2], [tester3, tester4]);
+        const testersAdded = [tester1, tester2, tester3, tester4];
+        await service.deleteTesters(existingBox._id, 3);
+
+        const testerPlayer_ids = testersAdded.map((tester) => tester.player_id);
+        const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
+
+        const amountOfPlayersInClan1 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const amountOfPlayersInClan2 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const playerAmountDifference = Math.abs(amountOfPlayersInClan1-amountOfPlayersInClan2);
+        expect(playerAmountDifference).toBe(1);
+    });
+
+    it('Should remove on 1 tester more from the clan where the amount of testers is larger and the specified amount is an odd number', async () => {
+        await addTestersToClans([tester1, tester2], [tester3, tester4, tester5]);
+        const testersAdded = [tester1, tester2, tester3, tester4, tester5];
+        await service.deleteTesters(existingBox._id, 3);
+
+        const testerPlayer_ids = testersAdded.map((tester) => tester.player_id);
+        const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
+
+        const amountOfPlayersInClan1 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const amountOfPlayersInClan2 = playersInDB.reduce(
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            0
+        );
+
+        const playerAmountDifference = Math.abs(amountOfPlayersInClan1-amountOfPlayersInClan2);
+        expect(playerAmountDifference).toBe(1);
+    });
+
+    it('Should return ServiceError NOT_ALLOWED if amount is a negative number', async () => {
+        const amount = -5;
+
+        const [wasRemoved, errors] = await service.deleteTesters(existingBox._id, amount);
+
+        expect(wasRemoved).toBeNull();
+        expect(errors).toContainSE_NOT_ALLOWED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(amount);
+    });
+
+    it('Should not remove any profiles and players if amount is a negative number', async () => {
+        const amount = -5;
+
+        const profilesBefore = await profileModel.find();
+        const playersBefore = await playerModel.find();
+        await service.deleteTesters(existingBox._id, amount);
+        const profilesAfter = await profileModel.find();
+        const playersAfter = await playerModel.find();
+
+        expect(profilesBefore).toHaveLength(profilesAfter.length);
+        expect(playersBefore).toHaveLength(playersAfter.length);
+    });
+
+    it('Should return ServiceError NOT_ALLOWED if amount is zero', async () => {
+        const amount = 0;
+
+        const [wasRemoved, errors] = await service.deleteTesters(existingBox._id, amount);
+
+        expect(wasRemoved).toBeNull();
+        expect(errors).toContainSE_NOT_ALLOWED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(amount);
+    });
+
+    it('Should not delete any profiles and players if amount is zero', async () => {
+        const amount = 0;
+
+        const profilesBefore = await profileModel.find();
+        const playersBefore = await playerModel.find();
+        await service.deleteTesters(existingBox._id, amount);
+        const profilesAfter = await profileModel.find();
+        const playersAfter = await playerModel.find();
+
+        expect(profilesBefore).toHaveLength(profilesAfter.length);
+        expect(playersBefore).toHaveLength(playersAfter.length);
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is null', async () => {
+        const [areAdded, errors] = await service.deleteTesters(null, 1);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is undefined', async () => {
+        const [areAdded, errors] = await service.deleteTesters(undefined, 1);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if box_id is an empty string', async () => {
+        const [areAdded, errors] = await service.deleteTesters(undefined, 1);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe('');
+    });
+
+    it('Should return REQUIRED ServiceError if amount is null', async () => {
+        const [areAdded, errors] = await service.deleteTesters(existingBox._id, null);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return REQUIRED ServiceError if amount is undefined', async () => {
+        const [areAdded, errors] = await service.deleteTesters(existingBox._id, undefined);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBeNull();
+    });
+
+    it('Should return NOT_FOUND ServiceError if box with provided _id does not exists', async () => {
+        const nonExisting_id = new ObjectId(getNonExisting_id());
+        const [areAdded, errors] = await service.deleteTesters(nonExisting_id, 1);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toEqual(nonExisting_id);
+    });
+
+    it('Should return NOT_FOUND ServiceError the specified amount is larger than the actual amount of testers', async () => {
+        const largerAmount = existingBox.testers.length + 10;
+        const [areAdded, errors] = await service.deleteTesters(existingBox._id, largerAmount);
+
+        expect(areAdded).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+        expect(errors[0].field).toBe('amount');
+        expect(errors[0].value).toBe(largerAmount);
+    });
+
+    /**
+     * Adds specified testers to the clans
+     * @param toClan1 testers to add to the clan 1
+     * @param toClan2 testers to add to the clan 2
+     */
+    async function addTestersToClans(toClan1: Tester[], toClan2: Tester[]) {
+        for (let i = 0; i < toClan1.length; i++)
+            await playerModel.updateOne({_id: toClan1[i].player_id}, {clan_id: boxClan1._id});
+
+        for (let i = 0; i < toClan2.length; i++)
+            await playerModel.updateOne({_id: toClan2[i].player_id}, {clan_id: boxClan2._id});
+    }
 });

--- a/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
@@ -103,12 +103,12 @@ describe('TesterService.deleteTesters() test suite', () => {
         const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
 
         const amountOfPlayersInClan1 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
         const amountOfPlayersInClan2 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
@@ -124,12 +124,12 @@ describe('TesterService.deleteTesters() test suite', () => {
         const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
 
         const amountOfPlayersInClan1 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
         const amountOfPlayersInClan2 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
@@ -146,16 +146,16 @@ describe('TesterService.deleteTesters() test suite', () => {
         const playersInDB = await playerModel.find({_id: { $in: testerPlayer_ids }}).exec();
 
         const amountOfPlayersInClan1 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan1._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
         const amountOfPlayersInClan2 = playersInDB.reduce(
-            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? prevAmount++ : prevAmount,
+            (prevAmount, player) => player.clan_id?.toString() === boxClan2._id.toString() ? ++prevAmount : prevAmount,
             0
         );
 
-        const playerAmountDifference = Math.abs(amountOfPlayersInClan1-amountOfPlayersInClan2);
+        const playerAmountDifference = amountOfPlayersInClan2-amountOfPlayersInClan1;
         expect(playerAmountDifference).toBe(1);
     });
 
@@ -226,7 +226,7 @@ describe('TesterService.deleteTesters() test suite', () => {
     });
 
     it('Should return REQUIRED ServiceError if box_id is an empty string', async () => {
-        const [areAdded, errors] = await service.deleteTesters(undefined, 1);
+        const [areAdded, errors] = await service.deleteTesters('', 1);
 
         expect(areAdded).toBeNull();
         expect(errors).toContainSE_REQUIRED();

--- a/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
+++ b/src/__tests__/box/tester/TesterService/deleteTesters.test.ts
@@ -1,0 +1,50 @@
+import {TesterService} from "../../../../box/tester/tester.service";
+import BoxModule from "../../modules/box.module";
+import {Box} from "../../../../box/schemas/box.schema";
+import ProfileModule from "../../../profile/modules/profile.module";
+import PlayerModule from "../../../player/modules/player.module";
+import ClanModule from "../../../clan/modules/clan.module";
+import {Clan} from "../../../../clan/clan.schema";
+import {ObjectId} from "mongodb";
+import BoxBuilderFactory from "../../data/boxBuilderFactory";
+import ClanBuilderFactory from "../../../clan/data/clanBuilderFactory";
+
+describe('TesterService.deleteTesters() test suite', () => {
+    let service: TesterService;
+
+    const boxModel = BoxModule.getBoxModel();
+    const boxBuilder = BoxBuilderFactory.getBuilder('Box');
+    let existingBox: Box;
+
+    const profileModel = ProfileModule.getProfileModel();
+    const playerModel = PlayerModule.getPlayerModel();
+    const clanModel = ClanModule.getClanModel();
+    const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+    let boxClan1: Clan, boxClan2: Clan;
+
+    beforeEach(async () => {
+        service = await BoxModule.getTesterService();
+
+        boxClan1 = clanBuilder.setName('clan1').build();
+        const clan1Resp = await clanModel.create(boxClan1);
+        boxClan1._id = clan1Resp._id;
+        boxClan2 = clanBuilder.setName('clan2').build();
+        const clan2Resp = await clanModel.create(boxClan2);
+        boxClan2._id = clan2Resp._id;
+
+        existingBox = boxBuilder
+            .setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
+            .setClanIds([boxClan1._id as any, boxClan2._id as any])
+            .setSoulHomeIds([new ObjectId(), new ObjectId()]).setRoomIds([new ObjectId(), new ObjectId()])
+            .setStockIds([new ObjectId(), new ObjectId()])
+            .setChatId(new ObjectId())
+            .build();
+        const boxResp = await boxModel.create(existingBox);
+        existingBox._id = boxResp._id;
+    });
+
+    it('Should ', async () => {
+
+    });
+
+});

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -1,5 +1,5 @@
 import {Module} from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
+import {MongooseModule} from '@nestjs/mongoose';
 import {ModelName} from "../common/enum/modelName.enum";
 import {BoxSchema} from "./schemas/box.schema";
 import {GroupAdminSchema} from "./groupAdmin/groupAdmin.schema";
@@ -24,19 +24,20 @@ import {DailyTaskController} from "./dailyTask/dailyTask.controller";
 import {DailyTaskService} from "./dailyTask/dailyTask.service";
 import {GroupAdminGuard} from "./auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "./tester/passwordGenerator";
+import {TesterService} from "./tester/tester.service";
 
 @Module({
     imports: [
         MongooseModule.forFeature([
-            { name: ModelName.BOX, schema: BoxSchema },
-            { name: ModelName.GROUP_ADMIN, schema: GroupAdminSchema },
-            { name: ModelName.PROFILE, schema: ProfileSchema },
-            { name: ModelName.PLAYER, schema: PlayerSchema },
-            { name: ModelName.CLAN, schema: ClanSchema },
-            { name: ModelName.SOULHOME, schema: SoulhomeSchema },
-            { name: ModelName.ROOM, schema: RoomSchema },
-            { name: ModelName.STOCK, schema: StockSchema },
-            { name: ModelName.CHAT, schema: ChatSchema }
+            {name: ModelName.BOX, schema: BoxSchema},
+            {name: ModelName.GROUP_ADMIN, schema: GroupAdminSchema},
+            {name: ModelName.PROFILE, schema: ProfileSchema},
+            {name: ModelName.PLAYER, schema: PlayerSchema},
+            {name: ModelName.CLAN, schema: ClanSchema},
+            {name: ModelName.SOULHOME, schema: SoulhomeSchema},
+            {name: ModelName.ROOM, schema: RoomSchema},
+            {name: ModelName.STOCK, schema: StockSchema},
+            {name: ModelName.CHAT, schema: ChatSchema}
         ]),
         ClanModule,
         ChatModule,
@@ -50,10 +51,11 @@ import {PasswordGenerator} from "./tester/passwordGenerator";
         BoxService, GroupAdminService, BoxHelper, BoxCreator,
         DailyTaskService,
         BoxAuthHandler, GroupAdminGuard,
-        PasswordGenerator
+        PasswordGenerator, TesterService
     ],
     exports: [
         BoxService, GroupAdminGuard
     ]
 })
-export class BoxModule {}
+export class BoxModule {
+}

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -25,6 +25,7 @@ import {DailyTaskService} from "./dailyTask/dailyTask.service";
 import {GroupAdminGuard} from "./auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "./tester/passwordGenerator";
 import {TesterService} from "./tester/tester.service";
+import {TesterController} from "./tester/tester.controller";
 
 @Module({
     imports: [
@@ -45,7 +46,7 @@ import {TesterService} from "./tester/tester.service";
         PlayerModule
     ],
     controllers: [
-        BoxController, DailyTaskController
+        BoxController, DailyTaskController, TesterController
     ],
     providers: [
         BoxService, GroupAdminService, BoxHelper, BoxCreator,

--- a/src/box/tester/dto/define.testers.dto.ts
+++ b/src/box/tester/dto/define.testers.dto.ts
@@ -1,0 +1,14 @@
+import {IsNumber, IsOptional, Max, Min} from "class-validator";
+
+export default class DefineTestersDto {
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    @Max(99)
+    amountToAdd: number;
+
+    @IsOptional()
+    @IsNumber()
+    @Min(1)
+    amountToRemove: number;
+}

--- a/src/box/tester/tester.controller.ts
+++ b/src/box/tester/tester.controller.ts
@@ -1,0 +1,47 @@
+import {Body, Controller, Post} from "@nestjs/common";
+import {TesterService} from "./tester.service";
+import DefineTestersDto from "./dto/define.testers.dto";
+import {IsGroupAdmin} from "../auth/decorator/IsGroupAdmin";
+import {UniformResponse} from "../../common/decorator/response/UniformResponse";
+import {ModelName} from "../../common/enum/modelName.enum";
+import {APIError} from "../../common/controller/APIError";
+import {APIErrorReason} from "../../common/controller/APIErrorReason";
+import {LoggedUser} from "../../common/decorator/param/LoggedUser.decorator";
+import {BoxUser} from "../auth/BoxUser";
+
+@Controller('/box/testers')
+export class TesterController {
+    constructor(private testerService: TesterService) {
+    }
+
+    @Post()
+    @IsGroupAdmin()
+    @UniformResponse(ModelName.BOX)
+    async defineTestersAmount(@Body() body: DefineTestersDto, @LoggedUser() user: BoxUser) {
+        if (!body.amountToAdd && !body.amountToRemove)
+            return [null, [
+                new APIError({
+                    reason: APIErrorReason.REQUIRED, message: 'One of the amount is required to be set'
+                })]];
+
+        if (body.amountToAdd) {
+            const [createdTesters, creationErrors] = await this.testerService.createTesters(body.amountToAdd);
+            if (creationErrors)
+                return [null, creationErrors];
+
+            const [wereAddedToBox, boxAdditionErrors] = await this.testerService.addTestersToBox(user.box_id, createdTesters);
+            if (boxAdditionErrors)
+                return [null, boxAdditionErrors];
+
+            const [wereAddedToClans, clanAdditionErrors] = await this.testerService.addTestersToClans(user.box_id, createdTesters);
+            if (clanAdditionErrors)
+                return [null, boxAdditionErrors];
+        }
+
+        if (body.amountToRemove) {
+            const [wereRemoved, removalErrors] = await this.testerService.deleteTesters(user.box_id, body.amountToRemove);
+            if (removalErrors)
+                return [null, removalErrors];
+        }
+    }
+}

--- a/src/box/tester/tester.service.ts
+++ b/src/box/tester/tester.service.ts
@@ -2,9 +2,28 @@ import {Injectable} from "@nestjs/common";
 import {IServiceReturn} from "../../common/service/basicService/IService";
 import {ObjectId} from "mongodb";
 import {Tester} from "../schemas/tester.schema";
+import ServiceError from "../../common/service/basicService/ServiceError";
+import {SEReason} from "../../common/service/basicService/SEReason";
+import {PasswordGenerator} from "./passwordGenerator";
+import {Profile, ProfileDocument} from "../../profile/profile.schema";
+import {InjectModel} from "@nestjs/mongoose";
+import {Model} from "mongoose";
+import {Player, PlayerDocument} from "../../player/player.schema";
+import {ProfileService} from "../../profile/profile.service";
+import {ProfileDto} from "../../profile/dto/profile.dto";
+import {Box, BoxDocument} from "../schemas/box.schema";
 
 @Injectable()
 export class TesterService {
+
+    constructor(
+        private readonly passwordGenerator: PasswordGenerator,
+        private readonly profileService: ProfileService,
+        @InjectModel(Profile.name) private readonly profileModel: Model<ProfileDocument>,
+        @InjectModel(Player.name) private readonly playerModel: Model<PlayerDocument>,
+        @InjectModel(Box.name) private readonly boxModel: Model<BoxDocument>
+    ) {
+    }
 
     /**
      * Creates new tester profiles and players.
@@ -12,11 +31,43 @@ export class TesterService {
      * @param amount amount of testers to create.
      *
      * @returns created testers or ServiceError:
-     *  - NOT_ALLOWED if the amount is negative number or equals zero
+     *  - NOT_ALLOWED if the amount is negative number, more than 100 or equals zero
      *  - REQUIRED if the amount is null or undefined
      */
     async createTesters(amount: number): Promise<IServiceReturn<Tester[]>> {
-        return null;
+        if (amount === undefined || amount === null)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'amount', value: amount,
+                message: 'Amount of testers is required'
+            })]];
+
+        if (amount <= 0)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_ALLOWED, field: 'amount', value: amount,
+                message: 'Amount of testers must be greater than 0'
+            })]];
+
+        if (amount >= 100)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_ALLOWED, field: 'amount', value: amount,
+                message: 'Amount of testers must be less than 100'
+            })]];
+
+        const passwords = this.generateUniquePasswords(amount);
+        const [createdProfiles, profilesCreationErrors] = await this.createProfiles(passwords);
+        const [createdPlayers, playerCreationErrors] = await this.createPlayers(passwords, createdProfiles);
+
+        const testers: Tester[] = [];
+        for (let i = 0; i < createdProfiles.length; i++) {
+            const tester = {
+                profile_id: createdProfiles[i]._id as any,
+                player_id: createdPlayers[i]._id as any,
+                isClaimed: false
+            };
+            testers.push(tester);
+        }
+
+        return [testers, null];
     }
 
     /**
@@ -32,12 +83,33 @@ export class TesterService {
      *  - NOT_FOUND if the box with provided _id is not found
      */
     async addTestersToBox(box_id: ObjectId | string, testers: Tester[]): Promise<IServiceReturn<true>> {
-        return null;
+        if (!box_id)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'box_id', value: box_id,
+                message: 'Box _id is required'
+            })]];
+
+        if (!testers || testers.length === 0)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'testers', value: testers,
+                message: 'testers array is required'
+            })]];
+
+        const box = await this.boxModel.findById(box_id);
+        if (!box)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND, field: 'box_id', value: box_id,
+                message: 'Box with provided _id is not found'
+            })]];
+
+        await this.boxModel.findByIdAndUpdate(box_id, {$push: {testers}});
+
+        return [true, null];
     }
 
     /**
      * Adds testers to clans of the specified box.
-     * The testers will be added evenly to clans, so that in the end there will be only the same amount of testers in each clan.
+     * The testers will be added evenly to clans, so that in the end there will be the same amount of testers in each clan.
      *
      * Notice that the method does not check the existence of the testers' profiles and players
      *
@@ -49,7 +121,41 @@ export class TesterService {
      *  - NOT_FOUND if the box with provided _id is not found, or if the box does not have 2 clans
      */
     async addTestersToClans(box_id: ObjectId | string, testers: Tester[]): Promise<IServiceReturn<true>> {
-        return null;
+        if (!box_id)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'box_id', value: box_id,
+                message: 'Box _id is required'
+            })]];
+
+        if (!testers || testers.length === 0)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'testers', value: testers,
+                message: 'testers array is required'
+            })]];
+
+        const box = await this.boxModel.findById(box_id);
+        if (!box)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND, field: 'box_id', value: box_id,
+                message: 'Box with provided _id is not found'
+            })]];
+
+        if (box.clan_ids.length < 2)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND, field: 'clan_ids', value: box.clan_ids,
+                message: 'Box does not have 2 clans'
+            })]];
+
+        const clan1TesterLastIndex = Math.ceil(testers.length / 2);
+        const clan1Testers = testers.slice(0, clan1TesterLastIndex);
+        const clan1Tester_ids = clan1Testers.map(tester => tester.player_id);
+        const clan2Testers = testers.slice(clan1TesterLastIndex);
+        const clan2Tester_ids = clan2Testers.map(tester => tester.player_id);
+
+        await this.playerModel.updateMany({_id: {$in: clan1Tester_ids}}, {clan_id: box.clan_ids[0]});
+        await this.playerModel.updateMany({_id: {$in: clan2Tester_ids}}, {clan_id: box.clan_ids[1]});
+
+        return [true, null];
     }
 
     /**
@@ -68,5 +174,150 @@ export class TesterService {
      */
     async deleteTesters(box_id: ObjectId | string, amount: number): Promise<IServiceReturn<true>> {
         return null;
+    }
+
+    /**
+     * Checks that each element in the provided array has a unique value in the DB.
+     * If the value for provided field already exists an amount number will be added to the end of the value in order to make it unique.
+     *
+     * @param model model where the values should be unique
+     * @param field unique field name
+     * @param values of the unique fields
+     * @private
+     *
+     * @returns an array, where each value is a unique in DB.
+     */
+    private async generateUniqueFieldValues(model: Model<any>, field: string, values: string[]): Promise<string[]> {
+        const uniqueValues: string[] = [];
+
+        const existingValues = await this.getExistingUniqueValues(model, field, values);
+
+        for (const value of values) {
+            let uniqueValue = value;
+
+            if (existingValues[value] !== undefined) {
+                let highestNumber = existingValues[value];
+                highestNumber++;
+                uniqueValue = `${value}-${highestNumber}`;
+            }
+
+            while (uniqueValues.includes(uniqueValue) || await model.exists({[field]: uniqueValue})) {
+                existingValues[value]++;
+                uniqueValue = `${value}-${existingValues[value]}`;
+            }
+
+            uniqueValues.push(uniqueValue);
+        }
+
+        return uniqueValues;
+    }
+
+    /**
+     * Searches for the amount of items in the DB, which field starts with the values.
+     * If the value for provided field exists it will be added to the returned record.
+     * For example if there are an items which start with "john" and "john-1", it will return that there are 2 values like this.
+     *
+     * @param model model where search for the values
+     * @param field field name
+     * @param values values to search
+     * @private
+     *
+     * @returns an array containing values which were found in DB.
+     */
+    private async getExistingUniqueValues(model: Model<any>, field: string, values: string[]): Promise<Record<string, number>> {
+        const existingItems = await model.find({
+            [field]: {$regex: new RegExp(`^(${values.join("|")})(-\\d+)?$`, "i")}
+        }).select(field).lean();
+
+        const valuesCounts: Record<string, number> = {};
+
+        existingItems.forEach(item => {
+            const match = item[field].match(/^(.*?)(-(\d+))?$/);
+            if (match) {
+                const base = match[1];
+                const number = match[3] ? parseInt(match[3], 10) : 0;
+
+                if (!valuesCounts[base] || number > valuesCounts[base]) {
+                    valuesCounts[base] = number;
+                }
+            }
+        });
+
+        return valuesCounts;
+    }
+
+    /**
+     * Generates a set of unique passwords
+     * @param amount how mach passwords to generate
+     * @private
+     *
+     * @returns an array of unique passwords
+     */
+    private generateUniquePasswords(amount: number) {
+        const passwords: string[] = [];
+        for (let i = 0; i < amount; i++) {
+            let password = this.passwordGenerator.generatePassword('fi');
+
+            if (passwords.includes(password)) {
+                while (true) {
+                    password = this.passwordGenerator.generatePassword('fi');
+                    if (!passwords.includes(password))
+                        break;
+                }
+            }
+
+            passwords.push(password);
+        }
+
+        return passwords;
+    }
+
+    /**
+     * Create profiles with provided usernames.
+     * Notice that if a profile with the username already exists its value will be changed to be unique
+     *
+     * @param usernames to be used for the profiles
+     * @private
+     *
+     * @return created profiles
+     */
+    private async createProfiles(usernames: string[]): Promise<IServiceReturn<ProfileDto[]>> {
+        const uniqueUsernames = await this.generateUniqueFieldValues(this.profileModel, 'username', usernames);
+        const createdProfiles: ProfileDto[] = [];
+        for (let i = 0; i < uniqueUsernames.length; i++) {
+            const profile = {username: uniqueUsernames[i], password: uniqueUsernames[i]};
+            const [createdProfile, errors] = await this.profileService.createWithHashedPassword(profile);
+
+            if (!errors)
+                createdProfiles.push(createdProfile);
+        }
+
+        return [createdProfiles, null];
+    }
+
+    /**
+     * Create players with provided names.
+     * Notice that if a player with the name or uniqueIdentifier already exists its value will be changed to be unique
+     *
+     * @param names to be used for player names and unique identifiers
+     * @param profiles with which players should be associated
+     * @private
+     *
+     * @return created players
+     */
+    private async createPlayers(names: string[], profiles: ProfileDto[]): Promise<IServiceReturn<Player[]>> {
+        const uniqueNames = await this.generateUniqueFieldValues(this.playerModel, 'name', names);
+        const uniqueIds = await this.generateUniqueFieldValues(this.playerModel, 'uniqueIdentifier', names);
+        const playersToCreate: Partial<Player>[] = [];
+        for (let i = 0; i < uniqueNames.length; i++) {
+            const player: Partial<Player> = {
+                above13: true, backpackCapacity: 10, parentalAuth: true, points: 0,
+                name: uniqueNames[i], uniqueIdentifier: uniqueIds[i], profile_id: profiles[i]._id
+            };
+            playersToCreate.push(player);
+        }
+        const createdPlayers = await this.playerModel.insertMany(playersToCreate);
+
+        return [createdPlayers, null];
     }
 }

--- a/src/box/tester/tester.service.ts
+++ b/src/box/tester/tester.service.ts
@@ -173,6 +173,37 @@ export class TesterService {
      *  - NOT_FOUND if the box with provided _id is not found, or if the specified amount is larger than the actual amount of testers
      */
     async deleteTesters(box_id: ObjectId | string, amount: number): Promise<IServiceReturn<true>> {
+        if (!box_id)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'box_id', value: box_id,
+                message: 'Box _id is required'
+            })]];
+
+        if (amount === undefined || amount === null)
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED, field: 'amount', value: amount,
+                message: 'Amount of testers is required'
+            })]];
+
+        if (amount <= 0)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_ALLOWED, field: 'amount', value: amount,
+                message: 'Amount of testers must be greater than 0'
+            })]];
+
+        const box = await this.boxModel.findById(box_id);
+        if (!box)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND, field: 'box_id', value: box_id,
+                message: 'Box with provided _id is not found'
+            })]];
+
+        if (box.testers.length < amount)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND, field: 'amount', value: amount,
+                message: 'The amount of testers to remove could not be more than the amount of existing testers in the box'
+            })]];
+
         return null;
     }
 

--- a/src/box/tester/tester.service.ts
+++ b/src/box/tester/tester.service.ts
@@ -1,0 +1,72 @@
+import {Injectable} from "@nestjs/common";
+import {IServiceReturn} from "../../common/service/basicService/IService";
+import {ObjectId} from "mongodb";
+import {Tester} from "../schemas/tester.schema";
+
+@Injectable()
+export class TesterService {
+
+    /**
+     * Creates new tester profiles and players.
+     *
+     * @param amount amount of testers to create.
+     *
+     * @returns created testers or ServiceError:
+     *  - NOT_ALLOWED if the amount is negative number or equals zero
+     *  - REQUIRED if the amount is null or undefined
+     */
+    async createTesters(amount: number): Promise<IServiceReturn<Tester[]>> {
+        return null;
+    }
+
+    /**
+     * Adds testers data to the specified box.
+     *
+     * Notice that the method will not check the existence of the testers' profiles and players
+     *
+     * @param box_id _id of the box where the testers data should be registered
+     * @param testers testers to register
+     *
+     * @returns true if the testers were registered or ServiceError:
+     *  - REQUIRED if box_id is null, undefined or an empty string, or testers is null, undefined or an empty array
+     *  - NOT_FOUND if the box with provided _id is not found
+     */
+    async addTestersToBox(box_id: ObjectId | string, testers: Tester[]): Promise<IServiceReturn<true>> {
+        return null;
+    }
+
+    /**
+     * Adds testers to clans of the specified box.
+     * The testers will be added evenly to clans, so that in the end there will be only the same amount of testers in each clan.
+     *
+     * Notice that the method does not check the existence of the testers' profiles and players
+     *
+     * @param box_id box _id where the testers should be added
+     * @param testers testers to be added
+     *
+     * @returns true if the testers were added or ServiceError:
+     *  - REQUIRED if box_id is null, undefined or an empty string, or testers is null, undefined or an empty array
+     *  - NOT_FOUND if the box with provided _id is not found, or if the box does not have 2 clans
+     */
+    async addTestersToClans(box_id: ObjectId | string, testers: Tester[]): Promise<IServiceReturn<true>> {
+        return null;
+    }
+
+    /**
+     * Removes the specified amount of tester profiles and players from DB. As well as removes their data from box and clans.
+     * The testers will be removed evenly from clans, so that in the end there will be the same amount of testers in each clan.
+     *
+     * Notice that the method will not remove any other data associated with the testers.
+     *
+     * @param box_id box _id where the testers should be added
+     * @param amount amount of testers to be removed
+     *
+     * @returns created testers or ServiceError:
+     *  - NOT_ALLOWED if the amount is negative number or equals zero
+     *  - REQUIRED if the box_id is null, undefined or an empty string or if amount is null or undefined
+     *  - NOT_FOUND if the box with provided _id is not found
+     */
+    async deleteTesters(box_id: ObjectId | string, amount: number): Promise<IServiceReturn<true>> {
+        return null;
+    }
+}

--- a/src/box/tester/tester.service.ts
+++ b/src/box/tester/tester.service.ts
@@ -56,7 +56,7 @@ export class TesterService {
      * Removes the specified amount of tester profiles and players from DB. As well as removes their data from box and clans.
      * The testers will be removed evenly from clans, so that in the end there will be the same amount of testers in each clan.
      *
-     * Notice that the method will not remove any other data associated with the testers.
+     * Notice that the method will not remove any other data associated with the testers
      *
      * @param box_id box _id where the testers should be added
      * @param amount amount of testers to be removed
@@ -64,7 +64,7 @@ export class TesterService {
      * @returns created testers or ServiceError:
      *  - NOT_ALLOWED if the amount is negative number or equals zero
      *  - REQUIRED if the box_id is null, undefined or an empty string or if amount is null or undefined
-     *  - NOT_FOUND if the box with provided _id is not found
+     *  - NOT_FOUND if the box with provided _id is not found, or if the specified amount is larger than the actual amount of testers
      */
     async deleteTesters(box_id: ObjectId | string, amount: number): Promise<IServiceReturn<true>> {
         return null;


### PR DESCRIPTION
### Brief description

The endpoint _/box/testers_ POST was added, where the amount of testers can be defined. The amount of testers can be increased or decreased. Additionally for each tester in the box a profile and player objects are created / removed, and the player objects are automatically and evenly assigned / removed  in one of box clans.

Notice that in order to be able to use this endpoint the user should be an admin of this box and the box should be already initialized.

### Change list

- Added _/box/testers_ POST endpoint
- Added tests for the `TesterService` class

Closes #417 
