### PR TITLE
Fixed a bug where /clan GET endpoint does not return pagination data

### DIFF
--- a/src/clan/clan.controller.ts
+++ b/src/clan/clan.controller.ts
@@ -85,7 +85,6 @@ export class ClanController {
   public get(
     @Param() param: _idDto,
     @IncludeQuery(publicReferences) includeRefs: ModelName[],
-
   ) {
     return this.service.readOneById(param._id, { includeRefs });
   }

--- a/src/clan/clan.controller.ts
+++ b/src/clan/clan.controller.ts
@@ -85,16 +85,17 @@ export class ClanController {
   public get(
     @Param() param: _idDto,
     @IncludeQuery(publicReferences) includeRefs: ModelName[],
+
   ) {
     return this.service.readOneById(param._id, { includeRefs });
   }
 
   @Get()
   @NoAuth()
+  @UniformResponse(ModelName.CLAN, ClanDto)
   @OffsetPaginate(ModelName.CLAN)
   @AddSearchQuery(ClanDto)
   @AddSortQuery(ClanDto)
-  @UniformResponse(ModelName.CLAN, ClanDto)
   public getAll(@GetAllQuery() query: IGetAllQuery) {
     return this.service.readAll(query);
   }


### PR DESCRIPTION
### Brief description
OffsetPaginate validate if the response already contains the metaData and wont populate the paginationData into the response if the metaData is missing. UniformResponse populate the metaData, it need to be executed before than the OffsetPaginate.

### Change list

- clan.controller:  put the UniformResponse attribute on top of the OffsetPaginate attribute in order to get populated the paginationData object in the response for the get clan api
