### PR TITLE
Added endpoint to delete named role from clan

### DIFF
--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
@@ -1,0 +1,155 @@
+import ClanRoleService from '../../../../clan/role/clanRole.service';
+import ClanBuilderFactory from '../../data/clanBuilderFactory';
+import ClanModule from '../../modules/clan.module';
+import { ClanBasicRight } from '../../../../clan/role/enum/clanBasicRight.enum';
+import { ObjectId } from 'mongodb';
+import { SEReason } from '../../../../common/service/basicService/SEReason';
+import { ClanRoleType } from '../../../../clan/role/enum/clanRoleType.enum';
+
+describe('ClanRoleService.deleteOneById() test suite', () => {
+  let roleService: ClanRoleService;
+
+  const clanModel = ClanModule.getClanModel();
+  const roleBuilder = ClanBuilderFactory.getBuilder('ClanRole');
+  const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+
+  beforeEach(async () => {
+    roleService = await ClanModule.getClanRoleService();
+  });
+
+  it('Should delete a role if input is valid', async () => {
+    const newRoleName = 'my-new-role';
+    const newRoleId = new ObjectId();
+    
+    const roleToDelete = roleBuilder
+      .setId(newRoleId)
+      .setName(newRoleName)
+      .setClanRoleType(ClanRoleType.NAMED)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+
+    const existingClan = clanBuilder.setRoles([roleToDelete]).build();
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+
+    const clan = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, error] = await roleService.deleteOneById(
+      clan._id,
+      roleToDelete._id,
+    );
+    const clanResult = await clanModel.findById(existingClan._id);
+
+    expect(isSuccess).toBe(true);
+    expect(error).toBeNull();
+    expect(clanResult).not.toBeNull();
+    expect(clanResult?.roles).not.toContainEqual(roleToDelete);
+  });
+
+  it('Should return with error if the provided ClanRole_ID not exists', async () => {
+    const existingClan = clanBuilder.build();
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+
+    const clan = await clanModel.findById(existingClan._id);
+
+    const nonExistingRoleId = new ObjectId();
+    const [isSuccess, error] = await roleService.deleteOneById(
+      clan._id,
+      nonExistingRoleId,
+    );
+
+    expect(isSuccess).toBe(null);
+    expect(error).not.toBe(null);
+    expect(error[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(error[0].field).toBe('_id');
+    expect(error[0].value).toBe(nonExistingRoleId);
+    expect(error[0].message).toBe('ClanRole not found');
+  });
+
+  it('Should return with error if role has default type', async () => {
+    const newRoleName = 'my-new-role';
+    const newRoleId = new ObjectId();
+    const roleType = ClanRoleType.DEFAULT;
+    const roleToDelete = roleBuilder
+      .setId(newRoleId)
+      .setName(newRoleName)
+      .setClanRoleType(roleType)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+
+    const existingClan = clanBuilder.setRoles([roleToDelete]).build();
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+
+    const clanBeforeDelete = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, error] = await roleService.deleteOneById(
+      clanBeforeDelete._id,
+      roleToDelete._id,
+    );
+  
+    expect(isSuccess).toBe(null);
+    expect(error).not.toBeNull();
+    expect(error[0].reason).toBe(SEReason.VALIDATION);
+    expect(error[0].field).toBe('_id');
+    expect(error[0].value).toBe(newRoleId);
+    expect(error[0].message).toBe(`Cannot delete ${roleType} role`);
+
+    const clanResult = await clanModel.findById(existingClan._id);
+    expect(clanResult).not.toBeNull();
+    const roleNotDeleted = clanResult?.roles.find(
+      (role) => role._id.toString() === roleToDelete._id.toString(),
+    );
+    const roleToDeleteFromDB = clanBeforeDelete?.roles.find(
+      (role) => role._id.toString() === roleToDelete._id.toString(),
+    );
+    expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
+  });
+
+  it('Should return with error if role has personal type', async () => {
+    const newRoleName = 'my-new-role';
+    const newRoleId = new ObjectId();
+    const roleType = ClanRoleType.PERSONAL;
+    const roleToDelete = roleBuilder
+      .setId(newRoleId)
+      .setName(newRoleName)
+      .setClanRoleType(roleType)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+
+    const existingClan = clanBuilder.setRoles([roleToDelete]).build();
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+
+    const clanBeforeDelete = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, error] = await roleService.deleteOneById(
+      clanBeforeDelete._id,
+      roleToDelete._id,
+    );
+  
+    expect(isSuccess).toBe(null);
+    expect(error).not.toBeNull();
+    expect(error[0].reason).toBe(SEReason.VALIDATION);
+    expect(error[0].field).toBe('_id');
+    expect(error[0].value).toBe(newRoleId);
+    expect(error[0].message).toBe(`Cannot delete ${roleType} role`);
+
+    const clanResult = await clanModel.findById(existingClan._id);
+    expect(clanResult).not.toBeNull();
+    const roleNotDeleted = clanResult?.roles.find(
+      (role) => role._id.toString() === roleToDelete._id.toString(),
+    );
+    const roleToDeleteFromDB = clanBeforeDelete?.roles.find(
+      (role) => role._id.toString() === roleToDelete._id.toString(),
+    );
+    expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
+  });
+});

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
@@ -20,7 +20,7 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
   it('Should delete a role if input is valid', async () => {
     const roleForDelete_Name = 'my-new-role';
     const roleForDelete_Id = new ObjectId();
-    
+
     const roleToDelete = roleBuilder
       .setId(roleForDelete_Id)
       .setName(roleForDelete_Name)
@@ -93,7 +93,7 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
       clanBeforeDelete._id,
       roleToDelete._id,
     );
-    
+
     const clanAfterDelete = await clanModel.findById(existingClan._id);
 
     const roleNotDeleted = clanAfterDelete?.roles.find(
@@ -102,7 +102,7 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     const roleToDeleteFromDB = clanBeforeDelete?.roles.find(
       (role) => role._id.toString() === roleToDelete._id.toString(),
     );
-    
+
     expect(isSuccess).toBe(null);
     expect(error).not.toBeNull();
     expect(error[0].reason).toBe(SEReason.VALIDATION);
@@ -111,7 +111,7 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
 
     expect(clanAfterDelete).not.toBeNull();
-    
+
     expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
   });
 

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
@@ -18,12 +18,12 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
   });
 
   it('Should delete a role if input is valid', async () => {
-    const newRoleName = 'my-new-role';
-    const newRoleId = new ObjectId();
+    const roleForDelete_Name = 'my-new-role';
+    const roleForDelete_Id = new ObjectId();
     
     const roleToDelete = roleBuilder
-      .setId(newRoleId)
-      .setName(newRoleName)
+      .setId(roleForDelete_Id)
+      .setName(roleForDelete_Name)
       .setClanRoleType(ClanRoleType.NAMED)
       .setRights({
         [ClanBasicRight.EDIT_CLAN_DATA]: true,
@@ -34,18 +34,18 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
 
-    const clan = await clanModel.findById(existingClan._id);
+    const clanBeforeDelete = await clanModel.findById(existingClan._id);
 
     const [isSuccess, error] = await roleService.deleteOneById(
-      clan._id,
+      clanBeforeDelete._id,
       roleToDelete._id,
     );
-    const clanResult = await clanModel.findById(existingClan._id);
+    const clanAfterDelete = await clanModel.findById(existingClan._id);
 
     expect(isSuccess).toBe(true);
     expect(error).toBeNull();
-    expect(clanResult).not.toBeNull();
-    expect(clanResult?.roles).not.toContainEqual(roleToDelete);
+    expect(clanAfterDelete).not.toBeNull();
+    expect(clanAfterDelete?.roles).not.toContainEqual(roleToDelete);
   });
 
   it('Should return with error if the provided ClanRole_ID not exists', async () => {
@@ -53,30 +53,31 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
 
-    const clan = await clanModel.findById(existingClan._id);
+    const clanBeforeDelete = await clanModel.findById(existingClan._id);
 
-    const nonExistingRoleId = new ObjectId();
+    const nonExistingRole_Id = new ObjectId();
     const [isSuccess, error] = await roleService.deleteOneById(
-      clan._id,
-      nonExistingRoleId,
+      clanBeforeDelete._id,
+      nonExistingRole_Id,
     );
 
     expect(isSuccess).toBe(null);
     expect(error).not.toBe(null);
     expect(error[0].reason).toBe(SEReason.NOT_FOUND);
     expect(error[0].field).toBe('_id');
-    expect(error[0].value).toBe(nonExistingRoleId);
+    expect(error[0].value).toBe(nonExistingRole_Id);
     expect(error[0].message).toBe('ClanRole not found');
   });
 
   it('Should return with error if role has default type', async () => {
-    const newRoleName = 'my-new-role';
-    const newRoleId = new ObjectId();
-    const roleType = ClanRoleType.DEFAULT;
+    const roleForDelete_Name = 'my-new-role';
+    const roleForDelete_Id = new ObjectId();
+    const roleForDelete_Type = ClanRoleType.DEFAULT;
+
     const roleToDelete = roleBuilder
-      .setId(newRoleId)
-      .setName(newRoleName)
-      .setClanRoleType(roleType)
+      .setId(roleForDelete_Id)
+      .setName(roleForDelete_Name)
+      .setClanRoleType(roleForDelete_Type)
       .setRights({
         [ClanBasicRight.EDIT_CLAN_DATA]: true,
       })
@@ -92,33 +93,36 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
       clanBeforeDelete._id,
       roleToDelete._id,
     );
-  
-    expect(isSuccess).toBe(null);
-    expect(error).not.toBeNull();
-    expect(error[0].reason).toBe(SEReason.VALIDATION);
-    expect(error[0].field).toBe('_id');
-    expect(error[0].value).toBe(newRoleId);
-    expect(error[0].message).toBe(`Cannot delete ${roleType} role`);
+    
+    const clanAfterDelete = await clanModel.findById(existingClan._id);
 
-    const clanResult = await clanModel.findById(existingClan._id);
-    expect(clanResult).not.toBeNull();
-    const roleNotDeleted = clanResult?.roles.find(
+    const roleNotDeleted = clanAfterDelete?.roles.find(
       (role) => role._id.toString() === roleToDelete._id.toString(),
     );
     const roleToDeleteFromDB = clanBeforeDelete?.roles.find(
       (role) => role._id.toString() === roleToDelete._id.toString(),
     );
+    
+    expect(isSuccess).toBe(null);
+    expect(error).not.toBeNull();
+    expect(error[0].reason).toBe(SEReason.VALIDATION);
+    expect(error[0].field).toBe('_id');
+    expect(error[0].value).toBe(roleForDelete_Id);
+    expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
+
+    expect(clanAfterDelete).not.toBeNull();
+    
     expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
   });
 
   it('Should return with error if role has personal type', async () => {
-    const newRoleName = 'my-new-role';
-    const newRoleId = new ObjectId();
-    const roleType = ClanRoleType.PERSONAL;
+    const roleForDelete_Name = 'my-new-role';
+    const roleForDelete_Id = new ObjectId();
+    const roleForDelete_Type = ClanRoleType.PERSONAL;
     const roleToDelete = roleBuilder
-      .setId(newRoleId)
-      .setName(newRoleName)
-      .setClanRoleType(roleType)
+      .setId(roleForDelete_Id)
+      .setName(roleForDelete_Name)
+      .setClanRoleType(roleForDelete_Type)
       .setRights({
         [ClanBasicRight.EDIT_CLAN_DATA]: true,
       })
@@ -134,22 +138,23 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
       clanBeforeDelete._id,
       roleToDelete._id,
     );
-  
-    expect(isSuccess).toBe(null);
-    expect(error).not.toBeNull();
-    expect(error[0].reason).toBe(SEReason.VALIDATION);
-    expect(error[0].field).toBe('_id');
-    expect(error[0].value).toBe(newRoleId);
-    expect(error[0].message).toBe(`Cannot delete ${roleType} role`);
 
-    const clanResult = await clanModel.findById(existingClan._id);
-    expect(clanResult).not.toBeNull();
-    const roleNotDeleted = clanResult?.roles.find(
+    const clanAfterDelete = await clanModel.findById(existingClan._id);
+    expect(clanAfterDelete).not.toBeNull();
+    const roleNotDeleted = clanAfterDelete?.roles.find(
       (role) => role._id.toString() === roleToDelete._id.toString(),
     );
     const roleToDeleteFromDB = clanBeforeDelete?.roles.find(
       (role) => role._id.toString() === roleToDelete._id.toString(),
     );
+
+    expect(isSuccess).toBe(null);
+    expect(error).not.toBeNull();
+    expect(error[0].reason).toBe(SEReason.VALIDATION);
+    expect(error[0].field).toBe('_id');
+    expect(error[0].value).toBe(roleForDelete_Id);
+    expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
+
     expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
   });
 });

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
@@ -105,8 +105,8 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
 
     expect(isSuccess).toBe(null);
     expect(error).not.toBeNull();
