### PR TITLE
Fixed bug, where player can add multiple same type custom characters to own account

### DIFF
--- a/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
@@ -37,11 +37,11 @@ describe('CustomCharacterService.createOne() test suite', () => {
         });
     });
 
-    it('Should return created custom character if the input is valid and should return NOT_UNIQUE if already exists with this characterId', async () => {
+    it('Should return created custom character if the input is valid', async () => {
         const characterId = CharacterId.Prankster_202;
         const characterToCreate = createCustomCharacterBuilder.setCharacterId(characterId).build();
 
-        let [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
+        const [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
 
         const expectedSpecs = CharacterBaseStats[characterId];
 
@@ -50,9 +50,15 @@ describe('CustomCharacterService.createOne() test suite', () => {
             ...characterToCreate, ...expectedSpecs,
             player_id: new ObjectId(player._id), _id: expect.any(ObjectId)
         }));
+    });
 
-        // Create another character with the same characterId
-        [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
+    it('Should return NOT_UNIQUE ServiceErrors if character with same player_id and characterId already exists', async () => {
+        const characterId = CharacterId.Prankster_202;
+        const characterToCreate = createCustomCharacterBuilder.setCharacterId(characterId).build();
+
+        await characterService.createOne(characterToCreate, player._id);
+
+        const [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
 
         expect(createdCharacter).toBeNull();
         expect(errors).toContainSE_NOT_UNIQUE();

--- a/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
@@ -37,11 +37,11 @@ describe('CustomCharacterService.createOne() test suite', () => {
         });
     });
 
-    it('Should return created custom character if the input is valid', async () => {
+    it('Should return created custom character if the input is valid and should return NOT_UNIQUE if already exists with this characterId', async () => {
         const characterId = CharacterId.Prankster_202;
         const characterToCreate = createCustomCharacterBuilder.setCharacterId(characterId).build();
 
-        const [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
+        let [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
 
         const expectedSpecs = CharacterBaseStats[characterId];
 
@@ -50,6 +50,12 @@ describe('CustomCharacterService.createOne() test suite', () => {
             ...characterToCreate, ...expectedSpecs,
             player_id: new ObjectId(player._id), _id: expect.any(ObjectId)
         }));
+
+        // Create another character with the same characterId
+        [createdCharacter, errors] = await characterService.createOne(characterToCreate, player._id);
+
+        expect(createdCharacter).toBeNull();
+        expect(errors).toContainSE_NOT_UNIQUE();
     });
 
     it('Should return WRONG_ENUM if the level value is not a number', async () => {

--- a/src/characterClass/files/jozsef.txt
+++ b/src/characterClass/files/jozsef.txt
@@ -1,1 +1,0 @@
-Hello world

--- a/src/player/customCharacter/customCharacter.service.ts
+++ b/src/player/customCharacter/customCharacter.service.ts
@@ -23,13 +23,13 @@ import {UpdateCustomCharacterDto} from "./dto/updateCustomCharacter.dto";
 @Injectable()
 export class CustomCharacterService {
     public constructor(
-        @InjectModel(CustomCharacter.name) public readonly model: Model<CustomCharacter>,
+        @InjectModel(CustomCharacter.name) public readonly customCharacterModel: Model<CustomCharacter>,
         @InjectModel(Player.name) public readonly playerModel: Model<Player>,
         private readonly requestHelperService: RequestHelperService
     ){
         this.refsInModel = [ModelName.PLAYER];
         this.modelName = ModelName.CUSTOM_CHARACTER;
-        this.basicService = new BasicService(model);
+        this.basicService = new BasicService(customCharacterModel);
     }
 
     public readonly refsInModel: ModelName[];

--- a/src/player/customCharacter/customCharacter.service.ts
+++ b/src/player/customCharacter/customCharacter.service.ts
@@ -19,6 +19,7 @@ import {Player} from "../player.schema";
 import BasicService from "../../common/service/basicService/BasicService";
 import {CharacterBaseStats} from "./const/CharacterBaseStats";
 import {UpdateCustomCharacterDto} from "./dto/updateCustomCharacter.dto";
+import {ObjectId} from "mongodb";
 
 @Injectable()
 export class CustomCharacterService {
@@ -54,6 +55,19 @@ export class CustomCharacterService {
                 reason: SEReason.NOT_FOUND, field: 'owner_id', value: owner_id,
                 message: 'Player with that _id does not exist'
             })]];
+
+            const isCustomCharacterExists = await this.customCharacterModel.findOne(
+                { "characterId": customCharacterToCreate.characterId, 
+                    "player_id": new ObjectId(owner_id) });
+                
+            if(isCustomCharacterExists)
+            {
+                console.log('Custom character already exists');
+                return [null, [new ServiceError({
+                    reason: SEReason.NOT_UNIQUE, field: 'characterId', value: owner_id,
+                    message: 'Custom character already exists with this characterId'
+                })]];
+            }
 
         const expectedSpecs = CharacterBaseStats[customCharacterToCreate.characterId];
 


### PR DESCRIPTION
### Brief description
Validate if CustomCharacter is already exists for _/customCharacter_ POST endpoint. Return with 409 error code if yes. Small code quality improvements.

### Change list
- CustomCharacterService: rename model variable to customCharacterModel
- CustomCharacterService: validate if CustomCharacter is already exists. Return with 409 error code if yes.
- Move the CustomCharacter request validations to a separate method
