### PR TITLE
Change/change array definitions in schemas 510

### DIFF
--- a/src/__tests__/clan/ClanService/updateOneById.test.ts
+++ b/src/__tests__/clan/ClanService/updateOneById.test.ts
@@ -110,7 +110,7 @@ describe('ClanService.updateOneById() test suite', () => {
     expect(wasUpdated).toBeTruthy();
 
     const updatedClan = await clanModel.findById(existingClan._id);
-    expect(updatedClan.admin_ids).toEqual([admin1._id]);
+    expect(updatedClan.admin_ids).toEqual([admin1._id.toString()]);
   });
 
   //TODO: strange behavior with _id fields for players and clans, if they are of different types (ObjectID or string)

--- a/src/box/schemas/box.schema.ts
+++ b/src/box/schemas/box.schema.ts
@@ -73,25 +73,25 @@ export class Box {
   /**
    * All clans that are related to the box
    */
-  @Prop({ type: Array<ObjectId>, required: true })
+  @Prop({ type: [ObjectId], required: true })
   clan_ids: ObjectId[];
 
   /**
    * All soul homes' _ids that are related to the box
    */
-  @Prop({ type: Array<ObjectId>, required: true })
+  @Prop({ type: [ObjectId], required: true })
   soulHome_ids: ObjectId[];
 
   /**
    * All rooms' _ids that are related to the box
    */
-  @Prop({ type: Array<ObjectId>, required: true })
+  @Prop({ type: [ObjectId], required: true })
   room_ids: ObjectId[];
 
   /**
    * All stocks' _ids that are related to the box
    */
-  @Prop({ type: Array<ObjectId>, required: true })
+  @Prop({ type: [ObjectId], required: true })
   stock_ids: ObjectId[];
 
   /**
@@ -110,7 +110,7 @@ export class Box {
    * Array of unique identifiers, which is used to identify the device sending the request to claim the profile.
    * Each identifier is unique within the box
    */
-  @Prop({ type: Array<string>, required: true, default: [] })
+  @Prop({ type: [String], required: true, default: [] })
   accountClaimersIds: string[];
 
   /**

--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -30,7 +30,7 @@ export class Clan {
   @Prop({ type: Number, default: 0 })
   points: number;
 
-  @Prop({ type: Array<string>, default: [] })
+  @Prop({ type: [String], default: [] })
   admin_ids: string[];
 
   @Prop({ type: Number, default: 1, min: 0 })

--- a/src/player/schemas/player.schema.ts
+++ b/src/player/schemas/player.schema.ts
@@ -46,7 +46,7 @@ export class Player {
   clan_id?: string;
 
   @ExtractField()
-  @Prop({ type: Array<ObjectId>, default: [] })
+  @Prop({ type: [ObjectId], default: [] })
   battleCharacter_ids?: string[] | ObjectId[];
 
   @Prop({ type: AvatarSchema, default: null })

--- a/src/voting/schemas/vote.schema.ts
+++ b/src/voting/schemas/vote.schema.ts
@@ -1,8 +1,9 @@
 import { Schema as MongooseSchema } from 'mongoose';
-import { Prop } from '@nestjs/mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { Choice } from '../type/choice.type';
 
+@Schema()
 export class Vote {
   @Prop({
     type: MongooseSchema.Types.ObjectId,
@@ -17,3 +18,5 @@ export class Vote {
   })
   choice: Choice;
 }
+
+export const VoteSchema = SchemaFactory.createForClass(Vote);

--- a/src/voting/schemas/voting.schema.ts
+++ b/src/voting/schemas/voting.schema.ts
@@ -2,7 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { HydratedDocument, Schema as MongooseSchema } from 'mongoose';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { VotingType } from '../enum/VotingType.enum';
-import { Vote } from './vote.schema';
+import { Vote, VoteSchema } from './vote.schema';
 import { Organizer } from './organizer.schema';
 
 export type VotingDocument = HydratedDocument<Voting>;
@@ -24,7 +24,7 @@ export class Voting {
   @Prop({ type: Number, default: 51 })
   minPercentage: number;
 
-  @Prop({ type: Array<Vote>, default: [] })
+  @Prop({ type: [VoteSchema], default: [] })
   votes: Vote[];
 
   @Prop({ type: MongooseSchema.Types.ObjectId })


### PR DESCRIPTION
### Brief description

This PR includes changes to schema array definitions from `Array<T>` to `[T]` and fix to a nested schema and one test that these changes broke.


### Change list
- Changed all schema prop types that were using `Array<T>` to ` [T].
- Added `@Schema()` decorator to the `Vote` class and created a `VoteSchema` using `SchemaFactory`.
- Updated the type definition for `votes` to use `[VoteSchema]` instead of `Array<Vote>`.
- Modified the test case to convert `admin1._id` to a string before comparison to ensure consistency in `ObjectId` handling.
