### PR TITLE
Fix: add maxlength validation for clan name in DTOs and schema

### DIFF
--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -12,7 +12,7 @@ export type ClanDocument = HydratedDocument<Clan>;
 
 @Schema({ toJSON: { virtuals: true }, toObject: { virtuals: true } })
 export class Clan {
-  @Prop({ type: String, required: true, unique: true })
+  @Prop({ type: String, required: true, unique: true, maxlength: 20 })
   name: string;
 
   @Prop({ type: String })

--- a/src/clan/dto/createClan.dto.ts
+++ b/src/clan/dto/createClan.dto.ts
@@ -6,6 +6,7 @@ import {
   IsOptional,
   IsString,
   ValidateNested,
+  MaxLength,
 } from 'class-validator';
 import AddType from '../../common/base/decorator/AddType.decorator';
 import { ClanLabel } from '../enum/clanLabel.enum';
@@ -18,6 +19,7 @@ import { ClanLogoDto } from './clanLogo.dto';
 @AddType('CreateClanDto')
 export class CreateClanDto {
   @IsString()
+  @MaxLength(20)
   name: string;
 
   @IsString()

--- a/src/clan/dto/updateClan.dto.ts
+++ b/src/clan/dto/updateClan.dto.ts
@@ -9,6 +9,7 @@ import {
   IsString,
   Validate,
   ValidateNested,
+  MaxLength,
 } from 'class-validator';
 import { IsClanExists } from '../decorator/validation/IsClanExists.decorator';
 import { IsPlayerExists } from '../../player/decorator/validation/IsPlayerExists.decorator';
@@ -28,6 +29,7 @@ export class UpdateClanDto {
 
   @IsString()
   @IsOptional()
+  @MaxLength(20)
   name?: string;
 
   @IsString()


### PR DESCRIPTION
### Brief description

Added max length to clan name in create and update DTO's and clan schema

### Change list

Updates to `Clan` schema:

* [`src/clan/clan.schema.ts`](diffhunk://#diff-2b0a6d9aa16122d4b8f08d8ea3430f94dce5476a904154c3f90f19b5127e0147L15-R15): Added `maxlength: 20` to the `name` property to enforce a maximum length constraint.

Updates to DTOs:

* [`src/clan/dto/createClan.dto.ts`](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dR9): Imported `MaxLength` from `class-validator` and added `@MaxLength(20)` to the `name` property in `CreateClanDto`. [[1]](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dR9) [[2]](diffhunk://#diff-f81896d9b4df86ee462fa096af094058561efd1ecefe0fe8428f3ba55b8a3d4dR22)
* [`src/clan/dto/updateClan.dto.ts`](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecR12): Imported `MaxLength` from `class-validator` and added `@MaxLength(20)` to the `name` property in `UpdateClanDto`. [[1]](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecR12) [[2]](diffhunk://#diff-8025a805c1dce2e419ba10dcd89a5f3105781bec93d2fefcc89f952f70354eecR32)