### PR TITLE
Added roles field to clan data

### DIFF
--- a/src/__tests__/clan/data/clan/ClanBuilder.ts
+++ b/src/__tests__/clan/data/clan/ClanBuilder.ts
@@ -5,6 +5,7 @@ import { Clan } from '../../../../clan/clan.schema';
 import { ClanLabel } from '../../../../clan/enum/clanLabel.enum';
 import { AgeRange } from '../../../../clan/enum/ageRange.enum';
 import { Goal } from '../../../../clan/enum/goal.enum';
+import { ClanRole } from '../../../../clan/role/ClanRole.schema';
 
 export default class ClanBuilder implements IDataBuilder<Clan> {
   private readonly base: Clan = {
@@ -24,6 +25,7 @@ export default class ClanBuilder implements IDataBuilder<Clan> {
     phrase: 'We are the best',
     language: Language.ENGLISH,
     clanLogo: { logoType: LogoType.HEART, pieceColors: ['#FFFFFF', '#000000'] },
+    roles: [],
   };
 
   // Returns a new Clan object with the current base properties
@@ -103,6 +105,11 @@ export default class ClanBuilder implements IDataBuilder<Clan> {
 
   setLanguage(language: Language) {
     this.base.language = language;
+    return this;
+  }
+
+  setRoles(roles: ClanRole[]) {
+    this.base.roles = roles;
     return this;
   }
 }

--- a/src/__tests__/player/PlayerService/getAll.test.ts
+++ b/src/__tests__/player/PlayerService/getAll.test.ts
@@ -130,8 +130,18 @@ describe('PlayerService.getAll() test suite', () => {
     });
 
     expect(errors).toBeNull();
-    expect(players[0].Clan).toEqual(expect.objectContaining(existingClan));
-    expect(players[1].Clan).toEqual(expect.objectContaining(existingClan));
+
+    const { roles: dbRoles1, ...clan1 } = (players[0].Clan as any).toObject();
+    const { roles: existingClanRoles1, ...clanWithoutRoles1 } = existingClan;
+
+    expect(clan1).toEqual(expect.objectContaining(clanWithoutRoles1));
+    expect(dbRoles1).toEqual(existingClanRoles1);
+
+    const { roles: dbRoles2, ...clan2 } = (players[1].Clan as any).toObject();
+    const { roles: existingClanRoles2, ...clanWithoutRoles2 } = existingClan;
+
+    expect(clan2).toEqual(expect.objectContaining(clanWithoutRoles2));
+    expect(dbRoles2).toEqual(existingClanRoles2);
   });
 
   it('Should ignore non-existing references requested', async () => {

--- a/src/__tests__/player/PlayerService/getPlayerById.test.ts
+++ b/src/__tests__/player/PlayerService/getPlayerById.test.ts
@@ -89,7 +89,12 @@ describe('PlayerService.getPlayerById() test suite', () => {
     );
 
     expect(errors).toBeNull();
-    expect(player.Clan).toEqual(expect.objectContaining(existingClan));
+
+    const { roles: dbRoles, ...clan } = (player.Clan as any).toObject();
+    const { roles: existingClanRoles, ...clanWithoutRoles } = existingClan;
+
+    expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));
+    expect(dbRoles).toEqual(existingClanRoles);
   });
 
   it('Should ignore non-existing references requested', async () => {

--- a/src/__tests__/player/PlayerService/readOneWithCollections.test.ts
+++ b/src/__tests__/player/PlayerService/readOneWithCollections.test.ts
@@ -44,9 +44,12 @@ describe('PlayerService.readWithCollections() test suite', () => {
       ModelName.CLAN,
     );
 
-    const data = resp['data']['Player'];
+    const { roles: dbRoles, ...clan } =
+      resp['data']['Player']['Clan'].toObject();
+    const { roles: existingClanRoles, ...clanWithoutRoles } = existingClan;
 
-    expect(data.Clan).toEqual(expect.objectContaining(existingClan));
+    expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));
+    expect(dbRoles).toEqual(existingClanRoles);
   });
 
   it('Should retrieve player without references if withQuery is empty', async () => {

--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -7,6 +7,8 @@ import { AgeRange } from './enum/ageRange.enum';
 import { Language } from '../common/enum/language.enum';
 import { Goal } from './enum/goal.enum';
 import { ClanLogo } from './clanLogo.schema';
+import { ClanRole, ClanRoleSchema } from './role/ClanRole.schema';
+import { initializationClanRoles } from './role/initializationClanRoles';
 
 export type ClanDocument = HydratedDocument<Clan>;
 
@@ -56,6 +58,13 @@ export class Clan {
 
   @Prop({ type: String, enum: Language, default: Language.NONE })
   language: Language;
+
+  @Prop({
+    type: [ClanRoleSchema],
+    required: true,
+    default: initializationClanRoles,
+  })
+  roles: ClanRole[];
 
   @ExtractField()
   _id: string;

--- a/src/clan/dto/clan.dto.ts
+++ b/src/clan/dto/clan.dto.ts
@@ -8,6 +8,7 @@ import { Goal } from '../enum/goal.enum';
 import { StockDto } from '../../clanInventory/stock/dto/stock.dto';
 import { SoulHomeDto } from '../../clanInventory/soulhome/dto/soulhome.dto';
 import { ClanLogoDto } from './clanLogo.dto';
+import ClanRoleDto from '../role/dto/clanRole.dto';
 
 @AddType('ClanDto')
 export class ClanDto {
@@ -60,6 +61,10 @@ export class ClanDto {
 
   @Expose()
   isOpen: boolean;
+
+  @Type(() => ClanRoleDto)
+  @Expose()
+  roles: ClanRoleDto[];
 
   @Type(() => PlayerDto)
   @Expose()

--- a/src/clan/role/ClanRole.schema.ts
+++ b/src/clan/role/ClanRole.schema.ts
@@ -1,0 +1,32 @@
+import { ClanBasicRight } from './enum/clanBasicRight.enum';
+import { ClanRoleType } from './enum/clanRoleType.enum';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ObjectId } from 'mongodb';
+
+/**
+ * Defines clan role structure
+ */
+@Schema({ toJSON: { virtuals: true }, toObject: { virtuals: true } })
+export class ClanRole {
+  /**
+   * Unique for clan name of the role
+   */
+  @Prop({ type: String, required: true })
+  name: string;
+
+  /**
+   * Type of the role
+   */
+  @Prop({ type: String, enum: ClanRoleType, required: true })
+  claRoleType: ClanRoleType;
+
+  /**
+   * Object with basic rights that the role has
+   */
+  @Prop({ type: Object, required: true })
+  rights: Partial<Record<ClanBasicRight, true>>;
+
+  _id: ObjectId;
+}
+
+export const ClanRoleSchema = SchemaFactory.createForClass(ClanRole);

--- a/src/clan/role/ClanRole.schema.ts
+++ b/src/clan/role/ClanRole.schema.ts
@@ -18,15 +18,36 @@ export class ClanRole {
    * Type of the role
    */
   @Prop({ type: String, enum: ClanRoleType, required: true })
-  claRoleType: ClanRoleType;
+  clanRoleType: ClanRoleType;
 
   /**
    * Object with basic rights that the role has
    */
-  @Prop({ type: Object, required: true })
+  @Prop({
+    type: Map,
+    of: Boolean,
+    required: true,
+    validate: {
+      validator: (map: Map<ClanBasicRight, true>) => areRightsValid(map),
+      message:
+        'Rights object must have a key which is a value of ClanBasicRight enum and the value is true',
+    },
+  })
   rights: Partial<Record<ClanBasicRight, true>>;
 
   _id: ObjectId;
 }
 
 export const ClanRoleSchema = SchemaFactory.createForClass(ClanRole);
+
+function areRightsValid(map: Map<ClanBasicRight, true>): boolean {
+  const allowedKeys = new Set(Object.values(ClanBasicRight));
+
+  for (const [key, value] of map.entries()) {
+    if (!allowedKeys.has(key)) return false;
+
+    if (value !== true) return false;
+  }
+
+  return true;
+}

--- a/src/clan/role/dto/clanRole.dto.ts
+++ b/src/clan/role/dto/clanRole.dto.ts
@@ -1,0 +1,19 @@
+import { ClanRoleType } from '../enum/clanRoleType.enum';
+import { ClanBasicRight } from '../enum/clanBasicRight.enum';
+import { Expose } from 'class-transformer';
+import { ExtractField } from '../../../common/decorator/response/ExtractField';
+
+export default class ClanRoleDto {
+  @ExtractField()
+  @Expose()
+  _id: string;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  claRoleType: ClanRoleType;
+
+  @Expose()
+  rights: Partial<Record<ClanBasicRight, true>>;
+}

--- a/src/clan/role/dto/clanRole.dto.ts
+++ b/src/clan/role/dto/clanRole.dto.ts
@@ -12,7 +12,7 @@ export default class ClanRoleDto {
   name: string;
 
   @Expose()
-  claRoleType: ClanRoleType;
+  clanRoleType: ClanRoleType;
 
   @Expose()
   rights: Partial<Record<ClanBasicRight, true>>;

--- a/src/clan/role/enum/clanBasicRight.enum.ts
+++ b/src/clan/role/enum/clanBasicRight.enum.ts
@@ -10,7 +10,7 @@ export enum ClanBasicRight {
   /**
    * Change clan data
    */
-  EDIT_CLAN_DATA = 'edit_clan.data',
+  EDIT_CLAN_DATA = 'edit_clan_data',
 
   /**
    * Add and remove any basic right of any clan member except for clan leaders. As well as change a role of any clan member.

--- a/src/clan/role/enum/clanBasicRight.enum.ts
+++ b/src/clan/role/enum/clanBasicRight.enum.ts
@@ -1,0 +1,30 @@
+/**
+ * Defines clan basic rights from which clan roles are built
+ */
+export enum ClanBasicRight {
+  /**
+   * Change items location in the soul home rooms
+   */
+  EDIT_SOULHOME = 'edit_soulhome',
+
+  /**
+   * Change clan data
+   */
+  EDIT_CLAN_DATA = 'edit_clan.data',
+
+  /**
+   * Add and remove any basic right of any clan member except for clan leaders. As well as change a role of any clan member.
+   */
+  EDIT_MEMBER_RIGHTS = 'edit_member_rights',
+
+  /**
+   * Create, update, delete any of the custom roles except default roles
+   */
+  MANAGE_ROLE = 'manage_role',
+
+  /**
+   * Buy / sell an item on the flea market or buy an item in clan shop.
+   * Notice that this is not a right for bypassing voting when buying or selling an item
+   */
+  SHOP = 'shop',
+}

--- a/src/clan/role/enum/clanRoleType.enum.ts
+++ b/src/clan/role/enum/clanRoleType.enum.ts
@@ -1,0 +1,16 @@
+export enum ClanRoleType {
+  /**
+   * Role, which each clan must have and which is read-only for everybody
+   */
+  DEFAULT = 'default',
+
+  /**
+   * Role, which player can create, update and delete. After such role is created, it can be set to any amount of clan members.
+   */
+  NAMED = 'named',
+
+  /**
+   * Role, which player can create, update and delete for an individual clan member. It is personal and can be set to only one clan member.
+   */
+  PERSONAL = 'personal',
+}

--- a/src/clan/role/initializationClanRoles.ts
+++ b/src/clan/role/initializationClanRoles.ts
@@ -30,7 +30,7 @@ export const MemberClanRole: Omit<ClanRole, '_id'> = {
  * Named role, which is used with clan default roles on initialization
  */
 export const ElderClanRole: Omit<ClanRole, '_id'> = {
-  name: 'member',
+  name: 'elder',
   claRoleType: ClanRoleType.NAMED,
   rights: {
     [ClanBasicRight.EDIT_SOULHOME]: true,

--- a/src/clan/role/initializationClanRoles.ts
+++ b/src/clan/role/initializationClanRoles.ts
@@ -1,0 +1,49 @@
+import { ClanRole } from './ClanRole.schema';
+import { ClanRoleType } from './enum/clanRoleType.enum';
+import { ClanBasicRight } from './enum/clanBasicRight.enum';
+
+/**
+ * Default role, which has all the basic rights
+ */
+export const LeaderClanRole: Omit<ClanRole, '_id'> = {
+  name: 'leader',
+  claRoleType: ClanRoleType.DEFAULT,
+  rights: {
+    [ClanBasicRight.EDIT_SOULHOME]: true,
+    [ClanBasicRight.EDIT_CLAN_DATA]: true,
+    [ClanBasicRight.EDIT_MEMBER_RIGHTS]: true,
+    [ClanBasicRight.MANAGE_ROLE]: true,
+    [ClanBasicRight.SHOP]: true,
+  },
+};
+
+/**
+ * Default role, which has no basic rights at all
+ */
+export const MemberClanRole: Omit<ClanRole, '_id'> = {
+  name: 'member',
+  claRoleType: ClanRoleType.DEFAULT,
+  rights: {},
+};
+
+/**
+ * Named role, which is used with clan default roles on initialization
+ */
+export const ElderClanRole: Omit<ClanRole, '_id'> = {
+  name: 'member',
+  claRoleType: ClanRoleType.NAMED,
+  rights: {
+    [ClanBasicRight.EDIT_SOULHOME]: true,
+    [ClanBasicRight.EDIT_CLAN_DATA]: true,
+    [ClanBasicRight.SHOP]: true,
+  },
+};
+
+/**
+ * All roles, which each clan should have on creation
+ */
+export const initializationClanRoles: Omit<ClanRole, '_id'>[] = [
+  LeaderClanRole,
+  MemberClanRole,
+  ElderClanRole,
+];


### PR DESCRIPTION
### Brief description

`roles` field is added to clan data containing clan roles data, as well as required enums and clan initialization roles (leader, elder and member).

### Change list

- Added schema for clan role
- Added enums `ClanBasicRight` and `ClanRoleType`
- Added `roles` field to clan schema and DTO
- Fixed failing tests after adding the `roles` field to clan schema
