### PR TITLE
Fixed wrong response types retunred from endpoints

### DIFF
--- a/src/common/interceptor/response/Send204OnEmptyRes.ts
+++ b/src/common/interceptor/response/Send204OnEmptyRes.ts
@@ -23,8 +23,9 @@ export class Send204OnEmptyResInterceptor implements NestInterceptor {
     next: CallHandler<any>,
   ): Observable<any> | Promise<Observable<any>> {
     return next.handle().pipe(
-      map((data: any) => {
-        if (data != null) return data;
+      map(async (data: any) => {
+        const awaitedData = data instanceof Promise ? await data : data;
+        if (awaitedData != null) return awaitedData;
 
         const response = context.switchToHttp().getResponse();
         response.status(204);

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   Post,
   Put,
@@ -99,6 +100,7 @@ export default class ProfileController {
   }
 
   @Delete('/:_id')
+  @HttpCode(204)
   @Authorize({ action: Action.delete, subject: ProfileDto })
   @CheckPermissions()
   @BasicDELETE(ModelName.PROFILE)


### PR DESCRIPTION
### Brief description

Fixed endpoints, which was returning 200 status code instead of 204. The errors was caused by `Send204OnEmptyResInterceptor` class did not await the incoming data.

### Change list

- Fixed _/profile_ DELETE endpoint
- Fixed _/clan_ PUT endpoint
- Fixed _/clan_ DELETE endpoint
- Fixed _/item_ PUT endpoint
