### PR TITLE
Set player_id field to null by default for daily tasks

### DIFF
--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -113,6 +113,7 @@ export default class SessionStarterService {
         amountLeft: dailyTask.amount,
         title: { fi: dailyTask.title },
         timeLimitMinutes: 30,
+        player_id: null,
         _id: undefined,
       };
     });

--- a/src/clan/role/ClanRole.schema.ts
+++ b/src/clan/role/ClanRole.schema.ts
@@ -35,7 +35,7 @@ export class ClanRole {
   })
   rights: Partial<Record<ClanBasicRight, true>>;
 
-  _id: ObjectId;
+  _id: ObjectId | string;
 }
 
 export const ClanRoleSchema = SchemaFactory.createForClass(ClanRole);

--- a/src/clan/role/initializationClanRoles.ts
+++ b/src/clan/role/initializationClanRoles.ts
@@ -7,7 +7,7 @@ import { ClanBasicRight } from './enum/clanBasicRight.enum';
  */
 export const LeaderClanRole: Omit<ClanRole, '_id'> = {
   name: 'leader',
-  claRoleType: ClanRoleType.DEFAULT,
+  clanRoleType: ClanRoleType.DEFAULT,
   rights: {
     [ClanBasicRight.EDIT_SOULHOME]: true,
     [ClanBasicRight.EDIT_CLAN_DATA]: true,
@@ -22,7 +22,7 @@ export const LeaderClanRole: Omit<ClanRole, '_id'> = {
  */
 export const MemberClanRole: Omit<ClanRole, '_id'> = {
   name: 'member',
-  claRoleType: ClanRoleType.DEFAULT,
+  clanRoleType: ClanRoleType.DEFAULT,
   rights: {},
 };
 
@@ -31,7 +31,7 @@ export const MemberClanRole: Omit<ClanRole, '_id'> = {
  */
 export const ElderClanRole: Omit<ClanRole, '_id'> = {
   name: 'elder',
-  claRoleType: ClanRoleType.NAMED,
+  clanRoleType: ClanRoleType.NAMED,
   rights: {
     [ClanBasicRight.EDIT_SOULHOME]: true,
     [ClanBasicRight.EDIT_CLAN_DATA]: true,

--- a/src/dailyTasks/dailyTasks.schema.ts
+++ b/src/dailyTasks/dailyTasks.schema.ts
@@ -14,8 +14,8 @@ export class DailyTask {
   @Prop({ type: MongooseSchema.Types.ObjectId, required: true })
   clan_id: string;
 
-  @Prop({ type: MongooseSchema.Types.ObjectId })
-  player_id?: string;
+  @Prop({ type: MongooseSchema.Types.ObjectId, default: null })
+  player_id: string | null;
 
   @Prop({ type: Object, required: true })
   title: TaskTitle;


### PR DESCRIPTION
### Brief description

Set the default value of `player_id` field in daily tasks to `null`, so that it could be easier to debug on the game side

### Change list

- Set the `player_id` field default value to `null`
- Set `player_id` to null for all daily tasks on server, which was not set
- Fix found bugs with `ClanRole` class
