### PR TITLE
Feature add clan logo to player leaderboard data

### DIFF
--- a/src/leaderboard/dto/leaderboardPlayer.dto.ts
+++ b/src/leaderboard/dto/leaderboardPlayer.dto.ts
@@ -1,0 +1,9 @@
+import { Expose, Type } from 'class-transformer';
+import { PlayerDto } from '../../player/dto/player.dto';
+import { ClanLogoDto } from '../../clan/dto/clanLogo.dto';
+
+export class LeaderboardPlayerDto extends PlayerDto {
+  @Expose()
+  @Type(() => ClanLogoDto)
+  clanLogo: ClanLogoDto;
+}

--- a/src/leaderboard/leaderboard.controller.ts
+++ b/src/leaderboard/leaderboard.controller.ts
@@ -5,12 +5,12 @@ import { ModelName } from '../common/enum/modelName.enum';
 import { IGetAllQuery } from '../common/interface/IGetAllQuery';
 import { GetAllQuery } from '../common/decorator/param/GetAllQuery';
 import { OffsetPaginate } from '../common/interceptor/request/offsetPagination.interceptor';
-import { PlayerDto } from '../player/dto/player.dto';
 import { ClanDto } from '../clan/dto/clan.dto';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
 import { LoggedUser } from '../common/decorator/param/LoggedUser.decorator';
 import { User } from '../auth/user';
 import { PlayerService } from '../player/player.service';
+import { LeaderboardPlayerDto } from './dto/leaderboardPlayer.dto';
 
 @Controller('leaderboard')
 export class LeaderboardController {
@@ -21,16 +21,16 @@ export class LeaderboardController {
 
   @Get('player')
   @NoAuth()
+  @UniformResponse(ModelName.PLAYER, LeaderboardPlayerDto)
   @OffsetPaginate(ModelName.PLAYER)
-  @UniformResponse(ModelName.PLAYER, PlayerDto)
   async getPlayerLeaderboard(@GetAllQuery() query: IGetAllQuery) {
     return await this.leaderBoardService.getPlayerLeaderboard(query);
   }
 
   @Get('clan')
   @NoAuth()
-  @OffsetPaginate(ModelName.CLAN)
   @UniformResponse(ModelName.CLAN, ClanDto)
+  @OffsetPaginate(ModelName.CLAN)
   async getClanLeaderboard(@GetAllQuery() query: IGetAllQuery) {
     return await this.leaderBoardService.getClanLeaderboard(query);
   }

--- a/src/leaderboard/leaderboard.service.ts
+++ b/src/leaderboard/leaderboard.service.ts
@@ -5,8 +5,9 @@ import { IGetAllQuery } from '../common/interface/IGetAllQuery';
 import { CACHE_MANAGER, Cache } from '@nestjs/cache-manager';
 import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
-import mongoose from 'mongoose';
+import mongoose, { Model } from 'mongoose';
 import { CacheKeys } from '../common/enum/cacheKeys.enum';
+import { PlayerDocument } from 'src/player/schemas/player.schema';
 
 @Injectable()
 export class LeaderboardService {
@@ -68,24 +69,7 @@ export class LeaderboardService {
       const fetchedData = await model.find().sort({ points: -1 }).exec();
       if (!fetchedData) throw new ServiceError({ reason: SEReason.NOT_FOUND });
 
-      if (model === this.playerService.model) {
-        const clanIds = fetchedData.map((player) => player.clan_id);
-        const clans = await this.clanService.model
-          .find({ _id: { $in: clanIds } })
-          .exec();
-
-        const clanMap = clans.reduce((map, clan) => {
-          map[clan._id] = clan.clanLogo;
-          return map;
-        }, {});
-
-        data = fetchedData.map((player) => ({
-          ...player.toObject(),
-          clanLogo: clanMap[player.clan_id.toString()] || null,
-        }));
-      } else {
-        data = fetchedData;
-      }
+      data = await this.processCacheData(model, fetchedData);
 
       // Set the data with 12 hour ttl. The { ttl: number } as any is required to overwrite the default value.
       await this.cacheService.set(cacheKey, data, { ttl: 60 * 60 * 12 } as any);
@@ -133,5 +117,44 @@ export class LeaderboardService {
     const position = leaderboard.findIndex((clan) => clan['id'] == clanId) + 1;
     if (position === 0) throw new ServiceError({ reason: SEReason.NOT_FOUND });
     return { position };
+  }
+
+  /**
+   * Processes cached data based on the provided model. If the model matches the player service's model,
+   * it enriches the data by adding clan logo information. Otherwise, it returns the data as is.
+   *
+   * @param model - The model to compare against for determining the processing logic.
+   * @param data - The array of data to be processed.
+   * @returns A promise that resolves to the processed data.
+   */
+  private async processCacheData(model: Model<any>, data: any[]) {
+    if (model === this.playerService.model) {
+      return await this.addClanLogoData(data);
+    }
+
+    return data;
+  }
+
+  /**
+   * Adds the clan logo data to the provided player data.
+   *
+   * @param data - An array of player documents to be enriched with clan logo data.
+   * @returns A promise that resolves to an array of player objects with added `clanLogo` field.
+   */
+  private async addClanLogoData(data: PlayerDocument[]) {
+    const clanIds = data.map((player) => player.clan_id);
+    const clans = await this.clanService.model
+      .find({ _id: { $in: clanIds } })
+      .exec();
+
+    const clanMap = clans.reduce((map, clan) => {
+      map[clan._id] = clan.clanLogo;
+      return map;
+    }, {});
+
+    return data.map((player) => ({
+      ...player.toObject(),
+      clanLogo: clanMap[player.clan_id] || null,
+    }));
   }
 }


### PR DESCRIPTION
### Brief description
this PR enhances the player leaderboard data by adding the clan logo data to it and fixes the missing pagination data from response.


### Change list

- New DTO for leaderboard players that extends the PlayerDto with added clanLogo prop.
- Replaced PlayerDto with LeaderboardPlayerDto in `@UniformResponse` decorator in player leaderboard endpoint.
- Added logic to `LeaderboardService` to fetch clan logos for players.