-    expect(error[0].reason).toBe(SEReason.VALIDATION);
-    expect(error[0].field).toBe('_id');
+    expect(error[0].reason).toBe(SEReason.NOT_ALLOWED);
+    expect(error[0].field).toBe('clanRoleType');
     expect(error[0].value).toBe(roleForDelete_Id);
     expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
 
@@ -150,8 +150,8 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
 
     expect(isSuccess).toBe(null);
     expect(error).not.toBeNull();
-    expect(error[0].reason).toBe(SEReason.VALIDATION);
-    expect(error[0].field).toBe('_id');
+    expect(error[0].reason).toBe(SEReason.NOT_ALLOWED);
+    expect(error[0].field).toBe('clanRoleType');
     expect(error[0].value).toBe(roleForDelete_Id);
     expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
 

--- a/src/clan/role/clanRole.controller.ts
+++ b/src/clan/role/clanRole.controller.ts
@@ -10,6 +10,9 @@ import ClanRoleService from './clanRole.service';
 import { CreateClanRoleDto } from './dto/createClanRole.dto';
 import DetermineClanId from '../../common/guard/clanId.guard';
 import { _idDto } from '../../common/dto/_id.dto';
+import { SEReason } from '../../common/service/basicService/SEReason';
+import { APIError } from '../../common/controller/APIError';
+import { APIErrorReason } from '../../common/controller/APIErrorReason';
 
 @Controller('clan/role')
 export class ClanRoleController {
@@ -35,6 +38,23 @@ export class ClanRoleController {
       user?.clan_id,
       param?._id,
     );
+
+    if (
+      errors &&
+      errors[0].field === 'clanRoleType' &&
+      errors[0].reason === SEReason.NOT_ALLOWED
+    ) {
+      return [
+        null,
+        [
+          new APIError({
+            ...errors[0],
+            reason: APIErrorReason.NOT_AUTHORIZED,
+          }),
+        ],
+      ];
+    }
+
     if (errors) return [null, errors];
   }
 }

