### PR TITLE
Fixed the tests of onlinePlayers service 

### DIFF
--- a/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
+++ b/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { OnlinePlayersService } from '../../../onlinePlayers/onlinePlayers.service';
-import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
+import { CacheModule } from '@nestjs/cache-manager';
 
 export default class OnlinePlayersCommonModule {
   private static module: TestingModule;
@@ -9,18 +9,7 @@ export default class OnlinePlayersCommonModule {
     if (!OnlinePlayersCommonModule.module)
       OnlinePlayersCommonModule.module = await Test.createTestingModule({
         imports: [CacheModule.register()],
-        providers: [
-          OnlinePlayersService,
-          // {
-          //   provide: CACHE_MANAGER,
-          //   useValue: {
-          //     set: jest.fn(),
-          //     store: {
-          //       keys: jest.fn(),
-          //     },
-          //   },
-          // },
-        ],
+        providers: [OnlinePlayersService],
       }).compile();
 
     return OnlinePlayersCommonModule.module;


### PR DESCRIPTION
This pull request includes changes to the `onlinePlayers` test cases and module. Changes include the removal of commented-out code and adding mock implementations for cache management in the ttl test.

Improvements to caching and service retrieval:

* [`src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts`](diffhunk://#diff-d3e96e1dc3fc90c7dc5a9da2d1697f36fc937980f54b5ba77281ba9615271d77L3-R3): Removed the `CACHE_MANAGER` import and the commented-out provider configuration for `CACHE_MANAGER`. [[1]](diffhunk://#diff-d3e96e1dc3fc90c7dc5a9da2d1697f36fc937980f54b5ba77281ba9615271d77L3-R3) [[2]](diffhunk://#diff-d3e96e1dc3fc90c7dc5a9da2d1697f36fc937980f54b5ba77281ba9615271d77L12-R12)

Enhancements to test cases:

* [`src/__tests__/onlinePlayers/service/getAllOnlinePlayers.test.ts`](diffhunk://#diff-8234a318c5bb0fc843ad82425dc0717e4a189a419efc6c1c12fe185d9ad569e0R35-R57): Added mock implementations for `cacheManager.set` and `cacheManager.store.keys` to simulate cache behavior during tests.
