### PR TITLE
Replace Serialize decorator with UniformResponse

### DIFF
--- a/src/box/box.controller.ts
+++ b/src/box/box.controller.ts
@@ -14,7 +14,6 @@ import {
 import { BoxService } from './box.service';
 import { Request, Response } from 'express';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { ClaimAccountResponseDto } from './dto/claimAccountResponse.dto';
 import { APIError } from '../common/controller/APIError';
 import { APIErrorReason } from '../common/controller/APIErrorReason';
@@ -45,8 +44,7 @@ export class BoxController {
 
   @NoAuth()
   @Get('claim-account')
-  @UniformResponse()
-  @Serialize(ClaimAccountResponseDto)
+  @UniformResponse(undefined, ClaimAccountResponseDto)
   async claimAccount(
     @Req() req: Request,
     @Res() res: Response,
@@ -69,8 +67,7 @@ export class BoxController {
 
   @NoAuth()
   @Post()
-  @Serialize(CreatedBoxDto)
-  @UniformResponse(ModelName.BOX)
+  @UniformResponse(ModelName.BOX, CreatedBoxDto)
   async createBox(@Body() body: CreateBoxDto) {
     const [createdBox, errors] = await this.boxCreator.createBox(body);
     if (errors) return [null, errors];

--- a/src/box/dailyTask/dailyTask.controller.ts
+++ b/src/box/dailyTask/dailyTask.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Delete, Param, Post, Put } from '@nestjs/common';
-import { Serialize } from '../../common/interceptor/response/Serialize';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { CreatePredefinedDailyTaskDto } from './dto/createPredefinedDailyTask.dto';
@@ -24,8 +23,7 @@ export class DailyTaskController {
 
   @Post()
   @IsGroupAdmin()
-  @Serialize(PredefinedDailyTaskDto)
-  @UniformResponse(ModelName.DAILY_TASK)
+  @UniformResponse(ModelName.DAILY_TASK, PredefinedDailyTaskDto)
   async addOneDailyTask(
     @Body() body: CreatePredefinedDailyTaskDto,
     @LoggedUser() user: BoxUser,
@@ -35,8 +33,7 @@ export class DailyTaskController {
 
   @Post('/multiple')
   @IsGroupAdmin()
-  @Serialize(PredefinedDailyTaskDto)
-  @UniformResponse(ModelName.DAILY_TASK)
+  @UniformResponse(ModelName.DAILY_TASK, PredefinedDailyTaskDto)
   async addMultipleDailyTasks(
     @Body() body: CreatePredefinedDailyTaskDto[],
     @LoggedUser() user: BoxUser,

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -30,11 +30,11 @@ import { CreateMessageDto } from './dto/createMessage.dto';
 import { MessageDto } from './dto/message.dto';
 import { chat_idParam, messageParam } from './dto/messageParam';
 import { APIObjectName } from '../common/enum/apiObjectName.enum';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { Authorize } from '../authorization/decorator/Authorize';
 import { Action } from '../authorization/enum/action.enum';
 import { LoggedUser } from '../common/decorator/param/LoggedUser.decorator';
 import { User } from '../auth/user';
+import { UniformResponse } from '../common/decorator/response/UniformResponse';
 
 @Controller('chat')
 export class ChatController {
@@ -50,18 +50,18 @@ export class ChatController {
     return this.service.createOne(body);
   }
 
-  @Serialize(ChatDto)
   @Get('/:_id')
   @Authorize({ action: Action.read, subject: ChatDto })
   @BasicGET(ModelName.CHAT, ChatDto)
   @AddGetQueries()
+  @UniformResponse(ModelName.CHAT, ChatDto)
   public get(@Param() param: _idDto, @Req() request: Request) {
     return this.service.readOneById(param._id, request['mongoPopulate']);
   }
 
   @Get()
   @Authorize({ action: Action.read, subject: ChatDto })
-  @Serialize(ChatDto)
+  @UniformResponse(ModelName.CHAT, ChatDto)
   @OffsetPaginate(ModelName.CHAT)
   @AddSearchQuery(ChatDto)
   @AddSortQuery(ChatDto)

--- a/src/clan/clan.controller.ts
+++ b/src/clan/clan.controller.ts
@@ -34,7 +34,6 @@ import { User } from '../auth/user';
 import { UniformResponse } from '../common/decorator/response/UniformResponse';
 import { IncludeQuery } from '../common/decorator/param/IncludeQuery.decorator';
 import { publicReferences } from './clan.schema';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { RoomService } from '../clanInventory/room/room.service';
 import { ItemService } from '../clanInventory/item/item.service';
 import { PlayerService } from '../player/player.service';
@@ -58,8 +57,7 @@ export class ClanController {
   }
 
   @Get('items')
-  @Serialize(ClanItemsResponseDto)
-  @UniformResponse(ModelName.ITEM)
+  @UniformResponse(ModelName.ITEM, ClanItemsResponseDto)
   async getClanItems(@LoggedUser() user: User) {
     const clanId = await this.playerService.getPlayerClanId(user.player_id);
     const [clan, clanErrors] = await this.service.readOneById(clanId, {
@@ -96,8 +94,7 @@ export class ClanController {
   @OffsetPaginate(ModelName.CLAN)
   @AddSearchQuery(ClanDto)
   @AddSortQuery(ClanDto)
-  @Serialize(ClanDto)
-  @UniformResponse(ModelName.CLAN)
+  @UniformResponse(ModelName.CLAN, ClanDto)
   public getAll(@GetAllQuery() query: IGetAllQuery) {
     return this.service.readAll(query);
   }

--- a/src/clanInventory/soulhome/soulhome.controller.ts
+++ b/src/clanInventory/soulhome/soulhome.controller.ts
@@ -13,7 +13,6 @@ import { ModelName } from '../../common/enum/modelName.enum';
 import { AddSearchQuery } from '../../common/interceptor/request/addSearchQuery.interceptor';
 import { AddSortQuery } from '../../common/interceptor/request/addSortQuery.interceptor';
 import { OffsetPaginate } from '../../common/interceptor/request/offsetPagination.interceptor';
-import { Serialize } from '../../common/interceptor/response/Serialize';
 
 @Controller('soulhome')
 export class SoulHomeController {
@@ -27,8 +26,7 @@ export class SoulHomeController {
   @OffsetPaginate(ModelName.SOULHOME)
   @AddSearchQuery(SoulHomeDto)
   @AddSortQuery(SoulHomeDto)
-  @Serialize(SoulHomeDto)
-  @UniformResponse(ModelName.SOULHOME)
+  @UniformResponse(ModelName.SOULHOME, SoulHomeDto)
   public async getPlayerSoulHome(
     @IncludeQuery(publicReferences) includeRefs: ModelName[],
     @LoggedUser() user: User,

--- a/src/dailyTasks/dailyTasks.controller.ts
+++ b/src/dailyTasks/dailyTasks.controller.ts
@@ -30,8 +30,7 @@ export class DailyTasksController {
   ) {}
 
   @Get()
-  @Serialize(DailyTaskDto)
-  @UniformResponse(ModelName.DAILY_TASK)
+  @UniformResponse(ModelName.DAILY_TASK, DailyTaskDto)
   async getClanTasks(@LoggedUser() user: User) {
     const clanId = await this.playerService.getPlayerClanId(user.player_id);
     return this.dailyTasksService.readMany({
@@ -40,8 +39,7 @@ export class DailyTasksController {
   }
 
   @Get('/:_id')
-  @Serialize(DailyTaskDto)
-  @UniformResponse(ModelName.DAILY_TASK)
+  @UniformResponse(ModelName.DAILY_TASK, DailyTaskDto)
   async getTask(@Param() param: _idDto) {
     return this.dailyTasksService.readOneById(param._id);
   }
@@ -86,8 +84,7 @@ export class DailyTasksController {
 
   @HttpCode(204)
   @Delete('/:_id')
-  @Serialize(DailyTaskDto)
-  @UniformResponse(ModelName.DAILY_TASK)
+  @UniformResponse(ModelName.DAILY_TASK, DailyTaskDto)
   async deleteTask(@Param() param: _idDto, @LoggedUser() user: User) {
     const clanId = await this.playerService.getPlayerClanId(user.player_id);
     const [_result, errors] = await this.dailyTasksService.deleteTask(

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -4,7 +4,6 @@ import { UniformResponse } from '../common/decorator/response/UniformResponse';
 import { ModelName } from '../common/enum/modelName.enum';
 import { _idDto } from '../common/dto/_id.dto';
 import { OffsetPaginate } from '../common/interceptor/request/offsetPagination.interceptor';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { FleaMarketItemDto } from './dto/fleaMarketItem.dto';
 import { GetAllQuery } from '../common/decorator/param/GetAllQuery';
 import { IGetAllQuery } from '../common/interface/IGetAllQuery';
@@ -23,16 +22,14 @@ export class FleaMarketController {
   ) {}
 
   @Get('/:_id')
-  @Serialize(FleaMarketItemDto)
-  @UniformResponse(ModelName.FLEA_MARKET_ITEM)
+  @UniformResponse(ModelName.FLEA_MARKET_ITEM, FleaMarketItemDto)
   async getOne(@Param() param: _idDto) {
     return await this.service.readOneById(param._id);
   }
 
   @Get()
   @OffsetPaginate(ModelName.FLEA_MARKET_ITEM)
-  @Serialize(FleaMarketItemDto)
-  @UniformResponse(ModelName.FLEA_MARKET_ITEM)
+  @UniformResponse(ModelName.FLEA_MARKET_ITEM, FleaMarketItemDto)
   async getAll(@GetAllQuery() query: IGetAllQuery) {
     return await this.service.readMany(query);
   }

--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -5,7 +5,6 @@ import { ModelName } from '../common/enum/modelName.enum';
 import { IGetAllQuery } from '../common/interface/IGetAllQuery';
 import { GetAllQuery } from '../common/decorator/param/GetAllQuery';
 import { OffsetPaginate } from '../common/interceptor/request/offsetPagination.interceptor';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { PlayerDto } from '../player/dto/player.dto';
 import { ClanDto } from '../clan/dto/clan.dto';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
@@ -23,8 +22,7 @@ export class LeaderboardController {
   @Get('player')
   @NoAuth()
   @OffsetPaginate(ModelName.PLAYER)
-  @Serialize(PlayerDto)
-  @UniformResponse(ModelName.PLAYER)
+  @UniformResponse(ModelName.PLAYER, PlayerDto)
   async getPlayerLeaderboard(@GetAllQuery() query: IGetAllQuery) {
     return await this.leaderBoardService.getPlayerLeaderboard(query);
   }
@@ -32,8 +30,7 @@ export class LeaderboardController {
   @Get('clan')
   @NoAuth()
   @OffsetPaginate(ModelName.CLAN)
-  @Serialize(ClanDto)
-  @UniformResponse(ModelName.CLAN)
+  @UniformResponse(ModelName.CLAN, ClanDto)
   async getClanLeaderboard(@GetAllQuery() query: IGetAllQuery) {
     return await this.leaderBoardService.getClanLeaderboard(query);
   }

--- a/src/player/customCharacter/customCharacter.controller.ts
+++ b/src/player/customCharacter/customCharacter.controller.ts
@@ -15,9 +15,9 @@ import { AddSortQuery } from '../../common/interceptor/request/addSortQuery.inte
 import { LoggedUser } from '../../common/decorator/param/LoggedUser.decorator';
 import { User } from '../../auth/user';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
-import { Serialize } from '../../common/interceptor/response/Serialize';
 import { IncludeQuery } from '../../common/decorator/param/IncludeQuery.decorator';
 import { publicReferences } from './customCharacter.schema';
+import { Serialize } from '../../common/interceptor/response/Serialize';
 
 @Controller('customCharacter')
 export class CustomCharacterController {
@@ -25,8 +25,7 @@ export class CustomCharacterController {
 
   @Post()
   @Authorize({ action: Action.create, subject: CustomCharacterDto })
-  @Serialize(CustomCharacterDto)
-  @UniformResponse(ModelName.CUSTOM_CHARACTER)
+  @UniformResponse(ModelName.CUSTOM_CHARACTER, CustomCharacterDto)
   public create(
     @Body() body: CreateCustomCharacterDto,
     @LoggedUser() user: User,
@@ -36,16 +35,14 @@ export class CustomCharacterController {
 
   @Get('/battleCharacters')
   @Authorize({ action: Action.read, subject: CustomCharacterDto })
-  @Serialize(CustomCharacterDto)
-  @UniformResponse(ModelName.CUSTOM_CHARACTER)
+  @UniformResponse(ModelName.CUSTOM_CHARACTER, CustomCharacterDto)
   public async getBattleCharacters(@LoggedUser() user: User) {
     return this.service.readPlayerBattleCharacters(user.player_id);
   }
 
   @Get('/:_id')
   @Authorize({ action: Action.read, subject: CustomCharacterDto })
-  @Serialize(CustomCharacterDto)
-  @UniformResponse(ModelName.CUSTOM_CHARACTER)
+  @UniformResponse(ModelName.CUSTOM_CHARACTER, CustomCharacterDto)
   public async get(
     @Param() param: _idDto,
     @IncludeQuery(publicReferences) includeRefs: ModelName[],
@@ -62,8 +59,7 @@ export class CustomCharacterController {
   @OffsetPaginate(ModelName.CUSTOM_CHARACTER)
   @AddSearchQuery(CustomCharacterDto)
   @AddSortQuery(CustomCharacterDto)
-  @Serialize(CustomCharacterDto)
-  @UniformResponse(ModelName.CUSTOM_CHARACTER)
+  @UniformResponse(ModelName.CUSTOM_CHARACTER, CustomCharacterDto)
   public async getAll(
     @GetAllQuery() query: IGetAllQuery,
     @LoggedUser() user: User,

--- a/src/player/player.controller.ts
+++ b/src/player/player.controller.ts
@@ -18,7 +18,6 @@ import { BasicPUT } from '../common/base/decorator/BasicPUT.decorator';
 import { ModelName } from '../common/enum/modelName.enum';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
 import { CatchCreateUpdateErrors } from '../common/decorator/response/CatchCreateUpdateErrors';
-import { Serialize } from '../common/interceptor/response/Serialize';
 import { Authorize } from '../authorization/decorator/Authorize';
 import { Action } from '../authorization/enum/action.enum';
 import { OffsetPaginate } from '../common/interceptor/request/offsetPagination.interceptor';
@@ -36,15 +35,13 @@ export default class PlayerController {
 
   @NoAuth()
   @Post()
-  @CatchCreateUpdateErrors()
-  @Serialize(PlayerDto)
+  @UniformResponse(ModelName.PLAYER, PlayerDto)
   public create(@Body() body: CreatePlayerDto) {
     return this.service.createOne(body);
   }
 
   @Get('/:_id')
-  @Serialize(PlayerDto)
-  @UniformResponse(ModelName.PLAYER)
+  @UniformResponse(ModelName.PLAYER, PlayerDto)
   @Authorize({ action: Action.read, subject: PlayerDto })
   public async get(
     @Param() param: _idDto,

--- a/src/voting/dto/vote.dto.ts
+++ b/src/voting/dto/vote.dto.ts
@@ -1,0 +1,12 @@
+import { Expose } from 'class-transformer';
+
+export class VoteDto {
+  @Expose()
+  choice: string;
+
+  @Expose()
+  player_id: string;
+
+  @Expose()
+  _id: string;
+}

--- a/src/voting/dto/voting.dto.ts
+++ b/src/voting/dto/voting.dto.ts
@@ -1,10 +1,11 @@
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
 import { VotingType } from '../enum/VotingType.enum';
 import { Vote } from '../schemas/vote.schema';
 import { ExtractField } from '../../common/decorator/response/ExtractField';
 import AddType from '../../common/base/decorator/AddType.decorator';
 import { Organizer } from './organizer.dto';
 import { ItemName } from '../../clanInventory/item/enum/itemName.enum';
+import { VoteDto } from './vote.dto';
 
 @AddType('VotingDto')
 export class VotingDto {
@@ -34,7 +35,8 @@ export class VotingDto {
   minPercentage: number;
 
   @Expose()
-  votes: Vote[];
+  @Type(() => VoteDto)
+  votes: VoteDto[];
 
   @Expose()
   entity_id: string;

--- a/src/voting/dto/voting.dto.ts
+++ b/src/voting/dto/voting.dto.ts
@@ -36,7 +36,7 @@ export class VotingDto {
 
   @Expose()
   @Type(() => VoteDto)
-  votes: VoteDto[];
+  votes: Vote[];
 
   @Expose()
   entity_id: string;

--- a/src/voting/voting.controller.ts
+++ b/src/voting/voting.controller.ts
@@ -15,15 +15,13 @@ export class VotingController {
   constructor(private readonly service: VotingService) {}
 
   @Get()
-  @Serialize(VotingDto)
-  @UniformResponse(ModelName.VOTING)
+  @UniformResponse(ModelName.VOTING, VotingDto)
   async getClanVotings(@LoggedUser() user: User) {
     return this.service.getClanVotings(user.player_id);
   }
 
   @Get('/:_id')
-  @Serialize(VotingDto)
-  @UniformResponse(ModelName.VOTING)
+  @UniformResponse(ModelName.VOTING, VotingDto)
   async getVoting(@Param() param: _idDto, @LoggedUser() user: User) {
     const permission = await this.service.validatePermission(
       param._id,


### PR DESCRIPTION
### Brief description
This pr refactors the use of `@Serialize` decorator in multiple controllers. All the endpoints that used the `Serialize` decorator are now replaced with `UniformResponse` decorator.


### Change list

- All `@Serialize(someDto)` replaced with `@UniformResponse(someModel, someDto)`
- Added VoteDto to use in VotingDto