--- a/src/clan/role/clanRole.controller.ts
+++ b/src/clan/role/clanRole.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { LoggedUser } from '../../common/decorator/param/LoggedUser.decorator';
@@ -9,6 +9,7 @@ import ClanRoleDto from './dto/clanRole.dto';
 import ClanRoleService from './clanRole.service';
 import { CreateClanRoleDto } from './dto/createClanRole.dto';
 import DetermineClanId from '../../common/guard/clanId.guard';
+import { _idDto } from '../../common/dto/_id.dto';
 
 @Controller('clan/role')
 export class ClanRoleController {
@@ -23,5 +24,14 @@ export class ClanRoleController {
     @LoggedUser() user: User,
   ) {
     return this.service.createOne(body, user.clan_id);
+  }
+
+  @Delete('/:_id')
+  @HasClanRights([ClanBasicRight.MANAGE_ROLE])
+  @DetermineClanId()
+  @UniformResponse()
+  public async delete(@Param() param: _idDto, @LoggedUser() user: User) {
+    const [, errors] = await this.service.deleteOneById(user?.clan_id, param?._id);
+    if (errors) return [null, errors];
   }
 }

--- a/src/clan/role/clanRole.controller.ts
+++ b/src/clan/role/clanRole.controller.ts
@@ -31,7 +31,10 @@ export class ClanRoleController {
   @DetermineClanId()
   @UniformResponse()
   public async delete(@Param() param: _idDto, @LoggedUser() user: User) {
-    const [, errors] = await this.service.deleteOneById(user?.clan_id, param?._id);
+    const [, errors] = await this.service.deleteOneById(
+      user?.clan_id,
+      param?._id,
+    );
     if (errors) return [null, errors];
   }
 }

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -22,6 +22,7 @@ export default class ClanRoleService {
   ) {
     this.basicService = new BasicService(model);
   }
