### PR TITLE
The online players now returns an object containing name and id

### DIFF
--- a/src/__tests__/onlinePlayers/modules/onlinePlayers.module.ts
+++ b/src/__tests__/onlinePlayers/modules/onlinePlayers.module.ts
@@ -1,6 +1,9 @@
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import { OnlinePlayersService } from '../../../onlinePlayers/onlinePlayers.service';
 import OnlinePlayersCommonModule from './onlinePlayersCommon.module';
+import mongoose from 'mongoose';
+import { ModelName } from '../../../common/enum/modelName.enum';
+import { PlayerSchema } from '../../../player/schemas/player.schema';
 
 export default class OnlinePlayersModule {
   static async getOnlinePlayersService() {
@@ -11,5 +14,9 @@ export default class OnlinePlayersModule {
   static async getCacheManager() {
     const module = await OnlinePlayersCommonModule.getModule();
     return module.resolve<Cache>(CACHE_MANAGER);
+  }
+
+  static getPlayerModel() {
+    return mongoose.model(ModelName.PLAYER, PlayerSchema);
   }
 }

--- a/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
+++ b/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { OnlinePlayersService } from '../../../onlinePlayers/onlinePlayers.service';
 import { CacheModule } from '@nestjs/cache-manager';
+import { PlayerModule } from '../../../player/player.module';
+import { RequestHelperModule } from '../../../requestHelper/requestHelper.module';
+import { MongooseModule } from '@nestjs/mongoose';
+import { mongooseOptions, mongoString } from '../../test_utils/const/db';
 
 export default class OnlinePlayersCommonModule {
   private static module: TestingModule;
@@ -8,7 +12,12 @@ export default class OnlinePlayersCommonModule {
   static async getModule() {
     if (!OnlinePlayersCommonModule.module)
       OnlinePlayersCommonModule.module = await Test.createTestingModule({
-        imports: [CacheModule.register()],
+        imports: [
+          MongooseModule.forRoot(mongoString, mongooseOptions),
+          CacheModule.register(),
+          PlayerModule,
+          RequestHelperModule,
+        ],
         providers: [OnlinePlayersService],
       }).compile();
 

--- a/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
+++ b/src/__tests__/onlinePlayers/modules/onlinePlayersCommon.module.ts
@@ -5,6 +5,8 @@ import { PlayerModule } from '../../../player/player.module';
 import { RequestHelperModule } from '../../../requestHelper/requestHelper.module';
 import { MongooseModule } from '@nestjs/mongoose';
 import { mongooseOptions, mongoString } from '../../test_utils/const/db';
+import { ModelName } from '../../../common/enum/modelName.enum';
+import { PlayerSchema } from '../../../player/schemas/player.schema';
 
 export default class OnlinePlayersCommonModule {
   private static module: TestingModule;
@@ -14,6 +16,9 @@ export default class OnlinePlayersCommonModule {
       OnlinePlayersCommonModule.module = await Test.createTestingModule({
         imports: [
           MongooseModule.forRoot(mongoString, mongooseOptions),
+          MongooseModule.forFeature([
+            { name: ModelName.PLAYER, schema: PlayerSchema },
+          ]),
           CacheModule.register(),
           PlayerModule,
           RequestHelperModule,

--- a/src/onlinePlayers/onlinePlayers.controller.ts
+++ b/src/onlinePlayers/onlinePlayers.controller.ts
@@ -11,7 +11,7 @@ export class OnlinePlayersController {
   @Post('ping')
   @UniformResponse()
   async ping(@LoggedUser() user: User) {
-    this.onlinePlayersService.addPlayerOnline(user.player_id);
+    return this.onlinePlayersService.addPlayerOnline(user.player_id);
   }
 
   @Get()

--- a/src/onlinePlayers/onlinePlayers.module.ts
+++ b/src/onlinePlayers/onlinePlayers.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { OnlinePlayersService } from './onlinePlayers.service';
 import { OnlinePlayersController } from './onlinePlayers.controller';
+import { PlayerModule } from '../player/player.module';
 
 @Module({
+  imports: [PlayerModule],
   providers: [OnlinePlayersService],
   controllers: [OnlinePlayersController],
 })

--- a/src/onlinePlayers/onlinePlayers.service.ts
+++ b/src/onlinePlayers/onlinePlayers.service.ts
@@ -1,8 +1,8 @@
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 import { CacheKeys } from '../common/enum/cacheKeys.enum';
-import { PlayerService } from 'src/player/player.service';
-import { IServiceReturn } from 'src/common/service/basicService/IService';
+import { PlayerService } from '../player/player.service';
+import { IServiceReturn } from '../common/service/basicService/IService';
 
 @Injectable()
 export class OnlinePlayersService {

--- a/src/onlinePlayers/onlinePlayers.service.ts
+++ b/src/onlinePlayers/onlinePlayers.service.ts
@@ -1,13 +1,18 @@
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import { Inject, Injectable } from '@nestjs/common';
 import { CacheKeys } from '../common/enum/cacheKeys.enum';
+import { PlayerService } from 'src/player/player.service';
+import { IServiceReturn } from 'src/common/service/basicService/IService';
 
 @Injectable()
 export class OnlinePlayersService {
   private readonly ONLINE_PLAYERS_KEY = CacheKeys.ONLINE_PLAYERS;
   private readonly PLAYER_TTL = 300; // Time-to-live in seconds (5 minutes)
 
-  constructor(@Inject(CACHE_MANAGER) private cacheService: Cache) {}
+  constructor(
+    @Inject(CACHE_MANAGER) private cacheService: Cache,
+    private readonly playerService: PlayerService,
+  ) {}
 
   /**
    * Adds a player to the online players list by storing their status in the cache.
@@ -15,21 +20,33 @@ export class OnlinePlayersService {
    * @param playerId - The unique identifier of the player to be marked as online.
    * @returns A promise that resolves when the player's online status is successfully stored.
    */
-  async addPlayerOnline(playerId: string): Promise<void> {
-    await this.cacheService.set(`${this.ONLINE_PLAYERS_KEY}:${playerId}`, '1', {
-      ttl: this.PLAYER_TTL,
-    } as any);
+  async addPlayerOnline(playerId: string): Promise<IServiceReturn<void>> {
+    const [player, error] = await this.playerService.getPlayerById(playerId);
+    if (error) return [null, error];
+
+    const payload = {
+      id: playerId,
+      name: player.name,
+    };
+
+    await this.cacheService.set(
+      `${this.ONLINE_PLAYERS_KEY}:${JSON.stringify(payload)}`,
+      '1',
+      {
+        ttl: this.PLAYER_TTL,
+      } as any,
+    );
   }
 
   /**
-   * Gets all the online players and returns their IDs.
+   * Gets all the online players and returns data as JSON object.
    *
    * This method fetches all keys from the cache that match the pattern
-   * for online players and returns the player IDs.
+   * for online players.
    *
-   * @returns Array of player IDs.
+   * @returns Array of player name and id as JSON objects.
    */
-  async getAllOnlinePlayers(): Promise<string[]> {
+  async getAllOnlinePlayers(): Promise<{ id: string; name: string }[]> {
     const players = await this.cacheService.store.keys(
       `${this.ONLINE_PLAYERS_KEY}:*`,
     );
@@ -37,7 +54,8 @@ export class OnlinePlayersService {
     if (!players) return [];
 
     const ids = players.map((player) => {
-      return player.replace(`${this.ONLINE_PLAYERS_KEY}:`, '');
+      const playerData = player.replace(`${this.ONLINE_PLAYERS_KEY}:`, '');
+      return JSON.parse(playerData);
     });
 
     return ids;


### PR DESCRIPTION
### Brief description
This pull request makes a change to the data caching of online players. The cache now stores and returns objects containing player name and id instead of just id.


### Change list

- Updated the `ping` method in `OnlinePlayersController` to return the result of `addPlayerOnline`, since the method can now throw.
- Added `PlayerModule` as an import in `OnlinePlayersModule` to enable the use of `PlayerService` within the `OnlinePlayersService`.
- Updated `addPlayerOnline` in `OnlinePlayersService` to fetch player details using `PlayerService` and store both the player ID and name in the cache.
- Modified `getAllOnlinePlayers` in `OnlinePlayersService` to return an array of JSON objects containing player IDs and names, instead of just IDs.

