### PR TITLE
Added endpoint for updating clan role

### DIFF
--- a/src/__tests__/clan/data/clanBuilderFactory.ts
+++ b/src/__tests__/clan/data/clanBuilderFactory.ts
@@ -6,6 +6,7 @@ import UpdateClanDtoBuilder from './clan/UpdateClanDtoBuilder';
 import JoinBuilder from './clan/join/JoinBuilder';
 import ClanRoleBuilder from './role/ClanRoleBuilder';
 import CreateClanRoleDtoBuilder from './role/CreateClanRoleDtoBuilder';
+import UpdateClanRoleDtoBuilder from './role/UpdateClanRoleDtoBuilder';
 
 type BuilderName =
   | 'CreateClanDto'
@@ -15,7 +16,8 @@ type BuilderName =
   | 'RemovePlayerDTO'
   | 'Join'
   | 'ClanRole'
-  | 'CreateClanRoleDto';
+  | 'CreateClanRoleDto'
+  | 'UpdateClanRoleDto';
 
 type BuilderMap = {
   CreateClanDto: CreateClanDtoBuilder;
@@ -26,6 +28,7 @@ type BuilderMap = {
   Join: JoinBuilder;
   ClanRole: ClanRoleBuilder;
   CreateClanRoleDto: CreateClanRoleDtoBuilder;
+  UpdateClanRoleDto: UpdateClanRoleDtoBuilder;
 };
 
 export default class ClanBuilderFactory {
@@ -47,6 +50,8 @@ export default class ClanBuilderFactory {
         return new ClanRoleBuilder() as BuilderMap[T];
       case 'CreateClanRoleDto':
         return new CreateClanRoleDtoBuilder() as BuilderMap[T];
+      case 'UpdateClanRoleDto':
+        return new UpdateClanRoleDtoBuilder() as BuilderMap[T];
       default:
         throw new Error(`Unknown builder name: ${builderName}`);
     }

--- a/src/__tests__/clan/data/role/UpdateClanRoleDtoBuilder.ts
+++ b/src/__tests__/clan/data/role/UpdateClanRoleDtoBuilder.ts
@@ -1,0 +1,33 @@
+import { ClanBasicRight } from '../../../../clan/role/enum/clanBasicRight.enum';
+import IDataBuilder from '../../../test_utils/interface/IDataBuilder';
+import { UpdateClanRoleDto } from '../../../../clan/role/dto/updateClanRole.dto';
+import { ObjectId } from 'mongodb';
+
+export default class UpdateClanRoleDtoBuilder
+  implements IDataBuilder<UpdateClanRoleDto>
+{
+  private readonly base: UpdateClanRoleDto = {
+    _id: undefined,
+    name: undefined,
+    rights: undefined,
+  };
+
+  build() {
+    return { ...this.base } as UpdateClanRoleDto;
+  }
+
+  setId(_id: string | ObjectId) {
+    this.base._id = _id as any;
+    return this;
+  }
+
+  setName(name: string) {
+    this.base.name = name;
+    return this;
+  }
+
+  setRights(rights: Partial<Record<ClanBasicRight, true>>) {
+    this.base.rights = rights;
+    return this;
+  }
+}

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.deleteOneById.test.ts
@@ -65,8 +65,8 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     expect(error).not.toBe(null);
     expect(error[0].reason).toBe(SEReason.NOT_FOUND);
     expect(error[0].field).toBe('_id');
-    expect(error[0].value).toBe(nonExistingRole_Id);
-    expect(error[0].message).toBe('ClanRole not found');
+    expect(error[0].value).toBe(nonExistingRole_Id.toString());
+    expect(error[0].message).toBe('Role with this _id is not found');
   });
 
   it('Should return with error if role has default type', async () => {
@@ -107,8 +107,8 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     expect(error).not.toBeNull();
     expect(error[0].reason).toBe(SEReason.NOT_ALLOWED);
     expect(error[0].field).toBe('clanRoleType');
-    expect(error[0].value).toBe(roleForDelete_Id);
-    expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
+    expect(error[0].value).toBe(roleForDelete_Type);
+    expect(error[0].message).toBe(`Can process only role with type named`);
 
     expect(clanAfterDelete).not.toBeNull();
 
@@ -152,8 +152,8 @@ describe('ClanRoleService.deleteOneById() test suite', () => {
     expect(error).not.toBeNull();
     expect(error[0].reason).toBe(SEReason.NOT_ALLOWED);
     expect(error[0].field).toBe('clanRoleType');
-    expect(error[0].value).toBe(roleForDelete_Id);
-    expect(error[0].message).toBe(`Cannot delete ${roleForDelete_Type} role`);
+    expect(error[0].value).toBe(roleForDelete_Type);
+    expect(error[0].message).toBe(`Can process only role with type named`);
 
     expect(roleNotDeleted).toEqual(roleToDeleteFromDB);
   });

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.updateOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.updateOneById.test.ts
@@ -1,0 +1,270 @@
+import ClanRoleService from '../../../../clan/role/clanRole.service';
+import ClanBuilderFactory from '../../data/clanBuilderFactory';
+import ClanModule from '../../modules/clan.module';
+import { ClanBasicRight } from '../../../../clan/role/enum/clanBasicRight.enum';
+import { ObjectId } from 'mongodb';
+import ServiceError from '../../../../common/service/basicService/ServiceError';
+import { SEReason } from '../../../../common/service/basicService/SEReason';
+import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
+
+describe('ClanRoleService.updateOneById() test suite', () => {
+  let roleService: ClanRoleService;
+
+  const clanModel = ClanModule.getClanModel();
+  const updateRoleBuilder = ClanBuilderFactory.getBuilder('UpdateClanRoleDto');
+  const roleBuilder = ClanBuilderFactory.getBuilder('ClanRole');
+  const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+  const existingRole = roleBuilder
+    .setName('existing-role')
+    .setRights({
+      [ClanBasicRight.EDIT_CLAN_DATA]: true,
+    })
+    .build();
+  const existingClan = clanBuilder.setRoles([existingRole]).build();
+
+  beforeEach(async () => {
+    roleService = await ClanModule.getClanRoleService();
+
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+    existingRole._id = existingClan.roles[0]._id;
+  });
+
+  it('Should update a role if its data is unique and return true', async () => {
+    const newRoleName = 'new-name';
+    const roleToUpdate = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName(newRoleName)
+      .build();
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    const [isUpdated, errors] = await roleService.updateOneById(roleToUpdate);
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+
+    expect(errors).toBeNull();
+    expect(isUpdated).toBe(true);
+    expect(clanAfter.toObject().roles).toMatchObject([
+      ...clanBefore.toObject().roles,
+      {
+        ...existingRole,
+        name: newRoleName,
+      },
+    ]);
+  });
+
+  it('Should not update a role if clan already has a role with this name', async () => {
+    const sameName = 'same-role-name';
+    const oldRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const newRoleName = 'new-name';
+    const roleToUpdate = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName(newRoleName)
+      .build();
+
+    const sameNameRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    await roleService.createOne(sameNameRole, existingClan._id);
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+
+    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
+    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
+  });
+
+  it('Should not return errors if role name is not unique for the same role', async () => {
+    const sameName = 'same-role-name';
+    const oldRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const sameNameRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    await roleService.createOne(sameNameRole, existingClan._id);
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+
+    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
+    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
+  });
+
+  it('Should not return errors if role rights are not unique for the same role', async () => {
+    const sameName = 'same-role-name';
+    const oldRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const sameNameRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    await roleService.createOne(sameNameRole, existingClan._id);
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+
+    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
+    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
+  });
+
+  it('Should return NOT_UNIQUE error if clan already has a role with this name', async () => {
+    const sameName = 'same-role-name';
+    const oldRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const sameNameRole = roleBuilder
+      .setName(sameName)
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const [createdRole, errors] = await roleService.createOne(
+      sameNameRole,
+      existingClan._id,
+    );
+
+    expect(createdRole).toBeNull();
+    expect(errors).toContainSE_NOT_UNIQUE();
+    expect(errors[0]).toMatchObject(
+      new ServiceError({
+        reason: SEReason.NOT_UNIQUE,
+        field: 'name',
+        value: sameName,
+        message: 'Role with this name already exists',
+      }),
+    );
+  });
+
+  it('Should not update a role if clan already has a role with same rights', async () => {
+    const sameRights: Partial<Record<ClanBasicRight, true>> = {
+      [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      [ClanBasicRight.SHOP]: true,
+    };
+    const oldRole = roleBuilder
+      .setName('old-role-name')
+      .setRights(sameRights)
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const sameRightsRole = roleBuilder
+      .setName('new-role-name')
+      .setRights(sameRights)
+      .build();
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    await roleService.createOne(sameRightsRole, existingClan._id);
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+
+    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
+    expect(clanAfter.toObject().roles).not.toContain(sameRightsRole);
+  });
+
+  it('Should return NOT_UNIQUE error if clan already has a role with same rights', async () => {
+    const sameRights: Partial<Record<ClanBasicRight, true>> = {
+      [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      [ClanBasicRight.SHOP]: true,
+    };
+    const oldRole = roleBuilder
+      .setName('old-role-name')
+      .setRights(sameRights)
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+
+    const sameRightsRole = roleBuilder
+      .setName('new-role-name')
+      .setRights(sameRights)
+      .build();
+
+    const [createdRole, errors] = await roleService.createOne(
+      sameRightsRole,
+      existingClan._id,
+    );
+
+    expect(createdRole).toBeNull();
+    expect(errors).toContainSE_NOT_UNIQUE();
+    expect(errors[0]).toMatchObject(
+      new ServiceError({
+        reason: SEReason.NOT_UNIQUE,
+        field: 'rights',
+        value: sameRights,
+        message: 'Role with the same rights already exists',
+      }),
+    );
+  });
+
+  it('Should return NOT_FOUND error if clan does not exists', async () => {
+    const roleToCreate = roleBuilder
+      .setName('my-new-role')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+
+    const [createdRole, errors] = await roleService.createOne(
+      roleToCreate,
+      getNonExisting_id(),
+    );
+
+    expect(createdRole).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+  });
+
+  it('Should return NOT_FOUND error if role does not exists', async () => {
+    const roleToCreate = roleBuilder
+      .setName('my-new-role')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+
+    const [createdRole, errors] = await roleService.createOne(
+      roleToCreate,
+      getNonExisting_id(),
+    );
+
+    expect(createdRole).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+  });
+});

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.updateOneById.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.updateOneById.test.ts
@@ -2,10 +2,12 @@ import ClanRoleService from '../../../../clan/role/clanRole.service';
 import ClanBuilderFactory from '../../data/clanBuilderFactory';
 import ClanModule from '../../modules/clan.module';
 import { ClanBasicRight } from '../../../../clan/role/enum/clanBasicRight.enum';
-import { ObjectId } from 'mongodb';
 import ServiceError from '../../../../common/service/basicService/ServiceError';
 import { SEReason } from '../../../../common/service/basicService/SEReason';
 import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
+import { ObjectId } from 'mongodb';
+import { ClanRole } from '../../../../clan/role/ClanRole.schema';
+import { ClanRoleType } from '../../../../clan/role/enum/clanRoleType.enum';
 
 describe('ClanRoleService.updateOneById() test suite', () => {
   let roleService: ClanRoleService;
@@ -17,7 +19,7 @@ describe('ClanRoleService.updateOneById() test suite', () => {
   const existingRole = roleBuilder
     .setName('existing-role')
     .setRights({
-      [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      [ClanBasicRight.SHOP]: true,
     })
     .build();
   const existingClan = clanBuilder.setRoles([existingRole]).build();
@@ -27,244 +29,374 @@ describe('ClanRoleService.updateOneById() test suite', () => {
 
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
-    existingRole._id = existingClan.roles[0]._id;
+    existingClan.roles = createdClan.roles;
+    existingRole._id = createdClan.roles.find(
+      (role) => role.name === existingRole.name,
+    )._id;
   });
 
   it('Should update a role if its data is unique and return true', async () => {
-    const newRoleName = 'new-name';
-    const roleToUpdate = updateRoleBuilder
+    const updatingData = updateRoleBuilder
       .setId(existingRole._id)
-      .setName(newRoleName)
-      .build();
-
-    const clanBefore = await clanModel.findById(existingClan._id);
-
-    const [isUpdated, errors] = await roleService.updateOneById(roleToUpdate);
-
-    const clanAfter = await clanModel.findById(existingClan._id);
-
-    expect(errors).toBeNull();
-    expect(isUpdated).toBe(true);
-    expect(clanAfter.toObject().roles).toMatchObject([
-      ...clanBefore.toObject().roles,
-      {
-        ...existingRole,
-        name: newRoleName,
-      },
-    ]);
-  });
-
-  it('Should not update a role if clan already has a role with this name', async () => {
-    const sameName = 'same-role-name';
-    const oldRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      })
-      .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
-
-    const newRoleName = 'new-name';
-    const roleToUpdate = updateRoleBuilder
-      .setId(existingRole._id)
-      .setName(newRoleName)
-      .build();
-
-    const sameNameRole = roleBuilder
-      .setName(sameName)
+      .setName('new-role-name')
       .setRights({
         [ClanBasicRight.MANAGE_ROLE]: true,
       })
       .build();
 
-    const clanBefore = await clanModel.findById(existingClan._id);
-
-    await roleService.createOne(sameNameRole, existingClan._id);
-
-    const clanAfter = await clanModel.findById(existingClan._id);
-
-    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
-    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
-  });
-
-  it('Should not return errors if role name is not unique for the same role', async () => {
-    const sameName = 'same-role-name';
-    const oldRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      })
-      .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
-
-    const sameNameRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.MANAGE_ROLE]: true,
-      })
-      .build();
-
-    const clanBefore = await clanModel.findById(existingClan._id);
-
-    await roleService.createOne(sameNameRole, existingClan._id);
-
-    const clanAfter = await clanModel.findById(existingClan._id);
-
-    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
-    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
-  });
-
-  it('Should not return errors if role rights are not unique for the same role', async () => {
-    const sameName = 'same-role-name';
-    const oldRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      })
-      .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
-
-    const sameNameRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.MANAGE_ROLE]: true,
-      })
-      .build();
-
-    const clanBefore = await clanModel.findById(existingClan._id);
-
-    await roleService.createOne(sameNameRole, existingClan._id);
-
-    const clanAfter = await clanModel.findById(existingClan._id);
-
-    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
-    expect(clanAfter.toObject().roles).not.toContain(sameNameRole);
-  });
-
-  it('Should return NOT_UNIQUE error if clan already has a role with this name', async () => {
-    const sameName = 'same-role-name';
-    const oldRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      })
-      .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
-
-    const sameNameRole = roleBuilder
-      .setName(sameName)
-      .setRights({
-        [ClanBasicRight.MANAGE_ROLE]: true,
-      })
-      .build();
-
-    const [createdRole, errors] = await roleService.createOne(
-      sameNameRole,
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
       existingClan._id,
     );
 
