### PR TITLE
Added /box/start POST endpoint to start testing session

### DIFF
--- a/src/__tests__/box/SessionStarterService/start.test.ts
+++ b/src/__tests__/box/SessionStarterService/start.test.ts
@@ -1,0 +1,197 @@
+import BoxBuilderFactory from "../data/boxBuilderFactory";
+import BoxModule from "../modules/box.module";
+import {ObjectId} from "mongodb";
+import SessionStarterService from "../../../box/sessionStarter/sessionStarter.service";
+import ProfileModule from "../../profile/modules/profile.module";
+import PlayerModule from "../../player/modules/player.module";
+import ClanModule from "../../clan/modules/clan.module";
+import ProfileBuilderFactory from "../../profile/data/profileBuilderFactory";
+import PlayerBuilderFactory from "../../player/data/playerBuilderFactory";
+import ClanBuilderFactory from "../../clan/data/clanBuilderFactory";
+import {Box} from "../../../box/schemas/box.schema";
+import {Tester} from "../../../box/schemas/tester.schema";
+import DailyTasksModule from "../../dailyTasks/modules/dailyTasks.module";
+import {SessionStage} from "../../../box/enum/SessionStage.enum";
+
+describe('SessionStarterService.start() test suite', () => {
+    let starter: SessionStarterService;
+
+    const boxBuilder = BoxBuilderFactory.getBuilder('Box');
+    const boxModel = BoxModule.getBoxModel();
+    let existingBox: Box;
+    const profileModel = ProfileModule.getProfileModel();
+    const playerModel = PlayerModule.getPlayerModel();
+    const clanModel = ClanModule.getClanModel();
+    const dailyTaskModel = DailyTasksModule.getDailyTaskModel();
+
+    const testerBuilder = BoxBuilderFactory.getBuilder("Tester");
+    const profileBuilder = ProfileBuilderFactory.getBuilder("Profile");
+    const playerBuilder = PlayerBuilderFactory.getBuilder("Player");
+    const clanBuilder = ClanBuilderFactory.getBuilder("Clan");
+    const dailyTaskBuilder = BoxBuilderFactory.getBuilder("PredefinedDailyTask");
+
+    beforeEach(async () => {
+        starter = await BoxModule.getSessionStarterService();
+
+        const existingClan1 = clanBuilder.setName("clan1").build();
+        const existingClanResp1 = await clanModel.create(existingClan1);
+        existingClan1._id = existingClanResp1._id;
+        const existingClan2 = clanBuilder.setName("clan2").build();
+        const existingClanResp2 = await clanModel.create(existingClan2);
+        existingClan2._id = existingClanResp2._id;
+
+        const clan1Testers = await createTesters(3, existingClan1._id);
+        const clan2Testers = await createTesters(3, existingClan2._id);
+
+        const task1 = dailyTaskBuilder.setCoins(10).build();
+        const task2 = dailyTaskBuilder.setCoins(20).build();
+
+        existingBox = boxBuilder
+            .setAdminPassword('password').setAdminPlayerId(new ObjectId()).setAdminProfileId(new ObjectId())
+            .setClanIds([new ObjectId(existingClan1._id), new ObjectId(existingClan2._id)])
+            .setChatId(new ObjectId()).setTesters([...clan1Testers, ...clan2Testers])
+            .setDailyTasks([task1, task2])
+            .build();
+
+        const boxResp = await boxModel.create(existingBox);
+        existingBox._id = boxResp._id;
+    });
+
+    it('Should return true if input is valid', async () => {
+        const [isStarted, errors] = await starter.start(existingBox._id);
+
+        expect(errors).toBeNull();
+        expect(isStarted).toBeTruthy();
+    });
+
+    it('Should create predefined daily tasks for each clan', async () => {
+        await starter.start(existingBox._id);
+
+        const clanDailyTask = existingBox.dailyTasks;
+        const boxDailyTasksInDB = await dailyTaskModel.find({clan_id: { $in: existingBox.clan_ids }});
+
+        expect(boxDailyTasksInDB).toHaveLength(clanDailyTask.length*2);
+    });
+
+    it('Should set admins for box clans', async () => {
+        await starter.start(existingBox._id);
+
+        const clansInDB = await clanModel.find({_id: { $in: existingBox.clan_ids }});
+
+        expect(clansInDB[0].admin_ids).not.toBeNull();
+        expect(clansInDB[0].admin_ids).toHaveLength(1);
+        expect(clansInDB[1].admin_ids).not.toBeNull();
+        expect(clansInDB[1].admin_ids).toHaveLength(1);
+
+        const clan1Admin_id = clansInDB[0].admin_ids[0];
+        const clan2Admin_id = clansInDB[0].admin_ids[1];
+
+        const boxPlayer_ids = existingBox.testers.map(tester => tester.player_id);
+
+        expect(boxPlayer_ids).toContain(clan1Admin_id);
+        expect(boxPlayer_ids).toContain(clan2Admin_id);
+
+        const clan1Admin = await playerModel.findById(clan1Admin_id);
+        const clan1 = await clanModel.findById(existingBox.clan_ids[0]);
+        expect(clan1Admin.clan_id).toBe(clan1._id);
+        const clan2Admin = await playerModel.findById(clan2Admin_id);
+        const clan2 = await clanModel.findById(existingBox.clan_ids[1]);
+        expect(clan2Admin.clan_id).toBe(clan2._id);
+    });
+
+    it('Should set testers shared password for a box', async () => {
+        await starter.start(existingBox._id);
+
+        const boxInDB = await boxModel.findById(existingBox._id);
+
+        expect(boxInDB.testersSharedPassword).not.toBeNull();
+    });
+
+    it('Should set sessionStage of the box to TESTING', async () => {
+        await starter.start(existingBox._id);
+
+        const boxInDB = await boxModel.findById(existingBox._id);
+
+        expect(boxInDB.sessionStage).toBe(SessionStage.TESTING);
+    });
+
+    it('Should set reset time for the box to 7d from now', async () => {
+        await starter.start(existingBox._id);
+
+        const now = new Date().getTime();
+        const boxInDB = await boxModel.findById(existingBox._id);
+        const timeAfterWeek = now + 60 * 60 * 24 * 7;
+
+        expect(boxInDB.sessionResetTime).toBeLessThanOrEqual(timeAfterWeek);
+    });
+
+    it('Should set removal time for the box to 30d from now', async () => {
+        await starter.start(existingBox._id);
+
+        const now = new Date().getTime();
+        const boxInDB = await boxModel.findById(existingBox._id);
+        const timeAfterMonth = now + 60 * 60 * 24 * 30;
+
+        expect(boxInDB.boxRemovalTime).toBeLessThanOrEqual(timeAfterMonth);
+    });
+
+    it('Should return ServiceError with reason REQUIRED, if the provided box _id is undefined', async () => {
+        const [result, errors] = await starter.start(undefined);
+
+        expect(result).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe(null);
+    });
+
+    it('Should return ServiceError with reason REQUIRED, if the provided box _id is null', async () => {
+        const [result, errors] = await starter.start(undefined);
+
+        expect(result).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe(null);
+    });
+
+    it('Should return ServiceError with reason REQUIRED, if the provided box _id is empty string', async () => {
+        const [result, errors] = await starter.start('');
+
+        expect(result).toBeNull();
+        expect(errors).toContainSE_REQUIRED();
+        expect(errors[0].field).toBe('box_id');
+        expect(errors[0].value).toBe('');
+    });
+
+    it('Should return ServiceError with reason NOT_FOUND, if the provided box _id does not exists', async () => {
+        const [result, errors] = await starter.start(new ObjectId());
+
+        expect(result).toBeNull();
+        expect(errors).toContainSE_NOT_FOUND();
+    });
+
+    /**
+     * Creates specified amount of testers in DB
+     * @param amount amount to create
+     * @param clan_id testers clan
+     * @returns created testers
+     */
+    async function createTesters(amount: number, clan_id: string): Promise<Tester[]> {
+        const createdTesters: Tester[] = [];
+
+        for (let i = 0; i < amount; i++) {
+            const testerName = `tester${i}-${clan_id}`;
+            const testerProfile = profileBuilder.setUsername(testerName).build();
+            const testerProfileResp = await profileModel.create(testerProfile);
+
+            const testerPlayer = playerBuilder
+                .setName(testerName).setUniqueIdentifier(testerName)
+                .setClanId(clan_id).setProfileId(testerProfile._id).build();
+            const testerPlayerResp = await playerModel.create(testerPlayer);
+
+            const tester = testerBuilder.setProfileId(testerProfileResp._id as any).setPlayerId(testerPlayerResp._id as any).build();
+            createdTesters.push(tester);
+        }
+
+        return createdTesters;
+    }
+});