+
   public readonly basicService: BasicService;
 
   /**
@@ -95,7 +96,7 @@ export default class ClanRoleService {
     return [createdRole, null];
   }
 
-/**
+  /**
    * Deletes a ClanRole by its _id from DB.
    * @param clan_id - The Mongo _id of the Clan where from the role to delete.
    * @param role_id - The Mongo _id of the ClanRole to delete.
@@ -106,7 +107,6 @@ export default class ClanRoleService {
     clan_id: string | ObjectId,
     role_id: string | ObjectId,
   ): Promise<[true | null, ServiceError[] | null]> {
-    
     const [clan] = await this.basicService.readOneById<Clan>(
       clan_id.toString(),
     );
@@ -115,9 +115,10 @@ export default class ClanRoleService {
       (role) => role._id.toString() === role_id.toString(),
     );
 
-    const [isValidDefault, errorDefault] = await this.validateClanRoleDeleteRequest(roleToDelete, role_id);
+    const [isValidDefault, errorDefault] =
+      await this.validateClanRoleDeleteRequest(roleToDelete, role_id);
     if (!isValidDefault) return [isValidDefault, errorDefault];
-    
+
     await this.model.updateOne(
       { _id: clan_id },
       { $pull: { roles: { _id: role_id } } },
@@ -129,7 +130,6 @@ export default class ClanRoleService {
     roleToDelete: ClanRole,
     role_id: string | ObjectId,
   ): Promise<[true | null, ServiceError[] | null]> {
-    
     if (!roleToDelete) {
       return [
         null,
@@ -144,12 +144,20 @@ export default class ClanRoleService {
       ];
     }
 
-    const [isNotDefault, errorDefault] = await this.validateClanRoleType(roleToDelete, ClanRoleType.DEFAULT, role_id);
+    const [isNotDefault, errorDefault] = await this.validateClanRoleType(
+      roleToDelete,
+      ClanRoleType.DEFAULT,
+      role_id,
+    );
     if (!isNotDefault) return [isNotDefault, errorDefault];
 
-    const [isNotPersonal, errorPersonal] = await this.validateClanRoleType(roleToDelete, ClanRoleType.PERSONAL, role_id);
+    const [isNotPersonal, errorPersonal] = await this.validateClanRoleType(
+      roleToDelete,
+      ClanRoleType.PERSONAL,
+      role_id,
+    );
     if (!isNotPersonal) return [isNotPersonal, errorPersonal];
-    
+
     if (roleToDelete.clanRoleType.toString() != ClanRoleType.NAMED.toString()) {
       return [
         null,

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -94,4 +94,22 @@ export default class ClanRoleService {
 
     return [createdRole, null];
   }
+
+/**
+   * Deletes a ClanRole by its _id from DB.
+   * @param clan_id - The Mongo _id of the Clan where from the role to delete.
+   * @param role_id - The Mongo _id of the ClanRole to delete.
+   * @returns _true_ if ClanRole was removed successfully,
+   * or a ServiceError array if the ClanRole was not found or something else went wrong
+   */
+  async deleteOneById(
+    clan_id: string | ObjectId,
+    role_id: string | ObjectId,
+  ): Promise<[true | null, ServiceError[] | null]> {
+    await this.model.updateOne(
+      { _id: clan_id },
+      { $pull: { roles: { _id: role_id } } },
+    );
+    return [true, null];
+  }
 }

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -158,12 +158,14 @@ export default class ClanRoleService {
     );
     if (!isNotPersonal) return [isNotPersonal, errorPersonal];
 
