### PR TITLE
Fixed endpoints exposing profile password

### DIFF
--- a/src/__tests__/common/interceptor/response/SerializeInterceptor2/SerializeInterceptor2.test.ts
+++ b/src/__tests__/common/interceptor/response/SerializeInterceptor2/SerializeInterceptor2.test.ts
@@ -1,0 +1,139 @@
+import { Expose } from 'class-transformer';
+import TestUtilDataFactory from '../../../../test_utils/data/TestUtilsDataFactory';
+import { SerializeInterceptor2 } from '../../../../../common/interceptor/response/SerializeInterceptor2';
+
+describe('SerializeInterceptor2 class test suite', () => {
+  const contextBuilder = TestUtilDataFactory.getBuilder('ExecutionContext');
+  const handlerBuilder = TestUtilDataFactory.getBuilder('CallHandler');
+  const context = contextBuilder.build();
+  let interceptor: SerializeInterceptor2;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    interceptor = new SerializeInterceptor2(MockDtoClass);
+  });
+
+  it('Should serialize the object returned as IServiceResponse tuple and exclude fields not decorated with @Expose()', async () => {
+    const name = 'Alice';
+
+    const data = new MockDtoClass(name, 5000);
+    const mockResp = [data, null];
+    const expected = [{ name }, null];
+
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(expected);
+    });
+  });
+
+  it('Should serialize the array returned as IServiceResponse tuple and exclude fields not decorated with @Expose()', async () => {
+    const name1 = 'Alice';
+    const name2 = 'Bob';
+
+    const data = [new MockDtoClass(name1, 5000), new MockDtoClass(name2, 3000)];
+    const mockResp = [data, null];
+    const expected = [[{ name: name1 }, { name: name2 }], null];
+
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(expected);
+    });
+  });
+
+  it('Should serialize the data returned as object and exclude fields not decorated with @Expose()', async () => {
+    const name = 'Alice';
+
+    const mockResp = new MockDtoClass(name, 5000);
+    const expected = [{ name }, null];
+
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(expected);
+    });
+  });
+
+  it('Should serialize the data returned as array and exclude fields not decorated with @Expose()', async () => {
+    const name1 = 'Alice';
+    const name2 = 'Bob';
+
+    const mockResp = [
+      new MockDtoClass(name1, 5000),
+      new MockDtoClass(name2, 3000),
+    ];
+    const expected = [[{ name: name1 }, { name: name2 }], null];
+
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(expected);
+    });
+  });
+
+  it('Should return response as-is when no DTO shape is provided', async () => {
+    interceptor = new SerializeInterceptor2();
+    const mockResp = [new MockDtoClass('Alice', 999), null];
+
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(mockResp);
+    });
+  });
+
+  it('Should return IServiceResponse tuple as-is when error exists', async () => {
+    const errorTuple = [null, { message: 'Something went wrong' }];
+    const nextFn = handlerBuilder.setHandleResponse(errorTuple).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toEqual(errorTuple);
+    });
+  });
+
+  it('Should return undefined as-is when response is undefined', async () => {
+    const mockResp = undefined;
+    const nextFn = handlerBuilder.setHandleResponse(mockResp).build();
+
+    const result = await interceptor.intercept(context, nextFn);
+
+    result.subscribe(async (returnedData) => {
+      const awaitedData = await returnedData;
+      expect(awaitedData).toBeUndefined();
+    });
+  });
+});
+
+/**
+ * Dummy class used for testing the serialization
+ */
+class MockDtoClass {
+  constructor(name: string, salary: number) {
+    this.name = name;
+    this.salary = salary;
+  }
+
+  @Expose()
+  name: string;
+
+  salary: number;
+}

--- a/src/common/decorator/response/UniformResponse.ts
+++ b/src/common/decorator/response/UniformResponse.ts
@@ -32,8 +32,6 @@ export function UniformResponse(
     ),
   ];
 