--- a/src/__tests__/box/SessionStarterService/start.test.ts
+++ b/src/__tests__/box/SessionStarterService/start.test.ts
@@ -84,19 +84,19 @@ describe('SessionStarterService.start() test suite', () => {
         expect(clansInDB[1].admin_ids).toHaveLength(1);
 
         const clan1Admin_id = clansInDB[0].admin_ids[0];
-        const clan2Admin_id = clansInDB[0].admin_ids[1];
+        const clan2Admin_id = clansInDB[1].admin_ids[0];
 
-        const boxPlayer_ids = existingBox.testers.map(tester => tester.player_id);
+        const boxPlayer_ids = existingBox.testers.map(tester => tester.player_id.toString());
 
         expect(boxPlayer_ids).toContain(clan1Admin_id);
         expect(boxPlayer_ids).toContain(clan2Admin_id);
 
         const clan1Admin = await playerModel.findById(clan1Admin_id);
         const clan1 = await clanModel.findById(existingBox.clan_ids[0]);
-        expect(clan1Admin.clan_id).toBe(clan1._id);
+        expect(clan1Admin.clan_id.toString()).toBe(clan1._id.toString());
         const clan2Admin = await playerModel.findById(clan2Admin_id);
         const clan2 = await clanModel.findById(existingBox.clan_ids[1]);
-        expect(clan2Admin.clan_id).toBe(clan2._id);
+        expect(clan2Admin.clan_id.toString()).toBe(clan2._id.toString());
     });
 
     it('Should set testers shared password for a box', async () => {

--- a/src/__tests__/box/modules/box.module.ts
+++ b/src/__tests__/box/modules/box.module.ts
@@ -11,6 +11,7 @@ import BoxAuthHandler from "../../../box/auth/BoxAuthHandler";
 import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
 import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
 import {TesterService} from "../../../box/tester/tester.service";
+import SessionStarterService from "../../../box/sessionStarter/sessionStarter.service";
 
 export default class BoxModule {
     private constructor() {
@@ -62,5 +63,10 @@ export default class BoxModule {
     static async getTesterService() {
         const module = await BoxCommonModule.getModule();
         return module.resolve(TesterService);
+    }
+
+    static async getSessionStarterService() {
+        const module = await BoxCommonModule.getModule();
+        return module.resolve(SessionStarterService);
     }
 }

--- a/src/__tests__/box/modules/boxCommon.ts
+++ b/src/__tests__/box/modules/boxCommon.ts
@@ -25,6 +25,7 @@ import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
 import {GroupAdminGuard} from "../../../box/auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
 import {TesterService} from "../../../box/tester/tester.service";
+import SessionStarterService from "../../../box/sessionStarter/sessionStarter.service";
 
 
 export default class BoxCommonModule {
@@ -59,7 +60,7 @@ export default class BoxCommonModule {
                     BoxService, GroupAdminService, BoxHelper, BoxCreator,
                     DailyTaskService,
                     BoxAuthHandler, GroupAdminGuard,
-                    PasswordGenerator, TesterService
+                    PasswordGenerator, TesterService, SessionStarterService
                 ]
             }).compile();
 

--- a/src/__tests__/box/modules/boxCommon.ts
+++ b/src/__tests__/box/modules/boxCommon.ts
@@ -26,6 +26,7 @@ import {GroupAdminGuard} from "../../../box/auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "../../../box/tester/passwordGenerator";
 import {TesterService} from "../../../box/tester/tester.service";
 import SessionStarterService from "../../../box/sessionStarter/sessionStarter.service";
+import {DailyTasksModule} from "../../../dailyTasks/dailyTasks.module";
 
 
 export default class BoxCommonModule {
@@ -54,7 +55,8 @@ export default class BoxCommonModule {
                     ChatModule,
                     ProfileModule,
                     PlayerModule,
-                    JwtModule
+                    JwtModule,
+                    DailyTasksModule
                 ],
                 providers: [
                     BoxService, GroupAdminService, BoxHelper, BoxCreator,

--- a/src/__tests__/dailyTasks/data/dailyTaskBuilderFactory.ts
+++ b/src/__tests__/dailyTasks/data/dailyTaskBuilderFactory.ts
@@ -1,0 +1,19 @@
+import DailyTaskBuilder from "./dailyTasks/DailyTaskBuilder";
+
+type BuilderName =
+	"DailyTask";
+
+type BuilderMap = {
+	DailyTask: DailyTaskBuilder;
+};
+
+export default class DailyTaskBuilderFactory {
+	static getBuilder<T extends BuilderName>(builderName: T): BuilderMap[T] {
+		switch (builderName) {
+			case "DailyTask":
+				return new DailyTaskBuilder() as BuilderMap[T];
+			default:
+				throw new Error(`Unknown builder name: ${builderName}`);
+		}
+	}
+}

--- a/src/__tests__/dailyTasks/data/dailyTasks/DailyTaskBuilder.ts
+++ b/src/__tests__/dailyTasks/data/dailyTasks/DailyTaskBuilder.ts
@@ -1,0 +1,79 @@
+import {DailyTask} from "../../../../dailyTasks/dailyTasks.schema";
+import {TaskName} from "../../../../dailyTasks/enum/taskName.enum";
+import {TaskTitle} from "../../../../dailyTasks/type/taskTitle.type";
+import {ObjectId} from "mongodb";
+
+export default class DailyTaskBuilder {
+    private readonly base: Partial<DailyTask> = {
+        _id: undefined,
+        clan_id: null,
+        player_id: null,
+        title: {fi: 'Default task title'},
+        type: TaskName.PLAY_BATTLE,
+        startedAt: null,
+        points: 10,
+        coins: 5,
+        amount: 1,
+        amountLeft: 1,
+        timeLimitMinutes: 60,
+    };
+
+    build(): DailyTask {
+        return {...this.base} as DailyTask;
+    }
+
+    setId(id: string | ObjectId) {
+        this.base._id = id;
+        return this;
+    }
+
+    setClanId(clanId: string | ObjectId) {
+        this.base.clan_id = clanId as any;
+        return this;
+    }
+
+    setPlayerId(playerId: string | ObjectId | null) {
+        this.base.player_id = playerId as any;
+        return this;
+    }
+
+    setTitle(title: TaskTitle) {
+        this.base.title = title;
+        return this;
+    }
+
+    setType(type: TaskName) {
+        this.base.type = type;
+        return this;
+    }
+
+    setStartedAt(startedAt: Date | null) {
+        this.base.startedAt = startedAt;
+        return this;
+    }
+
+    setPoints(points: number) {
+        this.base.points = points;
+        return this;
+    }
+
+    setCoins(coins: number) {
+        this.base.coins = coins;
+        return this;
+    }
+
+    setAmount(amount: number) {
+        this.base.amount = amount;
+        return this;
+    }
+
+    setAmountLeft(amountLeft: number) {
+        this.base.amountLeft = amountLeft;
+        return this;
+    }
+
+    setTimeLimitMinutes(timeLimitMinutes: number) {
+        this.base.timeLimitMinutes = timeLimitMinutes;
+        return this;
+    }
+}

--- a/src/__tests__/dailyTasks/modules/dailyTasks.module.ts
+++ b/src/__tests__/dailyTasks/modules/dailyTasks.module.ts
@@ -1,0 +1,19 @@
+import mongoose from "mongoose";
+import DailyTasksCommonModule from "./dailyTasksCommon.module";
+import {ModelName} from "../../../common/enum/modelName.enum";
+import {DailyTaskSchema} from "../../../dailyTasks/dailyTasks.schema";
+import {DailyTaskService} from "../../../box/dailyTask/dailyTask.service";
+
+export default class DailyTasksModule {
+    private constructor() {
+    }
+
+    static async getDailyService() {
+        const module = await DailyTasksCommonModule.getModule();
+        return await module.resolve(DailyTaskService);
+    }
+
+    static getDailyTaskModel() {
+        return mongoose.model(ModelName.DAILY_TASK, DailyTaskSchema);
+    }
+}

--- a/src/__tests__/dailyTasks/modules/dailyTasksCommon.module.ts
+++ b/src/__tests__/dailyTasks/modules/dailyTasksCommon.module.ts
@@ -1,0 +1,38 @@
+import {MongooseModule} from "@nestjs/mongoose";
+import {Test, TestingModule} from "@nestjs/testing";
+import {DailyTask, DailyTaskSchema} from "../../../dailyTasks/dailyTasks.schema";
+import {BullModule} from "@nestjs/bullmq";
+import {PlayerModule} from "../../../player/player.module";
+import {DailyTasksService} from "../../../dailyTasks/dailyTasks.service";
+import {TaskGeneratorService} from "../../../dailyTasks/taskGenerator.service";
+import DailyTaskNotifier from "../../../dailyTasks/dailyTask.notifier";
+import {DailyTaskProcessor, DailyTaskQueue} from "../../../dailyTasks/dailyTask.queue";
+
+export default class DailyTasksCommonModule {
+    private constructor() {
+    }
+
+    private static module: TestingModule;
+
+    static async getModule() {
+        if (!DailyTasksCommonModule.module)
+            DailyTasksCommonModule.module = await Test.createTestingModule({
+                imports: [
+                    MongooseModule.forFeature([
+                        {name: DailyTask.name, schema: DailyTaskSchema},
+                    ]),
+                    BullModule.registerQueue({
+                        name: "daily-tasks",
+                    }),
+                    PlayerModule,
+                ],
+
+                providers: [
+                    DailyTasksService, DailyTaskNotifier, TaskGeneratorService,
+                    DailyTaskQueue, DailyTaskProcessor
+                ]
+            }).compile();
+
+        return DailyTasksCommonModule.module;
+    }
+}

--- a/src/box/box.controller.ts
+++ b/src/box/box.controller.ts
@@ -30,6 +30,7 @@ import { IsGroupAdmin } from "./auth/decorator/IsGroupAdmin";
 import { BoxUser } from "./auth/BoxUser";
 import { LoggedUser } from "../common/decorator/param/LoggedUser.decorator";
 import { BoxAuthGuard } from "./auth/boxAuth.guard";
+import SessionStarterService from "./sessionStarter/sessionStarter.service";
 
 @Controller('box')
 @UseGuards(BoxAuthGuard)
@@ -37,7 +38,8 @@ export class BoxController {
     public constructor(
         private readonly service: BoxService,
         private readonly boxCreator: BoxCreator,
-        private readonly authHandler: BoxAuthHandler
+        private readonly authHandler: BoxAuthHandler,
+        private readonly sessionStarter: SessionStarterService,
     ) {
     }
 
@@ -99,6 +101,15 @@ export class BoxController {
 
 		return [{ ...createdBox, accessToken: groupAdminAccessToken }, null];
 	}
+
+    @Post('/start')
+    @UniformResponse(ModelName.BOX)
+    @IsGroupAdmin()
+    async startTestingSession(@LoggedUser() user: BoxUser) {
+        const [wasStarted, errors] = await this.sessionStarter.start(user.box_id);
+        if (errors)
+            return [null, errors];
+    }
 
     //For time of development only
     @NoAuth()

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -27,6 +27,7 @@ import {PasswordGenerator} from "./tester/passwordGenerator";
 import {TesterService} from "./tester/tester.service";
 import {TesterController} from "./tester/tester.controller";
 import SessionStarterService from "./sessionStarter/sessionStarter.service";
+import {DailyTasksModule} from "../dailyTasks/dailyTasks.module";
 
 @Module({
     imports: [
@@ -44,7 +45,8 @@ import SessionStarterService from "./sessionStarter/sessionStarter.service";
         ClanModule,
         ChatModule,
         ProfileModule,
-        PlayerModule
+        PlayerModule,
+        DailyTasksModule
     ],
     controllers: [
         BoxController, DailyTaskController, TesterController

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -26,6 +26,7 @@ import {GroupAdminGuard} from "./auth/decorator/groupAdmin.guard";
 import {PasswordGenerator} from "./tester/passwordGenerator";
 import {TesterService} from "./tester/tester.service";
 import {TesterController} from "./tester/tester.controller";
+import SessionStarterService from "./sessionStarter/sessionStarter.service";
 
 @Module({
     imports: [
@@ -52,7 +53,7 @@ import {TesterController} from "./tester/tester.controller";
         BoxService, GroupAdminService, BoxHelper, BoxCreator,
         DailyTaskService,
         BoxAuthHandler, GroupAdminGuard,
-        PasswordGenerator, TesterService
+        PasswordGenerator, TesterService, SessionStarterService
     ],
     exports: [
         BoxService, GroupAdminGuard

--- a/src/box/dailyTask/dailyTask.service.ts
+++ b/src/box/dailyTask/dailyTask.service.ts
@@ -6,7 +6,7 @@ import { BoxReference } from "../enum/BoxReference.enum";
 import BasicService from "../../common/service/basicService/BasicService";
 import { IServiceReturn } from "../../common/service/basicService/IService";
 import { ObjectId } from "mongodb";
-import { PredefinedDailyTask, PredefinedDailyTaskDoc } from "./predefinedDailyTask.schema";
+import { PredefinedDailyTask } from "./predefinedDailyTask.schema";
 import { CreateDailyTask } from "./payloads/CreateDailyTask";
 import ServiceError from "../../common/service/basicService/ServiceError";
 import { SEReason } from "../../common/service/basicService/SEReason";

--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -66,7 +66,7 @@ export default class SessionStarterService {
         if(clanAdminsErrors)
             return [null, clanAdminsErrors];
 
-        const randNumber = 1 + (Math.random() * 99);
+        const randNumber = Math.floor(1 + (Math.random() * 99));
         const testersPassword = this.passwordGenerator.generatePassword('fi') + `-${randNumber}`;
 
         const now = new Date().getTime();

--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -13,7 +13,7 @@ export default class SessionStarterService {
      * - Creates predefined daily tasks for each clan
      * - Defines clan admins from the testers
      * - Generates and sets testers shared password
-     * - Sets testing session status to TESTING
+     * - Sets testing session stage to TESTING
      * - Sets reset and removal times of the box
      *
      * @param box_id _id of the box where to start the session

--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -1,12 +1,36 @@
 import {Injectable} from "@nestjs/common";
 import {ObjectId} from "mongodb";
 import {IServiceReturn} from "../../common/service/basicService/IService";
+import ServiceError from "../../common/service/basicService/ServiceError";
+import {SEReason} from "../../common/service/basicService/SEReason";
+import {InjectModel} from "@nestjs/mongoose";
+import {Box, BoxDocument} from "../schemas/box.schema";
+import {Model} from "mongoose";
+import BasicService from "../../common/service/basicService/BasicService";
+import {DailyTasksService} from "../../dailyTasks/dailyTasks.service";
+import {Player} from "../../player/player.schema";
+import {Clan} from "../../clan/clan.schema";
+import {PasswordGenerator} from "../tester/passwordGenerator";
+import {SessionStage} from "../enum/SessionStage.enum";
+import {PredefinedDailyTask} from "../dailyTask/predefinedDailyTask.schema";
 
 /**
  * Class responsible for starting the testing session process.
  */
 @Injectable()
 export default class SessionStarterService {
+
+    constructor(
+        @InjectModel(Box.name) public readonly taskModel: Model<Box>,
+        @InjectModel(Player.name) public readonly playerModel: Model<Player>,
+        @InjectModel(Clan.name) public readonly clanModel: Model<Clan>,
+        private readonly dailyTasksService: DailyTasksService,
+        private readonly passwordGenerator: PasswordGenerator
+    ) {
+        this.basicService = new BasicService(taskModel);
+    }
+
+    private readonly basicService: BasicService;
 
     /**
      * Starts a testing session which means:
@@ -23,6 +47,127 @@ export default class SessionStarterService {
      * - NOT_FOUND if the box with that _id does not exist
      */
     async start(box_id: ObjectId | string): Promise<IServiceReturn<true>> {
-        return null;
+        const [isBox_idValid, validationErrors] = this.validateBox_id(box_id);
+        if (validationErrors)
+            return [null, validationErrors];
+
+        const box_idString = box_id.toString();
+
+        const [boxInDB, errors] = await this.basicService.readOneById<BoxDocument>(box_idString);
+        if (errors)
+            return [null, errors];
+
+        const dailyTasksToCreate = boxInDB.dailyTasks.map(task => task['_doc']);
+        const [wasTasksCreated, tasksCreationErrors] = await this.createDailyTasks(dailyTasksToCreate, boxInDB.clan_ids[0], boxInDB.clan_ids[1]);
+        if (tasksCreationErrors)
+            return [null, tasksCreationErrors];
+
+        const [clanAdminsAreSet, clanAdminsErrors] = await this.setClanAdmins(boxInDB.adminPlayer_id, boxInDB.clan_ids[0], boxInDB.clan_ids[1]);
+        if(clanAdminsErrors)
+            return [null, clanAdminsErrors];
+
+        const randNumber = 1 + (Math.random() * 99);
+        const testersPassword = this.passwordGenerator.generatePassword('fi') + `-${randNumber}`;
+
+        const now = new Date().getTime();
+        const timeAfterWeek = now + 60 * 60 * 24 * 7;
+        const timeAfterMonth = now + 60 * 60 * 24 * 30;
+
+        const [wasUpdated, boxUpdateErrors] = await this.basicService.updateOneById<Partial<Box>>(box_id.toString(), {
+            sessionStage: SessionStage.TESTING, testersSharedPassword: testersPassword,
+            sessionResetTime: timeAfterWeek, boxRemovalTime: timeAfterMonth
+        });
+
+        if (boxUpdateErrors)
+            return [null, boxUpdateErrors];
+
+        return [true, null];
+    }
+
+    /**
+     * Creates daily tasks for the specified clans from the array of PredefinedDailyTask
+     *
+     * @param tasks tasks to create
+     * @param clan1_id first where clan tasks to be added
+     * @param clan2_id second clan where tasks to be added
+     * @private
+     *
+     * @returns true if tasks was created or ServiceErrors if any occurred
+     */
+    private async createDailyTasks(tasks: PredefinedDailyTask[], clan1_id: string | ObjectId, clan2_id: string | ObjectId): Promise<IServiceReturn<true>> {
+        const dailyTasksToCreate = tasks.map(dailyTask => {
+            return {
+                ...dailyTask,
+                amountLeft: dailyTask.amount,
+                title: {fi: dailyTask.title},
+                timeLimitMinutes: 30,
+                _id: undefined
+            }
+        });
+
+        const clan1Tasks = dailyTasksToCreate.map(dailyTask => {
+            return {...dailyTask, clan_id: clan1_id as any};
+        });
+
+        const clan2Tasks = dailyTasksToCreate.map(dailyTask => {
+            return {...dailyTask, clan_id: clan2_id as any};
+        });
+
+        const [clan1CreatedTasks, clan1TasksCreationErrors] = await this.dailyTasksService.createMany(clan1Tasks);
+        if (clan1TasksCreationErrors)
+            return [null, clan1TasksCreationErrors];
+
+        const [clan2CreatedTasks, clan2TasksCreationErrors] = await this.dailyTasksService.createMany(clan2Tasks);
+        if (clan2TasksCreationErrors)
+            return [null, clan2TasksCreationErrors];
+
+        return [true, null];
+    }
+
+    /**
+     * Sets one of the testers to be a clan admin
+     * @param admin_id player _id of the box admin
+     * @param clan1_id first clan _id
+     * @param clan2_id second clan _id
+     * @private
+     * @returns true if _id is valid or ServiceErrors if not
+     */
+    private async setClanAdmins(admin_id: string | ObjectId, clan1_id: string | ObjectId, clan2_id: string | ObjectId): Promise<IServiceReturn<true>> {
+        const clan1Admin = await this.playerModel.findOne({clan_id: clan1_id, _id: {$ne: admin_id}});
+        if (!clan1Admin)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND,
+                message: 'Could not fond any tester to be a clan 1 admin'
+            })]];
+        const clan2Admin = await this.playerModel.findOne({clan_id: clan2_id, _id: {$ne: admin_id}});
+        if (!clan2Admin)
+            return [null, [new ServiceError({
+                reason: SEReason.NOT_FOUND,
+                message: 'Could not fond any tester to be a clan 2 admin'
+            })]];
+
+        await this.clanModel.findByIdAndUpdate(clan1_id, {admin_ids: [clan1Admin._id.toString()]});
+        await this.clanModel.findByIdAndUpdate(clan2_id, {admin_ids: [clan2Admin._id.toString()]});
+
+        return [true, null];
+    }
+
+    /**
+     * Validates _id of the box
+     * @param box_id box _id to validate
+     * @private
+     *
+     * @returns true if _id is valid or ServiceErrors if not
+     */
+    private validateBox_id(box_id: string | ObjectId): IServiceReturn<true> {
+        if (!box_id || box_id === '')
+            return [null, [new ServiceError({
+                reason: SEReason.REQUIRED,
+                field: 'box_id',
+                value: box_id,
+                message: 'box_id is required'
+            })]];
+
+        return [true, null];
     }
 }

--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -1,0 +1,28 @@
+import {Injectable} from "@nestjs/common";
+import {ObjectId} from "mongodb";
+import {IServiceReturn} from "../../common/service/basicService/IService";
+
+/**
+ * Class responsible for starting the testing session process.
+ */
+@Injectable()
+export default class SessionStarterService {
+
+    /**
+     * Starts a testing session which means:
+     * - Creates predefined daily tasks for each clan
+     * - Defines clan admins from the testers
+     * - Generates and sets testers shared password
+     * - Sets testing session status to TESTING
+     * - Sets reset and removal times of the box
+     *
+     * @param box_id _id of the box where to start the session
+     *
+     * @returns true if the session is started successfully, or ServiceErrors:
+     * - REQUIRED if the box_id is not provided
+     * - NOT_FOUND if the box with that _id does not exist
+     */
+    async start(box_id: ObjectId | string): Promise<IServiceReturn<true>> {
+        return null;
+    }
+}

--- a/src/dailyTasks/dailyTasks.schema.ts
+++ b/src/dailyTasks/dailyTasks.schema.ts
@@ -3,6 +3,8 @@ import { HydratedDocument, Schema as MongooseSchema } from "mongoose";
 import { ModelName } from "../common/enum/modelName.enum";
 import { TaskName } from "./enum/taskName.enum";
 import {TaskTitle} from "./type/taskTitle.type";
+import {ExtractField} from "../common/decorator/response/ExtractField";
+import {ObjectId} from "mongodb";
 
 export type DailyTaskDocument = HydratedDocument<DailyTask>;
 
@@ -37,6 +39,9 @@ export class DailyTask {
 
 	@Prop({ type: Number, required: true })
 	timeLimitMinutes: number;
+
+	@ExtractField()
+	_id?: string | ObjectId;
 }
 
 export const DailyTaskSchema = SchemaFactory.createForClass(DailyTask);

--- a/src/dailyTasks/dailyTasks.service.ts
+++ b/src/dailyTasks/dailyTasks.service.ts
@@ -1,170 +1,193 @@
-import { Injectable } from "@nestjs/common";
-import { InjectModel } from "@nestjs/mongoose";
-import { Model } from "mongoose";
+import {Injectable} from "@nestjs/common";
+import {InjectModel} from "@nestjs/mongoose";
+import {Model} from "mongoose";
 import BasicService from "../common/service/basicService/BasicService";
-import { ModelName } from "../common/enum/modelName.enum";
+import {ModelName} from "../common/enum/modelName.enum";
 import DailyTaskNotifier from "./dailyTask.notifier";
-import { DailyTask } from "./dailyTasks.schema";
-import { DailyTaskDto } from "./dto/dailyTask.dto";
-import { Task } from "./type/task.type";
-import { DailyTaskQueue } from "./dailyTask.queue";
-import { taskReservedError } from "./errors/taskReserved.error";
-import { TaskGeneratorService } from "./taskGenerator.service";
+import {DailyTask} from "./dailyTasks.schema";
+import {DailyTaskDto} from "./dto/dailyTask.dto";
+import {Task} from "./type/task.type";
+import {DailyTaskQueue} from "./dailyTask.queue";
+import {taskReservedError} from "./errors/taskReserved.error";
+import {TaskGeneratorService} from "./taskGenerator.service";
 import {TIServiceCreateManyOptions, TReadByIdOptions} from "../common/service/basicService/IService";
 
 @Injectable()
 export class DailyTasksService {
-	public constructor(
-		@InjectModel(DailyTask.name) public readonly model: Model<DailyTask>,
-		private readonly notifier: DailyTaskNotifier,
-		private readonly taskQueue: DailyTaskQueue,
-		private readonly taskGenerator: TaskGeneratorService,
-	) {
-		this.basicService = new BasicService(model);
-		this.modelName = ModelName.DAILY_TASK;
-		this.refsInModel = [ModelName.PLAYER];
-	}
-	public readonly modelName: ModelName;
-	public readonly refsInModel: ModelName[];
-	private readonly basicService: BasicService;
+    public constructor(
+        @InjectModel(DailyTask.name) public readonly model: Model<DailyTask>,
+        private readonly notifier: DailyTaskNotifier,
+        private readonly taskQueue: DailyTaskQueue,
+        private readonly taskGenerator: TaskGeneratorService,
+    ) {
+        this.basicService = new BasicService(model);
+        this.modelName = ModelName.DAILY_TASK;
+        this.refsInModel = [ModelName.PLAYER];
+    }
 
-	/**
-	 * Generates a set of tasks for a new clan.
-	 *
-	 * This method creates 20 tasks with random values and assigns them to the specified clan.
-	 * Each task is created by calling `createTaskRandomValues` and then adding the `clanId`.
-	 * The tasks are then saved using the `basicService.createMany` method.
-	 *
-	 * @param clanId - The ID of the clan for which tasks are being generated.
-	 * @returns A promise that resolves to the result of the `createMany` operation.
-	 */
-	async generateTasksForNewClan(clanId: string) {
-		const tasks: Partial<Task>[] = [];
-		for (let i = 0; i < 20; i++) {
-			const partial = this.taskGenerator.createTaskRandomValues();
-			const timeLimitMinutes = partial.amount * 2;
-			const task: Partial<Task> = {
-				...partial,
-				amountLeft: partial.amount,
-				timeLimitMinutes,
-				clan_id: clanId,
-			};
-			tasks.push(task);
-		}
+    public readonly modelName: ModelName;
+    public readonly refsInModel: ModelName[];
+    private readonly basicService: BasicService;
 
-		return await this.basicService.createMany(tasks);
-	}
+    /**
+     * Generates a set of tasks for a new clan.
+     *
+     * This method creates 20 tasks with random values and assigns them to the specified clan.
+     * Each task is created by calling `createTaskRandomValues` and then adding the `clanId`.
+     * The tasks are then saved using the `basicService.createMany` method.
+     *
+     * @param clanId - The ID of the clan for which tasks are being generated.
+     * @returns A promise that resolves to the result of the `createMany` operation.
+     */
+    async generateTasksForNewClan(clanId: string) {
+        const tasks: Partial<Task>[] = [];
+        for (let i = 0; i < 20; i++) {
+            const partial = this.taskGenerator.createTaskRandomValues();
+            const timeLimitMinutes = partial.amount * 2;
+            const task: Partial<Task> = {
+                ...partial,
+                amountLeft: partial.amount,
+                timeLimitMinutes,
+                clan_id: clanId,
+            };
+            tasks.push(task);
+        }
 
-	/**
-	 * Reserves a daily task for a player.
-	 *
-	 * @param playerId - The ID of the player reserving the task.
-	 * @param taskId - The ID of the task to be reserved.
-	 * @param clanId - The ID of the clan to which the task belongs.
-	 * @throws Will throw an error if the task cannot be read or updated.
-	 * @throws Will throw an error if the task is already reserved by another player.
-	 */
-	async reserveTask(playerId: string, taskId: string, clanId: string) {
-		const [task, error] = await this.basicService.readOne<DailyTaskDto>({
-			filter: { _id: taskId, clan_id: clanId },
-		});
-		if (error) throw error;
-		if (task.player_id) throw taskReservedError;
+        return await this.basicService.createMany(tasks);
+    }
 
-		const startedAt = new Date();
-		task.player_id = playerId;
-		task.startedAt = startedAt;
+    /**
+     * Reserves a daily task for a player.
+     *
+     * @param playerId - The ID of the player reserving the task.
+     * @param taskId - The ID of the task to be reserved.
+     * @param clanId - The ID of the clan to which the task belongs.
+     * @throws Will throw an error if the task cannot be read or updated.
+     * @throws Will throw an error if the task is already reserved by another player.
+     */
+    async reserveTask(playerId: string, taskId: string, clanId: string) {
+        const [task, error] = await this.basicService.readOne<DailyTaskDto>({
+            filter: {_id: taskId, clan_id: clanId},
+        });
+        if (error) throw error;
+        if (task.player_id) throw taskReservedError;
 
-		const [_, updateError] = await this.basicService.updateOneById(
-			taskId,
-			task
-		);
-		if (updateError) throw updateError;
+        const startedAt = new Date();
+        task.player_id = playerId;
+        task.startedAt = startedAt;
 
-		await this.taskQueue.addDailyTask(task);
-		await this.notifier.taskReceived(playerId, task);
+        const [_, updateError] = await this.basicService.updateOneById(
+            taskId,
+            task
+        );
+        if (updateError) throw updateError;
 
-		return task;
-	}
+        await this.taskQueue.addDailyTask(task);
+        await this.notifier.taskReceived(playerId, task);
 
-	/**
-	 * Deletes a task by updating it with new random values and resetting certain fields.
-	 *
-	 * @param taskId - The ID of the task to be deleted.
-	 * @param clanId - The ID of the clan associated with the task.
-	 * @param playerId - The ID of the player associated with the task.
-	 * @returns A promise that resolves to the result of the update operation.
-	 */
-	async deleteTask(taskId: string, clanId: string, playerId: string) {
-		const newValues = this.taskGenerator.createTaskRandomValues();
-		const filter: any = { _id: taskId, clan_id: clanId };
-		filter.$or = [{ playerId }, { playerId: { $exists: false } }];
-		return await this.basicService.updateOne(
-			{
-				$set: {
-					...newValues,
-					amountLeft: newValues.amount,
-				},
-				$unset: {
-					playerId: "",
-					startedAt: "",
-				},
-			},
-			{ filter }
-		);
-	}
+        return task;
+    }
 
-	/**
-	 * Updates the daily task for a given player. Decrements the amount left for the task.
-	 * If the amount left reaches zero, the task is deleted. Otherwise, the task is updated.
-	 *
-	 * @param playerId - The ID of the player whose task is being updated.
-	 * @returns The updated task.
-	 * @throws Will throw an error if there is an issue reading or updating the task.
-	 */
-	async updateTask(playerId: string) {
-		const [task, error] = await this.basicService.readOne<DailyTaskDto>({
-			filter: { playerId },
-		});
-		if (error) throw error;
+    /**
+     * Deletes a task by updating it with new random values and resetting certain fields.
+     *
+     * @param taskId - The ID of the task to be deleted.
+     * @param clanId - The ID of the clan associated with the task.
+     * @param playerId - The ID of the player associated with the task.
+     * @returns A promise that resolves to the result of the update operation.
+     */
+    async deleteTask(taskId: string, clanId: string, playerId: string) {
+        const newValues = this.taskGenerator.createTaskRandomValues();
+        const filter: any = {_id: taskId, clan_id: clanId};
+        filter.$or = [{playerId}, {playerId: {$exists: false}}];
+        return await this.basicService.updateOne(
+            {
+                $set: {
+                    ...newValues,
+                    amountLeft: newValues.amount,
+                },
+                $unset: {
+                    playerId: "",
+                    startedAt: "",
+                },
+            },
+            {filter}
+        );
+    }
 
-		task.amountLeft--;
+    /**
+     * Updates the daily task for a given player. Decrements the amount left for the task.
+     * If the amount left reaches zero, the task is deleted. Otherwise, the task is updated.
+     *
+     * @param playerId - The ID of the player whose task is being updated.
+     * @returns The updated task.
+     * @throws Will throw an error if there is an issue reading or updating the task.
+     */
+    async updateTask(playerId: string) {
+        const [task, error] = await this.basicService.readOne<DailyTaskDto>({
+            filter: {playerId},
+        });
+        if (error) throw error;
 
-		if (task.amountLeft === 0) {
-			await this.deleteTask(task._id.toString(), task.clan_id, playerId);
-			this.notifier.taskCompleted(playerId, task);
-		} else {
-			const [_, updateError] = await this.basicService.updateOne(task, {
-				filter: { playerId },
-			});
-			if (updateError) throw updateError;
-			this.notifier.taskUpdated(playerId, task);
-		}
+        task.amountLeft--;
 
-		return task;
-	}
+        if (task.amountLeft === 0) {
+            await this.deleteTask(task._id.toString(), task.clan_id, playerId);
+            this.notifier.taskCompleted(playerId, task);
+        } else {
+            const [_, updateError] = await this.basicService.updateOne(task, {
+                filter: {playerId},
+            });
+            if (updateError) throw updateError;
+            this.notifier.taskUpdated(playerId, task);
+        }
 
-	/**
-	 * Reads a DailyTask by its _id in DB.
-	 *
-	 * @param _id - The Mongo _id of the DailyTask to read.
-	 * @param options - Options for reading the DailyTask.
-	 * @returns DailyTask with the given _id on succeed or an array of ServiceErrors if any occurred.
-	 */
-	async readOneById(_id: string, options?: TReadByIdOptions) {
-		const optionsToApply = options;
-		if(options?.includeRefs)
-			optionsToApply.includeRefs = options.includeRefs.filter((ref) => this.refsInModel.includes(ref));
-		return this.basicService.readOneById<DailyTaskDto>(_id, optionsToApply);
-	}
+        return task;
+    }
 
-	/**
-	 * Reads multiple daily tasks from the database based on the provided options.
-	 *
-	 * @param options - Optional settings for the read operation.
-	 * @returns A promise that resolves to a tuple where the first element is an array of ItemDto objects, and the second element is either null or an array of ServiceError objects if something went wrong.
-	 */
-	async readMany(options?: TIServiceCreateManyOptions) {
-		return this.basicService.readMany<DailyTaskDto>(options);
-	}
+    /**
+     * Reads a DailyTask by its _id in DB.
+     *
+     * @param _id - The Mongo _id of the DailyTask to read.
+     * @param options - Options for reading the DailyTask.
+     * @returns DailyTask with the given _id on succeed or an array of ServiceErrors if any occurred.
+     */
+    async readOneById(_id: string, options?: TReadByIdOptions) {
+        const optionsToApply = options;
+        if (options?.includeRefs)
+            optionsToApply.includeRefs = options.includeRefs.filter((ref) => this.refsInModel.includes(ref));
+        return this.basicService.readOneById<DailyTaskDto>(_id, optionsToApply);
+    }
+
+    /**
+     * Reads multiple daily tasks from the database based on the provided options.
+     *
+     * @param options - Optional settings for the read operation.
+     * @returns A promise that resolves to a tuple where the first element is an array of ItemDto objects, and the second element is either null or an array of ServiceError objects if something went wrong.
+     */
+    async readMany(options?: TIServiceCreateManyOptions) {
+        return this.basicService.readMany<DailyTaskDto>(options);
+    }
+
+    /**
+     * Creates a new daily task in DB.
+     *
+     * @param dailyTaskToCreate daily task to create
+     *
+     * @returns created daily task or ServiceError if any occurred
+     */
+    async createOne(dailyTaskToCreate: Omit<DailyTask, '_id'>) {
+        return this.basicService.createOne(dailyTaskToCreate);
+    }
+
+    /**
+     * Creates multiple daily tasks in DB.
+     *
+     * @param dailyTasksToCreate daily tasks to create
+     *
+     * @returns created daily task or ServiceError if any occurred
+     */
+    async createMany(dailyTasksToCreate: Omit<DailyTask, '_id'>[]) {
+        return this.basicService.createMany(dailyTasksToCreate);
+    }
 }


### PR DESCRIPTION
### Brief description

Added _/box/start_ POST endpoint to start testing session. Notice that only box admin can start a testing session.

### Change list

- Added _/box/start_ POST endpoint to start testing session
- Added tests for the `SessionStarterService` class
- Added `createOne()` and `createMultiple()` methods to `DailyTaskService`