-    if (roleToDelete.clanRoleType.toString() != ClanRoleType.NAMED.toString()) {
+    if (
+      roleToDelete.clanRoleType.toString() !== ClanRoleType.NAMED.toString()
+    ) {
       return [
         null,
         [
           new ServiceError({
-            reason: SEReason.VALIDATION,
+            reason: SEReason.NOT_ALLOWED,
             field: 'clanRoleType',
             value: roleToDelete?.clanRoleType,
             message: 'Can delete only named role',
@@ -185,8 +187,8 @@ export default class ClanRoleService {
         null,
         [
           new ServiceError({
-            reason: SEReason.VALIDATION,
-            field: '_id',
+            reason: SEReason.NOT_ALLOWED,
+            field: 'clanRoleType',
             value: role_id,
             message: `Cannot delete ${roleType} role`,
           }),

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -115,7 +115,7 @@ export default class ClanRoleService {
       (role) => role._id.toString() === role_id.toString(),
     );
 
-    const [isValidDefault, errorDefault] = await this.validateClanRoleDeleteRequest(roleToDelete);
+    const [isValidDefault, errorDefault] = await this.validateClanRoleDeleteRequest(roleToDelete, role_id);
     if (!isValidDefault) return [isValidDefault, errorDefault];
     
     await this.model.updateOne(
@@ -127,6 +127,7 @@ export default class ClanRoleService {
 
   private async validateClanRoleDeleteRequest(
     roleToDelete: ClanRole,
+    role_id: string | ObjectId,
   ): Promise<[true | null, ServiceError[] | null]> {
     
     if (!roleToDelete) {
@@ -136,17 +137,17 @@ export default class ClanRoleService {
           new ServiceError({
             reason: SEReason.NOT_FOUND,
             field: '_id',
-            value: roleToDelete._id,
+            value: role_id,
             message: 'ClanRole not found',
           }),
         ],
       ];
     }
 
-    const [isNotDefault, errorDefault] = await this.validateClanRoleType(roleToDelete, ClanRoleType.DEFAULT);
+    const [isNotDefault, errorDefault] = await this.validateClanRoleType(roleToDelete, ClanRoleType.DEFAULT, role_id);
     if (!isNotDefault) return [isNotDefault, errorDefault];
 
-    const [isNotPersonal, errorPersonal] = await this.validateClanRoleType(roleToDelete, ClanRoleType.PERSONAL);
+    const [isNotPersonal, errorPersonal] = await this.validateClanRoleType(roleToDelete, ClanRoleType.PERSONAL, role_id);
     if (!isNotPersonal) return [isNotPersonal, errorPersonal];
     
     if (roleToDelete.clanRoleType.toString() != ClanRoleType.NAMED.toString()) {
@@ -169,6 +170,7 @@ export default class ClanRoleService {
   private async validateClanRoleType(
     role: ClanRole,
     roleType: ClanRoleType,
+    role_id: string | ObjectId = null,
   ): Promise<[true | null, ServiceError[] | null]> {
     if (role.clanRoleType === roleType) {
       return [
@@ -177,7 +179,7 @@ export default class ClanRoleService {
           new ServiceError({
             reason: SEReason.VALIDATION,
             field: '_id',
-            value: role._id,
+            value: role_id,
             message: `Cannot delete ${roleType} role`,
           }),
         ],

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -156,8 +156,8 @@ export default class ClanRoleService {
         [
           new ServiceError({
             reason: SEReason.VALIDATION,
-            field: '_id',
-            value: roleToDelete,
+            field: 'clanRoleType',
+            value: roleToDelete?.clanRoleType,
             message: 'Can delete only named role',
           }),
         ],


### PR DESCRIPTION
### Brief description

Create the endpoint for deleting a clan role by its _id field.
Add tests that cover the delete clan role functionality.


### Change list

- clanRole.controller: add delete Create the endpoint for deleting a clan role by its _id field
- clanRolse.servcie: add deleteOneById, validateClanRoleDeleteRequest and validateClanRoleType methods
- Add ClanRoleService.deleteOneById() test suite