-  // if (serializationShape) decorators.push(Serialize2(serializationShape));
-
   return function (
     target: any,
     propertyKey: string | symbol,

--- a/src/common/decorator/response/UniformResponse.ts
+++ b/src/common/decorator/response/UniformResponse.ts
@@ -4,6 +4,8 @@ import { FormatAPIResponseInterceptor } from '../../interceptor/response/FormatA
 import { ModelName } from '../../enum/modelName.enum';
 import { Send204OnEmptyRes } from '../../interceptor/response/Send204OnEmptyRes';
 import { APIErrorFilter } from '../../exceptionFilter/APIErrorFilter';
+import { IClass } from '../../interface/IClass';
+import { SerializeInterceptor2 } from '../../interceptor/response/SerializeInterceptor2';
 
 /**
  * Uniform response sent to the client side as follows
@@ -14,14 +16,23 @@ import { APIErrorFilter } from '../../exceptionFilter/APIErrorFilter';
  * it will be treated as a success and this data will be formatted into {data: ..., metaData: ...} form.
  * - If nothing is returned the response with 204 (No Content) status will be returned
  * @param modelName name of the model, what the controller returning on success
+ * @param serializationShape class, which determines the serialization of the response data, ignored if not specified
  * @returns
  */
-export function UniformResponse(modelName?: ModelName) {
+export function UniformResponse(
+  modelName?: ModelName,
+  serializationShape?: IClass,
+) {
   const decorators = [
     Send204OnEmptyRes(),
     UseFilters(new ValidationExceptionFilter(), new APIErrorFilter()),
-    UseInterceptors(new FormatAPIResponseInterceptor(modelName)),
+    UseInterceptors(
+      new FormatAPIResponseInterceptor(modelName),
+      new SerializeInterceptor2(serializationShape),
+    ),
   ];
+
+  // if (serializationShape) decorators.push(Serialize2(serializationShape));
 
   return function (
     target: any,

--- a/src/common/interceptor/response/SerializeInterceptor2.ts
+++ b/src/common/interceptor/response/SerializeInterceptor2.ts
@@ -1,0 +1,64 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { plainToInstance } from 'class-transformer';
+import { IClass } from '../../interface/IClass';
+
+/**
+ * Interceptor that serializes the response data into a specified DTO class using `class-transformer` library.
+ * The serialized data replaces the original data in the response before it is sent to the client side.
+ *
+ * @implements {NestInterceptor}
+ */
+export class SerializeInterceptor2 implements NestInterceptor {
+  public constructor(private readonly dto?: IClass) {}
+
+  public intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(
+      map(async (data: any) => {
+        if (!data || !this.dto) return data;
+
+        const parsedData = await data;
+
+        let dataToReturn = parsedData;
+
+        if (isTupleWithError(parsedData)) return parsedData;
+
+        if (isTupleWithData(parsedData)) dataToReturn = parsedData[0];
+
+        const serializedData = plainToInstance(this.dto, dataToReturn, {
+          excludeExtraneousValues: true,
+        });
+
+        return [serializedData, null];
+      }),
+    );
+  }
+}
+
+/**
+ * Determines whenever the provided data is of type IServiceReturn and has an error in it
+ * @param data data to check
+ *
+ * @returns true if tuple with error or false if it is not a tuple, or it has no error
+ */
+function isTupleWithError(data: any) {
+  return (
+    Array.isArray(data) && data.length === 2 && data[1] && data[0] === null
+  );
+}
+
+/**
+ * Determines whenever the provided data is of type IServiceReturn and has data in it
+ * @param data data to check
+ *
+ * @returns true if tuple with data or false if it is not a tuple, or it has no data
+ */
+function isTupleWithData(data: any) {
+  return (
+    Array.isArray(data) && data.length === 2 && data[0] && data[1] === null
+  );
+}

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -20,7 +20,6 @@ import { NoAuth } from '../auth/decorator/NoAuth.decorator';
 import { Action } from '../authorization/enum/action.enum';
 import { CheckPermissions } from '../authorization/authorization.interceptor';
 import { AddGetQueries } from '../common/decorator/request/AddGetQueries.decorator';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { Authorize } from '../authorization/decorator/Authorize';
 import { _idDto } from '../common/dto/_id.dto';
 import { MongooseError } from 'mongoose';
@@ -41,11 +40,9 @@ export default class ProfileController {
     private readonly playerService: PlayerService,
   ) {}
 
-  //: Promise<MongooseError | IResponseShape>
   @NoAuth()
   @Post()
-  @Serialize(ProfileDto)
-  @UniformResponse(ModelName.PROFILE)
+  @UniformResponse(ModelName.PROFILE, ProfileDto)
   public async create(@Body() body: CreateProfileDto) {
     const { Player } = body;
 
@@ -71,13 +68,9 @@ export default class ProfileController {
   }
 
   @Get('/info')
-  @Serialize(ProfileDto)
-  @UniformResponse(ModelName.PROFILE)
+  @UniformResponse(ModelName.PROFILE, ProfileDto)
   async getLoggedUserInfo(@LoggedUser() user: User) {
-    return await this.service.getLoggedUserInfo(
-      user.profile_id,
-      user.player_id,
-    );
+    return this.service.getLoggedUserInfo(user.profile_id, user.player_id);
   }
 
   @Get('/:_id')


### PR DESCRIPTION
### Brief description

The bug with endpoints which exposed profile password is fixed. The problem was that the `@Serialize()` decorator does not work properly with the `@UniformResponse()` decorator or more precisely  with `FormatAPIResponseInterceptor` interceptor. 

In case when both of the decorators are in use the order in which they are applied matters, so as a solution I created a new interceptor for serialization: `SerializeInterceptor2`, which recognize `IServiceResponse` format tuples or objects and arrays returned by controller methods. And then this interceptor is added to the `@UniformResponse()` to the right order position. This interceptor should then be used everywhere where is the serialization is required and the `@UniformResponse()` is used.

### Change list

- Added new `SerializeInterceptor2` interceptor for `@UniformResponse()` decorators
- Added tests for the `SerializeInterceptor2` interceptor
- Add use of the `SerializeInterceptor2` interceptor to `@UniformResponse()`
