### PR TITLE
Added /clan/role/set PUT endpoint for setting a role for a clan member

### DIFF
--- a/src/__tests__/clan/data/clanBuilderFactory.ts
+++ b/src/__tests__/clan/data/clanBuilderFactory.ts
@@ -7,6 +7,7 @@ import JoinBuilder from './clan/join/JoinBuilder';
 import ClanRoleBuilder from './role/ClanRoleBuilder';
 import CreateClanRoleDtoBuilder from './role/CreateClanRoleDtoBuilder';
 import UpdateClanRoleDtoBuilder from './role/UpdateClanRoleDtoBuilder';
+import SetClanRoleBuilder from './role/SetClanRoleBuilder';
 
 type BuilderName =
   | 'CreateClanDto'
@@ -17,7 +18,8 @@ type BuilderName =
   | 'Join'
   | 'ClanRole'
   | 'CreateClanRoleDto'
-  | 'UpdateClanRoleDto';
+  | 'UpdateClanRoleDto'
+  | 'SetClanRole';
 
 type BuilderMap = {
   CreateClanDto: CreateClanDtoBuilder;
@@ -29,6 +31,7 @@ type BuilderMap = {
   ClanRole: ClanRoleBuilder;
   CreateClanRoleDto: CreateClanRoleDtoBuilder;
   UpdateClanRoleDto: UpdateClanRoleDtoBuilder;
+  SetClanRole: SetClanRoleBuilder;
 };
 
 export default class ClanBuilderFactory {
@@ -52,6 +55,8 @@ export default class ClanBuilderFactory {
         return new CreateClanRoleDtoBuilder() as BuilderMap[T];
       case 'UpdateClanRoleDto':
         return new UpdateClanRoleDtoBuilder() as BuilderMap[T];
+      case 'SetClanRole':
+        return new SetClanRoleBuilder() as BuilderMap[T];
       default:
         throw new Error(`Unknown builder name: ${builderName}`);
     }

--- a/src/__tests__/clan/data/role/SetClanRoleBuilder.ts
+++ b/src/__tests__/clan/data/role/SetClanRoleBuilder.ts
@@ -1,14 +1,14 @@
-import SetClanRole from '../../../../clan/role/payloads/SetClanRole';
+import SetClanRoleDto from '../../../../clan/role/dto/setClanRole.dto';
 import { ObjectId } from 'mongodb';
 
 export default class SetClanRoleBuilder {
-  private readonly base: Partial<SetClanRole> = {
+  private readonly base: Partial<SetClanRoleDto> = {
     player_id: new ObjectId(),
     role_id: new ObjectId(),
   };
 
-  build(): SetClanRole {
-    return { ...this.base } as SetClanRole;
+  build(): SetClanRoleDto {
+    return { ...this.base } as SetClanRoleDto;
   }
 
   setPlayerId(playerId: string | ObjectId) {

--- a/src/__tests__/clan/data/role/SetClanRoleBuilder.ts
+++ b/src/__tests__/clan/data/role/SetClanRoleBuilder.ts
@@ -1,0 +1,23 @@
+import SetClanRole from '../../../../clan/role/payloads/SetClanRole';
+import { ObjectId } from 'mongodb';
+
+export default class SetClanRoleBuilder {
+  private readonly base: Partial<SetClanRole> = {
+    player_id: new ObjectId(),
+    role_id: new ObjectId(),
+  };
+
+  build(): SetClanRole {
+    return { ...this.base } as SetClanRole;
+  }
+
+  setPlayerId(playerId: string | ObjectId) {
+    this.base.player_id = playerId;
+    return this;
+  }
+
+  setRoleId(roleId: string | ObjectId) {
+    this.base.role_id = roleId;
+    return this;
+  }
+}

--- a/src/__tests__/clan/role/ClanRoleService/ClanRoleService.setRoleToPlayer.test.ts
+++ b/src/__tests__/clan/role/ClanRoleService/ClanRoleService.setRoleToPlayer.test.ts
@@ -1,0 +1,261 @@
+import ClanRoleService from '../../../../clan/role/clanRole.service';
+import ClanBuilderFactory from '../../data/clanBuilderFactory';
+import ClanModule from '../../modules/clan.module';
+import { ClanBasicRight } from '../../../../clan/role/enum/clanBasicRight.enum';
+import PlayerModule from '../../../player/modules/player.module';
+import PlayerBuilderFactory from '../../../player/data/playerBuilderFactory';
+import { ClanRoleType } from '../../../../clan/role/enum/clanRoleType.enum';
+import { SEReason } from '../../../../common/service/basicService/SEReason';
+import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
+
+describe('ClanRoleService.setRoleToPlayer() test suite', () => {
+  let roleService: ClanRoleService;
+
+  const clanModel = ClanModule.getClanModel();
+  const roleBuilder = ClanBuilderFactory.getBuilder('ClanRole');
+  const existingRole = roleBuilder
+    .setName('role-1')
+    .setClanRoleType(ClanRoleType.NAMED)
+    .setRights({
+      [ClanBasicRight.EDIT_CLAN_DATA]: true,
+    })
+    .build();
+  const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+  const existingClan = clanBuilder.setRoles([existingRole]).build();
+
+  const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
+  const existingPlayer = playerBuilder
+    .setName('name')
+    .setUniqueIdentifier('name')
+    .setClanRoleId(null)
+    .build();
+  const playerModel = PlayerModule.getPlayerModel();
+
+  beforeEach(async () => {
+    roleService = await ClanModule.getClanRoleService();
+
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+    existingRole._id = createdClan.roles[0]._id;
+
+    existingPlayer.clan_id = createdClan._id;
+    const createdPlayer = await playerModel.create(existingPlayer);
+    existingPlayer._id = createdPlayer._id;
+  });
+
+  it('Should set a role to player and return true', async () => {
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: existingRole._id,
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(errors).toBeNull();
+    expect(isSet).toBe(true);
+    expect(playerInDB.clanRole_id.toString()).toBe(existingRole._id.toString());
+  });
+
+  it('Should not set a role to player if he / she is in another clan than a role', async () => {
+    const anotherRole = roleBuilder
+      .setName('another-role')
+      .setRights({
+        [ClanBasicRight.EDIT_MEMBER_RIGHTS]: true,
+      })
+      .setClanRoleType(ClanRoleType.NAMED)
+      .build();
+    const clan = clanBuilder
+      .setName('another-clan')
+      .setRoles([anotherRole])
+      .build();
+    const anotherClan = await clanModel.create(clan);
+    const anotherRole_id = anotherClan.roles[0]._id;
+
+    await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: anotherRole_id,
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(playerInDB.clanRole_id).toBeNull();
+  });
+
+  it('Should return NOT_FOUND ServiceError if he / she is in another clan than a role', async () => {
+    const anotherRole = roleBuilder
+      .setName('another-role')
+      .setRights({
+        [ClanBasicRight.EDIT_MEMBER_RIGHTS]: true,
+      })
+      .setClanRoleType(ClanRoleType.NAMED)
+      .build();
+    const clan = clanBuilder
+      .setName('another-clan')
+      .setRoles([anotherRole])
+      .build();
+    const anotherClan = await clanModel.create(clan);
+    const anotherRole_id = anotherClan.roles[0]._id;
+
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: anotherRole_id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(errors[0].field).toBe('role_id');
+    expect(errors[0].value).toBe(anotherRole_id.toString());
+  });
+
+  it('Should not set a role to player if he / she not in any clan', async () => {
+    await playerModel.findByIdAndUpdate(existingPlayer._id, {
+      clan_id: null,
+    });
+
+    await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: existingRole._id,
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(playerInDB.clanRole_id).toBeNull();
+  });
+
+  it('Should return NOT_FOUND ServiceError if he / she not in any clan', async () => {
+    await playerModel.findByIdAndUpdate(existingPlayer._id, {
+      clan_id: null,
+    });
+
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: existingRole._id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(errors[0].field).toBe('clan_id');
+    expect(errors[0].value).toBeNull();
+  });
+
+  it('Should not set a role to player if clan does not exists', async () => {
+    await playerModel.findByIdAndUpdate(existingPlayer._id, {
+      clan_id: getNonExisting_id(),
+    });
+
+    await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: existingRole._id,
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(playerInDB.clanRole_id).toBeNull();
+  });
+
+  it('Should return NOT_FOUND ServiceError if clan does not exists', async () => {
+    const nonExistingClan_id = getNonExisting_id();
+    await playerModel.findByIdAndUpdate(existingPlayer._id, {
+      clan_id: nonExistingClan_id,
+    });
+
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: existingRole._id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(errors[0].field).toBe('_id');
+    expect(errors[0].value.toString()).toBe(nonExistingClan_id);
+  });
+
+  it('Should not set a role to player if role does not exists', async () => {
+    await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: getNonExisting_id(),
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(playerInDB.clanRole_id).toBeNull();
+  });
+
+  it('Should return NOT_FOUND ServiceError if role does not exists', async () => {
+    const nonExisting_id = getNonExisting_id();
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: nonExisting_id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(errors[0].field).toBe('role_id');
+    expect(errors[0].value).toBe(nonExisting_id);
+  });
+
+  it('Should return NOT_FOUND ServiceError if player does not exists', async () => {
+    const nonExisting_id = getNonExisting_id();
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: nonExisting_id,
+      role_id: existingRole._id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].reason).toBe(SEReason.NOT_FOUND);
+    expect(errors[0].field).toBe('player_id');
+    expect(errors[0].value).toBe(nonExisting_id);
+  });
+
+  it('Should not set a role to player if role is of type personal', async () => {
+    const personalRole = roleBuilder
+      .setName('personal-role')
+      .setRights({
+        [ClanBasicRight.EDIT_MEMBER_RIGHTS]: true,
+      })
+      .setClanRoleType(ClanRoleType.PERSONAL)
+      .build();
+    const anotherClan = await clanModel.findByIdAndUpdate(existingClan._id, {
+      roles: [personalRole],
+    });
+
+    await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: anotherClan.roles[0]._id,
+    });
+
+    const playerInDB = await playerModel.findById(existingPlayer._id);
+
+    expect(playerInDB.clanRole_id).toBeNull();
+  });
+
+  it('Should return NOT_ALLOWED ServiceError if role is of type personal', async () => {
+    const personalRole = roleBuilder
+      .setName('personal-role')
+      .setRights({
+        [ClanBasicRight.EDIT_MEMBER_RIGHTS]: true,
+      })
+      .setClanRoleType(ClanRoleType.PERSONAL)
+      .build();
+    await clanModel.findByIdAndUpdate(existingClan._id, {
+      roles: [personalRole],
+    });
+    const updatedClan = await clanModel.findById(existingClan._id);
+
+    const [isSet, errors] = await roleService.setRoleToPlayer({
+      player_id: existingPlayer._id,
+      role_id: updatedClan.roles[0]._id,
+    });
+
+    expect(isSet).toBeNull();
+    expect(errors).toContainSE_NOT_ALLOWED();
+    expect(errors[0].reason).toBe(SEReason.NOT_ALLOWED);
+    expect(errors[0].field).toBe('clanRoleType');
+    expect(errors[0].value).toBe(ClanRoleType.PERSONAL);
+  });
+});

--- a/src/__tests__/clan/role/decorator/guard/HasClanRightsGuard/canActivate.test.ts
+++ b/src/__tests__/clan/role/decorator/guard/HasClanRightsGuard/canActivate.test.ts
@@ -19,7 +19,10 @@ import { ModelName } from '../../../../../../common/enum/modelName.enum';
 import { ClanSchema } from '../../../../../../clan/clan.schema';
 import { PlayerSchema } from '../../../../../../player/schemas/player.schema';
 import { ObjectId } from 'mongodb';
-import { APIError } from '../../../../../../common/controller/APIError';
+import {
+  APIError,
+  APIErrorArray,
+} from '../../../../../../common/controller/APIError';
 
 describe('HasClanRightsGuard.canActivate() test suite', () => {
   let guard: HasClanRightsGuard;
@@ -82,14 +85,16 @@ describe('HasClanRightsGuard.canActivate() test suite', () => {
     const contextBuilder = TestUtilDataFactory.getBuilder('ExecutionContext');
     const context = contextBuilder.setHttpRequest({ user }).build();
 
-    await expect(guard.canActivate(context)).rejects.toEqual([
-      new APIError({
-        reason: APIErrorReason.NOT_AUTHORIZED,
-        field: 'rights',
-        value: requiredRights[1],
-        message: 'Logged-in player role does not have all required rights',
-      }),
-    ]);
+    await expect(guard.canActivate(context)).rejects.toEqual(
+      new APIErrorArray([
+        new APIError({
+          reason: APIErrorReason.NOT_AUTHORIZED,
+          field: 'rights',
+          value: requiredRights[1],
+          message: 'Logged-in player role does not have all required rights',
+        }),
+      ]),
+    );
   });
 
   it('Should throw APIError NOT_AUTHORIZED if player has no rights at all', async () => {
@@ -98,20 +103,22 @@ describe('HasClanRightsGuard.canActivate() test suite', () => {
     const contextBuilder = TestUtilDataFactory.getBuilder('ExecutionContext');
     const context = contextBuilder.setHttpRequest({ user }).build();
 
-    await expect(guard.canActivate(context)).rejects.toMatchObject([
-      new APIError({
-        reason: APIErrorReason.NOT_AUTHORIZED,
-        field: 'rights',
-        value: requiredRights[0],
-        message: 'Logged-in player role does not have all required rights',
-      }),
-      new APIError({
-        reason: APIErrorReason.NOT_AUTHORIZED,
-        field: 'rights',
-        value: requiredRights[1],
-        message: 'Logged-in player role does not have all required rights',
-      }),
-    ]);
+    await expect(guard.canActivate(context)).rejects.toMatchObject(
+      new APIErrorArray([
+        new APIError({
+          reason: APIErrorReason.NOT_AUTHORIZED,
+          field: 'rights',
+          value: requiredRights[0],
+          message: 'Logged-in player role does not have all required rights',
+        }),
+        new APIError({
+          reason: APIErrorReason.NOT_AUTHORIZED,
+          field: 'rights',
+          value: requiredRights[1],
+          message: 'Logged-in player role does not have all required rights',
+        }),
+      ]),
+    );
   });
 
   it('Should throw APIError MISCONFIGURED if Request does not have a user object', async () => {

--- a/src/__tests__/player/data/player/playerBuilder.ts
+++ b/src/__tests__/player/data/player/playerBuilder.ts
@@ -105,4 +105,9 @@ export default class PlayerBuilder {
     this.base.battleCharacter_ids = _ids as any;
     return this;
   }
+
+  setClanRoleId(clanRole_id: string | ObjectId | null) {
+    this.base.clanRole_id = clanRole_id as any;
+    return this;
+  }
 }

--- a/src/clan/role/clanRole.controller.ts
+++ b/src/clan/role/clanRole.controller.ts
@@ -15,6 +15,7 @@ import { APIError } from '../../common/controller/APIError';
 import { APIErrorReason } from '../../common/controller/APIErrorReason';
 import { UpdateClanRoleDto } from './dto/updateClanRole.dto';
 import ServiceError from '../../common/service/basicService/ServiceError';
+import SetClanRoleDto from './dto/setClanRole.dto';
 
 @Controller('clan/role')
 export class ClanRoleController {
@@ -54,6 +55,15 @@ export class ClanRoleController {
       param?._id,
     );
 
+    return this.handleErrorReturnIfFound(errors);
+  }
+
+  @Put('set')
+  @HasClanRights([ClanBasicRight.EDIT_MEMBER_RIGHTS])
+  @DetermineClanId()
+  @UniformResponse()
+  public async setRole(@Body() body: SetClanRoleDto) {
+    const [, errors] = await this.service.setRoleToPlayer(body);
     return this.handleErrorReturnIfFound(errors);
   }
 

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -12,7 +12,7 @@ import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
 import { ClanRoleType } from './enum/clanRoleType.enum';
 import { UpdateClanRoleDto } from './dto/updateClanRole.dto';
-import SetClanRole from './payloads/SetClanRole';
+import SetClanRoleDto from './dto/setClanRole.dto';
 import { Player } from '../../player/schemas/player.schema';
 
 /**
@@ -185,7 +185,9 @@ export default class ClanRoleService {
    * - NOT_FOUND if the player is not found, player is not in any clan or if the clan or role is not found
    * - NOT_ALLOWED if the role is of type personal
    */
-  async setRoleToPlayer(setData: SetClanRole): Promise<IServiceReturn<true>> {
+  async setRoleToPlayer(
+    setData: SetClanRoleDto,
+  ): Promise<IServiceReturn<true>> {
     const [player, playerReadErrors] =
       await this.playerService.readOneById<Player>(
         setData.player_id.toString(),

--- a/src/clan/role/decorator/guard/HasClanRights.ts
+++ b/src/clan/role/decorator/guard/HasClanRights.ts
@@ -10,7 +10,10 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Player } from '../../../../player/schemas/player.schema';
 import { Model } from 'mongoose';
 import { Request } from 'express';
-import { APIError } from '../../../../common/controller/APIError';
+import {
+  APIError,
+  APIErrorArray,
+} from '../../../../common/controller/APIError';
 import { APIErrorReason } from '../../../../common/controller/APIErrorReason';
 import { Clan } from '../../../clan.schema';
 import { ClanBasicRight } from '../../enum/clanBasicRight.enum';
@@ -121,7 +124,7 @@ export class HasClanRightsGuard implements CanActivate {
       context.getHandler(),
     );
 
-    const errors: APIError[] = [];
+    const errors = new APIErrorArray();
     for (const rightToHave of rightsToHave) {
       if (!playerRole.rights[rightToHave]) {
         errors.push(

--- a/src/clan/role/dto/setClanRole.dto.ts
+++ b/src/clan/role/dto/setClanRole.dto.ts
@@ -1,16 +1,19 @@
 import { ObjectId } from 'mongodb';
+import { IsMongoId } from 'class-validator';
 
 /**
- * Payload to set a clan role for a player
+ * DTO to set a clan role for a player
  */
-export default class SetClanRole {
+export default class SetClanRoleDto {
   /**
    * _id of player to whom role should be set
    */
+  @IsMongoId()
   player_id: string | ObjectId;
 
   /**
    * _id of the role to set
    */
+  @IsMongoId()
   role_id: string | ObjectId;
 }

--- a/src/clan/role/payloads/SetClanRole.ts
+++ b/src/clan/role/payloads/SetClanRole.ts
@@ -1,0 +1,16 @@
+import { ObjectId } from 'mongodb';
+
+/**
+ * Payload to set a clan role for a player
+ */
+export default class SetClanRole {
+  /**
+   * _id of player to whom role should be set
+   */
+  player_id: string | ObjectId;
+
+  /**
+   * _id of the role to set
+   */
+  role_id: string | ObjectId;
+}

--- a/src/common/controller/APIError.ts
+++ b/src/common/controller/APIError.ts
@@ -88,6 +88,27 @@ export class APIError extends HttpException {
   additional: any | null;
 }
 
+export class APIErrorArray extends Error {
+  constructor(errors: APIError[] = []) {
+    super('Array of APIErrors');
+    this.errors = errors;
+  }
+
+  public readonly errors: APIError[];
+
+  push(error: APIError) {
+    this.errors.push(error);
+  }
+
+  get length() {
+    return this.errors.length;
+  }
+
+  [Symbol.iterator]() {
+    return this.errors[Symbol.iterator]();
+  }
+}
+
 /**
  * Determines whenever the specified object or array is APIError or not.
  *

--- a/src/common/exceptionFilter/APIErrorFilter.ts
+++ b/src/common/exceptionFilter/APIErrorFilter.ts
@@ -1,19 +1,23 @@
 import { ExceptionFilter, Catch, ArgumentsHost } from '@nestjs/common';
 import { Response } from 'express';
-import { APIError } from '../controller/APIError';
+import { APIError, APIErrorArray } from '../controller/APIError';
 
 /**
  * Error filter to handle thrown APIError.
  *
  * Filter will return APIError as it is to client in the standard error response format
  */
-@Catch(APIError)
+@Catch(APIError, APIErrorArray)
 export class APIErrorFilter implements ExceptionFilter {
   catch(exception: APIError, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
 
-    const errors = Array.isArray(exception) ? exception : [exception];
+    let errors: APIError[] = [];
+
+    if (exception instanceof APIErrorArray) {
+      errors = exception.errors;
+    } else errors = Array.isArray(exception) ? exception : [exception];
 
     response.status(errors[0].statusCode).json({
       errors,


### PR DESCRIPTION
### Brief description

Added _/clan/role/set_ PUT endpoint to set a default or named role to a specified player. Notice the limitations of this endpoint in the attached issue.

### Change list

- Added _/clan/role/set_ PUT endpoint
- Added tests
- Fixed bug with `APIError` error filter by introducing a new wrapper class, which holds an array of `APIError` and behaves similarly to array 