-    expect(createdRole).toBeNull();
+    const updatedRole = await getRoleDataByName(
+      existingClan._id,
+      updatingData.name,
+    );
+
+    expect(errors).toBeNull();
+    expect(isUpdated).toBe(true);
+    expect(updatedRole.name).toBe(updatingData.name);
+    expect(updatedRole.rights).toEqual(updatingData.rights);
+  });
+
+  it('Should not return errors if role name is not unique for the same role', async () => {
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName(existingRole.name)
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(errors).toBeNull();
+    expect(isUpdated).toBe(true);
+  });
+
+  it('Should not return errors if role rights are not unique for the same role', async () => {
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName('new-role-name')
+      .setRights(existingRole.rights)
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(errors).toBeNull();
+    expect(isUpdated).toBe(true);
+  });
+
+  it('Should not update a role if clan already has a role with this name', async () => {
+    const role2 = roleBuilder
+      .setName('role-2')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    const roles = await addClanRoles(existingClan._id, [role2]);
+    const anotherRole = roles[0];
+
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName(anotherRole.name)
+      .build();
+
+    await roleService.updateOneById(updatingData, existingClan._id);
+
+    const updatedRole = await getRoleDataByName(
+      existingClan._id,
+      existingRole.name,
+    );
+
+    expect(updatedRole.name).toBe(existingRole.name);
+  });
+
+  it('Should return NOT_UNIQUE error if clan already has a role with this name', async () => {
+    const role2 = roleBuilder
+      .setName('role-2')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    const roles = await addClanRoles(existingClan._id, [role2]);
+    const anotherRole = roles[0];
+
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
+      .setName(anotherRole.name)
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(isUpdated).toBeNull();
     expect(errors).toContainSE_NOT_UNIQUE();
     expect(errors[0]).toMatchObject(
       new ServiceError({
         reason: SEReason.NOT_UNIQUE,
         field: 'name',
-        value: sameName,
+        value: updatingData.name,
         message: 'Role with this name already exists',
       }),
     );
   });
 
   it('Should not update a role if clan already has a role with same rights', async () => {
-    const sameRights: Partial<Record<ClanBasicRight, true>> = {
-      [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      [ClanBasicRight.SHOP]: true,
-    };
-    const oldRole = roleBuilder
-      .setName('old-role-name')
-      .setRights(sameRights)
+    const role2 = roleBuilder
+      .setName('role-2')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
       .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+    const roles = await addClanRoles(existingClan._id, [role2]);
+    const anotherRole = roles[0];
 
-    const sameRightsRole = roleBuilder
-      .setName('new-role-name')
-      .setRights(sameRights)
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
+      .setRights(anotherRole.rights)
       .build();
 
-    const clanBefore = await clanModel.findById(existingClan._id);
+    await roleService.updateOneById(updatingData, existingClan._id);
 
-    await roleService.createOne(sameRightsRole, existingClan._id);
+    const updatedRole = await getRoleDataByName(
+      existingClan._id,
+      existingRole.name,
+    );
 
-    const clanAfter = await clanModel.findById(existingClan._id);
-
-    expect(clanAfter.roles).toHaveLength(clanBefore.roles.length);
-    expect(clanAfter.toObject().roles).not.toContain(sameRightsRole);
+    expect(updatedRole.rights).toEqual(existingRole.rights);
   });
 
   it('Should return NOT_UNIQUE error if clan already has a role with same rights', async () => {
-    const sameRights: Partial<Record<ClanBasicRight, true>> = {
-      [ClanBasicRight.EDIT_CLAN_DATA]: true,
-      [ClanBasicRight.SHOP]: true,
-    };
-    const oldRole = roleBuilder
-      .setName('old-role-name')
-      .setRights(sameRights)
+    const role2 = roleBuilder
+      .setName('role-2')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
       .build();
-    await clanModel.findByIdAndUpdate(existingClan._id, { roles: [oldRole] });
+    const roles = await addClanRoles(existingClan._id, [role2]);
+    const anotherRole = roles[0];
 
-    const sameRightsRole = roleBuilder
+    const updatingData = updateRoleBuilder
+      .setId(existingRole._id)
       .setName('new-role-name')
-      .setRights(sameRights)
+      .setRights(anotherRole.rights)
       .build();
 
-    const [createdRole, errors] = await roleService.createOne(
-      sameRightsRole,
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
       existingClan._id,
     );
 
-    expect(createdRole).toBeNull();
+    expect(isUpdated).toBeNull();
     expect(errors).toContainSE_NOT_UNIQUE();
     expect(errors[0]).toMatchObject(
       new ServiceError({
         reason: SEReason.NOT_UNIQUE,
         field: 'rights',
-        value: sameRights,
+        value: updatingData.rights,
         message: 'Role with the same rights already exists',
       }),
     );
   });
 
-  it('Should return NOT_FOUND error if clan does not exists', async () => {
-    const roleToCreate = roleBuilder
-      .setName('my-new-role')
+  it('Should not update a role if its type is default', async () => {
+    const role = roleBuilder
+      .setClanRoleType(ClanRoleType.DEFAULT)
+      .setName('default-role')
       .setRights({
         [ClanBasicRight.EDIT_CLAN_DATA]: true,
       })
       .build();
+    const roles = await addClanRoles(existingClan._id, [role]);
+    const defaultRole = roles[0];
 
-    const [createdRole, errors] = await roleService.createOne(
-      roleToCreate,
-      getNonExisting_id(),
+    const updatingData = updateRoleBuilder
+      .setId(defaultRole._id)
+      .setName('new-role-name')
+      .build();
+
+    await roleService.updateOneById(updatingData, existingClan._id);
+
+    const updatedRole = await getRoleDataByName(
+      existingClan._id,
+      defaultRole.name,
     );
 
-    expect(createdRole).toBeNull();
+    expect(updatedRole.name).toBe(defaultRole.name);
+  });
+
+  it('Should return NOT_ALLOWED error if its type is default', async () => {
+    const role = roleBuilder
+      .setClanRoleType(ClanRoleType.DEFAULT)
+      .setName('default-role')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    const roles = await addClanRoles(existingClan._id, [role]);
+    const defaultRole = roles[0];
+
+    const updatingData = updateRoleBuilder
+      .setId(defaultRole._id)
+      .setName('new-role-name')
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(isUpdated).toBeNull();
+    expect(errors).toContainSE_NOT_ALLOWED();
+    expect(errors[0]).toMatchObject(
+      new ServiceError({
+        reason: SEReason.NOT_ALLOWED,
+        field: 'clanRoleType',
+        value: defaultRole.clanRoleType,
+        message: 'Can process only role with type named',
+      }),
+    );
+  });
+
+  it('Should not update a role if its type is personal', async () => {
+    const role = roleBuilder
+      .setClanRoleType(ClanRoleType.PERSONAL)
+      .setName('default-role')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    const roles = await addClanRoles(existingClan._id, [role]);
+    const personalRole = roles[0];
+
+    const updatingData = updateRoleBuilder
+      .setId(personalRole._id)
+      .setName('new-role-name')
+      .build();
+
+    await roleService.updateOneById(updatingData, existingClan._id);
+
+    const updatedRole = await getRoleDataByName(
+      existingClan._id,
+      personalRole.name,
+    );
+
+    expect(updatedRole.name).toBe(personalRole.name);
+  });
+
+  it('Should return NOT_ALLOWED error if its type is personal', async () => {
+    const role = roleBuilder
+      .setClanRoleType(ClanRoleType.PERSONAL)
+      .setName('personal-role')
+      .setRights({
+        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+      })
+      .build();
+    const roles = await addClanRoles(existingClan._id, [role]);
+    const personalRole = roles[0];
+
+    const updatingData = updateRoleBuilder
+      .setId(personalRole._id)
+      .setName('new-role-name')
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(isUpdated).toBeNull();
+    expect(errors).toContainSE_NOT_ALLOWED();
+    expect(errors[0]).toMatchObject(
+      new ServiceError({
+        reason: SEReason.NOT_ALLOWED,
+        field: 'clanRoleType',
+        value: personalRole.clanRoleType,
+        message: 'Can process only role with type named',
+      }),
+    );
+  });
+
+  it('Should return NOT_FOUND error if clan does not exists', async () => {
+    await clanModel.findByIdAndDelete(existingClan._id);
+    const updatingData = updateRoleBuilder
+      .setId(new ObjectId())
+      .setName('new-role-name')
+      .setRights({
+        [ClanBasicRight.MANAGE_ROLE]: true,
+      })
+      .build();
+
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
+    );
+
+    expect(isUpdated).toBeNull();
     expect(errors).toContainSE_NOT_FOUND();
   });
 
   it('Should return NOT_FOUND error if role does not exists', async () => {
-    const roleToCreate = roleBuilder
-      .setName('my-new-role')
+    const updatingData = updateRoleBuilder
+      .setId(getNonExisting_id())
+      .setName('new-role-name')
       .setRights({
-        [ClanBasicRight.EDIT_CLAN_DATA]: true,
+        [ClanBasicRight.MANAGE_ROLE]: true,
       })
       .build();
 
-    const [createdRole, errors] = await roleService.createOne(
-      roleToCreate,
-      getNonExisting_id(),
+    const [isUpdated, errors] = await roleService.updateOneById(
+      updatingData,
+      existingClan._id,
     );
 
-    expect(createdRole).toBeNull();
+    expect(isUpdated).toBeNull();
     expect(errors).toContainSE_NOT_FOUND();
   });
+
+  /**
+   * Adds clan roles to a clan
+   * @param clan_id clan _id where to add
+   * @param roles roles to be added
+   * @returns added roles
+   */
+  async function addClanRoles(
+    clan_id: string | ObjectId,
+    roles: Partial<ClanRole>[],
+  ) {
+    const updatedClan = await clanModel.findByIdAndUpdate(
+      clan_id,
+      {
+        $push: { roles: { $each: roles } },
+      },
+      { new: true },
+    );
+
+    const roleNames = roles.map((role) => role.name);
+    return updatedClan.roles.filter((role) => roleNames.includes(role.name));
+  }
+
+  /**
+   * Gets a role from a specified clan by its name
+   * @param clan_id clan _id where to search
+   * @param roleName role name
+   * @returns found role
+   */
+  async function getRoleDataByName(
+    clan_id: string | ObjectId,
+    roleName: string,
+  ) {
+    const clan = await clanModel.findById(clan_id);
+    return clan.roles.find((role) => role.name === roleName);
+  }
 });

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -11,6 +11,7 @@ import { doesRoleWithRightsExists, isRoleNameExists } from './clanRoleUtils';
 import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
 import { ClanRoleType } from './enum/clanRoleType.enum';
+import { UpdateClanRoleDto } from './dto/updateClanRole.dto';
 
 /**
  * Manages clan roles
@@ -94,6 +95,24 @@ export default class ClanRoleService {
     );
 
     return [createdRole, null];
+  }
+
+  /**
+   * Updates specified role by provided _id
+   *
+   * Notice that the role name must be unique inside the clan and there should not be a role with exact same rights.
+   *
+   * @param roleToUpdate role data to update
+   *
+   * @returns true if role was updated or ServiceError if:
+   * - NOT_UNIQUE clan has role with that name or there is a role with the same rights.
+   * Notice that it does not apply to the own data of role being updated
+   * - NOT_FOUND if the clan or role could not be found
+   */
+  async updateOneById(
+    roleToUpdate: UpdateClanRoleDto,
+  ): Promise<IServiceReturn<true>> {
+    return null;
   }
 
   /**

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -12,6 +12,7 @@ import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
 import { ClanRoleType } from './enum/clanRoleType.enum';
 import { UpdateClanRoleDto } from './dto/updateClanRole.dto';
+import * as trace_events from 'node:trace_events';
 
 /**
  * Manages clan roles
@@ -48,31 +49,11 @@ export default class ClanRoleService {
 
     if (clanReadingErrors) return [null, clanReadingErrors];
 
-    if (isRoleNameExists(clan.roles, roleToCreate.name))
-      return [
-        null,
-        [
-          new ServiceError({
-            reason: SEReason.NOT_UNIQUE,
-            field: 'name',
-            value: roleToCreate.name,
-            message: 'Role with this name already exists',
-          }),
-        ],
-      ];
-
-    if (doesRoleWithRightsExists(clan.roles.toObject(), roleToCreate.rights))
-      return [
-        null,
-        [
-          new ServiceError({
-            reason: SEReason.NOT_UNIQUE,
-            field: 'rights',
-            value: roleToCreate.rights,
-            message: 'Role with the same rights already exists',
-          }),
-        ],
-      ];
+    const [, uniquenessErrors] = this.validateClanRoleUniqueness(
+      roleToCreate,
+      clan.roles,
+    );
+    if (uniquenessErrors) return [null, uniquenessErrors];
 
     const newRole: Omit<ClanRole, '_id'> = {
       ...roleToCreate,
@@ -103,6 +84,7 @@ export default class ClanRoleService {
    * Notice that the role name must be unique inside the clan and there should not be a role with exact same rights.
    *
    * @param roleToUpdate role data to update
+   * @param clan_id clan which role will be updated
    *
    * @returns true if role was updated or ServiceError if:
    * - NOT_UNIQUE clan has role with that name or there is a role with the same rights.
@@ -111,8 +93,49 @@ export default class ClanRoleService {
    */
   async updateOneById(
     roleToUpdate: UpdateClanRoleDto,
+    clan_id: string | ObjectId,
   ): Promise<IServiceReturn<true>> {
-    return null;
+    const [clan, clanReadingErrors] = await this.basicService.readOneById<Clan>(
+      clan_id.toString(),
+    );
+
+    if (clanReadingErrors) return [null, clanReadingErrors];
+
+    const [role, roleNotExistsErrors] = this.findRoleFromRoles(
+      roleToUpdate._id,
+      clan.roles,
+    );
+    if (roleNotExistsErrors) return [null, roleNotExistsErrors];
+
+    const [, roleTypeErrors] = this.validateRoleIsNamed(role);
+    if (roleTypeErrors) return [null, roleTypeErrors];
+
+    const clanRolesWithoutUpdating = clan.roles.filter(
+      (role) => role._id.toString() !== roleToUpdate._id.toString(),
+    );
+
+    const [, uniquenessErrors] = this.validateClanRoleUniqueness(
+      roleToUpdate,
+      clanRolesWithoutUpdating,
+    );
+    if (uniquenessErrors) return [null, uniquenessErrors];
+
+    await this.model.updateOne(
+      {
+        _id: clan_id,
+        'roles._id': roleToUpdate._id,
+      },
+      {
+        $set: Object.fromEntries(
+          Object.entries(roleToUpdate).map(([key, value]) => [
+            `roles.$.${key}`,
+            value,
+          ]),
+        ),
+      },
+    );
+
+    return [true, null];
   }
 
   /**
@@ -130,12 +153,15 @@ export default class ClanRoleService {
       clan_id.toString(),
     );
 
-    const roleToDelete = clan.roles.find(
-      (role) => role._id.toString() === role_id.toString(),
+    const [roleToDelete, roleExistenceErrors] = this.findRoleFromRoles(
+      role_id,
+      clan.roles,
     );
 
+    if (roleExistenceErrors) return [null, roleExistenceErrors];
+
     const [isValidDefault, errorDefault] =
-      await this.validateClanRoleDeleteRequest(roleToDelete, role_id);
+      this.validateRoleIsNamed(roleToDelete);
     if (!isValidDefault) return [isValidDefault, errorDefault];
 
     await this.model.updateOne(
@@ -145,49 +171,64 @@ export default class ClanRoleService {
     return [true, null];
   }
 
-  private async validateClanRoleDeleteRequest(
-    roleToDelete: ClanRole,
-    role_id: string | ObjectId,
-  ): Promise<[true | null, ServiceError[] | null]> {
-    if (!roleToDelete) {
+  /**
+   * Validates clan role uniqueness (its name and rights)
+   * @param roleToValidate role to validate
+   * @param roles role array, where to check
+   * @private
+   *
+   * @returns true if the role is unique or ServiceErrors if any found
+   */
+  private validateClanRoleUniqueness(
+    roleToValidate: Partial<ClanRole>,
+    roles: ClanRole[],
+  ): IServiceReturn<true> {
+    if (isRoleNameExists(roles, roleToValidate.name))
       return [
         null,
         [
           new ServiceError({
-            reason: SEReason.NOT_FOUND,
-            field: '_id',
-            value: role_id,
-            message: 'ClanRole not found',
+            reason: SEReason.NOT_UNIQUE,
+            field: 'name',
+            value: roleToValidate.name,
+            message: 'Role with this name already exists',
           }),
         ],
       ];
-    }
 
-    const [isNotDefault, errorDefault] = await this.validateClanRoleType(
-      roleToDelete,
-      ClanRoleType.DEFAULT,
-      role_id,
-    );
-    if (!isNotDefault) return [isNotDefault, errorDefault];
+    if (doesRoleWithRightsExists(roles, roleToValidate.rights))
+      return [
+        null,
+        [
+          new ServiceError({
+            reason: SEReason.NOT_UNIQUE,
+            field: 'rights',
+            value: roleToValidate.rights,
+            message: 'Role with the same rights already exists',
+          }),
+        ],
+      ];
+    return [true, null];
+  }
 
-    const [isNotPersonal, errorPersonal] = await this.validateClanRoleType(
-      roleToDelete,
-      ClanRoleType.PERSONAL,
-      role_id,
-    );
-    if (!isNotPersonal) return [isNotPersonal, errorPersonal];
-
-    if (
-      roleToDelete.clanRoleType.toString() !== ClanRoleType.NAMED.toString()
-    ) {
+  /**
+   * Validates that the role is of type named
+   * @param roleToValidate role to validate
+   * @private
+   * @returns true if its type is named or ServiceError not allowed if the type is not named
+   */
+  private validateRoleIsNamed(
+    roleToValidate: Partial<ClanRole>,
+  ): IServiceReturn<true> {
+    if (roleToValidate.clanRoleType !== ClanRoleType.NAMED) {
       return [
         null,
         [
           new ServiceError({
             reason: SEReason.NOT_ALLOWED,
             field: 'clanRoleType',
-            value: roleToDelete?.clanRoleType,
-            message: 'Can delete only named role',
+            value: roleToValidate.clanRoleType,
+            message: 'Can process only role with type named',
           }),
         ],
       ];
@@ -196,25 +237,33 @@ export default class ClanRoleService {
     return [true, null];
   }
 
-  private async validateClanRoleType(
-    role: ClanRole,
-    roleType: ClanRoleType,
-    role_id: string | ObjectId = null,
-  ): Promise<[true | null, ServiceError[] | null]> {
-    if (role.clanRoleType === roleType) {
+  /**
+   * Finds a role from a specified array of roles by _id
+   * @param role_id _id of the role to find
+   * @param roles where to search
+   * @private
+   * @returns found role or ServiceError NOT_FOUND if the role was not found
+   */
+  private findRoleFromRoles(
+    role_id: string | ObjectId,
+    roles: ClanRole[],
+  ): IServiceReturn<ClanRole> {
+    const foundRole = roles.find(
+      (role) => role._id.toString() === role_id.toString(),
+    );
+    if (!foundRole)
       return [
         null,
         [
           new ServiceError({
-            reason: SEReason.NOT_ALLOWED,
-            field: 'clanRoleType',
-            value: role_id,
-            message: `Cannot delete ${roleType} role`,
+            reason: SEReason.NOT_FOUND,
+            field: '_id',
+            value: role_id.toString(),
+            message: 'Role with this _id is not found',
           }),
         ],
       ];
-    }
 
-    return [true, null];
+    return [foundRole, null];
   }
 }

--- a/src/clan/role/dto/updateClanRole.dto.ts
+++ b/src/clan/role/dto/updateClanRole.dto.ts
@@ -1,0 +1,18 @@
+import { IsMongoId, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ClanBasicRight } from '../enum/clanBasicRight.enum';
+import IsRoleRights from '../decorator/validation/IsRoleRights.decorator';
+import { CLAN_ROLE_MAX_LENGTH } from '../const/validation';
+
+export class UpdateClanRoleDto {
+  @IsMongoId()
+  _id: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(CLAN_ROLE_MAX_LENGTH)
+  name?: string;
+
+  @IsOptional()
+  @IsRoleRights()
+  rights?: Partial<Record<ClanBasicRight, true>>;
+}


### PR DESCRIPTION
### Brief description

Added endpoint to update a named role _/clan/role_ PUT. Notice that default and personal clan roles are not allowed to be changed via this endpoint.

### Change list

- Added _/clan/role_ PUT
- Refactored `ClanRoleService`
- Added tests for the `ClanRoleService`
