### PR TITLE
Added endpoint for getting clan shop items

### DIFF
--- a/src/clanShop/clanShop.controller.ts
+++ b/src/clanShop/clanShop.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { ClanShopScheduler } from './clanShop.scheduler';
+import { UniformResponse } from '../common/decorator/response/UniformResponse';
+import { ModelName } from '../common/enum/modelName.enum';
+import { NoAuth } from '../auth/decorator/NoAuth.decorator';
+
+@Controller('clan-shop')
+export class ClanShopController {
+  constructor(private readonly clanShopScheduler: ClanShopScheduler) {}
+
+  @Get('items')
+  @NoAuth()
+  @UniformResponse(ModelName.ITEM)
+  getShopItems() {
+    return this.clanShopScheduler.currentShopItems;
+  }
+}

--- a/src/clanShop/clanShop.module.ts
+++ b/src/clanShop/clanShop.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ClanShopScheduler } from './clanShop.scheduler';
+import { ClanShopController } from './clanShop.controller';
 
 @Module({
   providers: [ClanShopScheduler],
+  controllers: [ClanShopController],
 })
 export class ClanShopModule {}


### PR DESCRIPTION
### Brief description

This PR adds a new controller for the clan shop feature in the api. The changes include the addition of the `ClanShopController` and an endpoint to get the shop items.


### Change list

- Added the `ClanShopController`
- Added `GET /clan-shop/items` endpoint to get the shop items.
- Added the new controller to the `ClanShopModule`.

