### PR TITLE
Change player battle characters storing mechanism   517

### DIFF
--- a/src/__tests__/common/decorator/validation/IsMongoIdOrNull/IsMongoIdOrNull.test.ts
+++ b/src/__tests__/common/decorator/validation/IsMongoIdOrNull/IsMongoIdOrNull.test.ts
@@ -1,18 +1,23 @@
 import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { IsMongoIdOrNull } from '../../../../../common/decorator/validation/IsMongoIdOrNull.decorator';
-import { ObjectId } from 'mongodb';
 
 describe('@IsMongoIdOrNull() test suite', () => {
+  let dto: TestDto;
+  let objectId:  string ;
+  beforeEach(async () => {
+    dto = new TestDto();
+    objectId = "6814a2ae8cbeb9b0dcd086bd";
+  });
+
   it('Should pass validation for null and mongo Id input', async () => {
-    const dto = new TestDto();
-    dto.ids = [null, new ObjectId()];
+    dto.ids = [null, objectId];
 
     const errors = await validate(dto);
     expect(errors.length).toBe(0);
   });
 
-  it('Should pass validation without any inputs', async () => {
+  it('Should pass validation with empty array', async () => {
     const dto = new TestDto();
     dto.ids = [];
 
@@ -22,13 +27,13 @@ describe('@IsMongoIdOrNull() test suite', () => {
 
   it('Should pass validation with a single mongo id input', async () => {
     const dto = new TestDto();
-    dto.ids = new ObjectId();
+    dto.ids = objectId;
 
     const errors = await validate(dto);
     expect(errors.length).toBe(0);
   });
 
-  it('Should pass validation with a single null input', async () => {
+  it('Should pass validation with null input', async () => {
     const dto = new TestDto();
     dto.ids = null;
 
@@ -38,7 +43,7 @@ describe('@IsMongoIdOrNull() test suite', () => {
 
   it('Should pass validation with an mongo id input (array)', async () => {
     const dto = new TestDto();
-    dto.ids = [new ObjectId()];
+    dto.ids = [objectId];
 
     const errors = await validate(dto);
     expect(errors.length).toBe(0);
@@ -62,15 +67,15 @@ describe('@IsMongoIdOrNull() test suite', () => {
 
   it('Should pass validation with more mongo id input', async () => {
     const dto = new TestDto();
-    dto.ids = [new ObjectId(), new ObjectId(), new ObjectId()];
+    dto.ids = [objectId, objectId, objectId];
 
     const errors = await validate(dto);
     expect(errors.length).toBe(0);
   });
 
-  it('Should fail validation with invalid and more valid mongo id input', async () => {
+  it('Should fail validation with invalid mongo id input', async () => {
     const dto = new TestDto();
-    dto.ids = ['invalid', new ObjectId(), new ObjectId()];
+    dto.ids = ['invalid', objectId, objectId];
 
     const errors = await validate(dto);
     expect(errors.length).toBe(1);
@@ -79,19 +84,9 @@ describe('@IsMongoIdOrNull() test suite', () => {
     );
   });
 
-  it('Should fail validation with invalid, valid mongo id and null input', async () => {
-    const dto = new TestDto();
-    dto.ids = ['invalid', new ObjectId(), null];
-
-    const errors = await validate(dto);
-    expect(errors.length).toBe(1);
-    expect(errors[0].constraints?.IsMongoIdOrNullConstraint).toBe(
-      'ids must be a mongodb id or null',
-    );
-  });
 });
 
 class TestDto {
-  @IsMongoIdOrNull()
+  @IsMongoIdOrNull({each: true})
   ids: any;
 }

--- a/src/__tests__/player/PlayerService/createOne.test.ts
+++ b/src/__tests__/player/PlayerService/createOne.test.ts
@@ -30,6 +30,23 @@ describe('PlayerService.createOne() test suite', () => {
     expect(clearedResp).toEqual(expect.objectContaining(expectedPlayer));
   });
 
+  it('Should create a player in DB if input is valid and battleCharacterId values are null or ObjectId', async () => {
+    const playerName = 'john';
+    const playerToCreate = playerBuilder
+      .setBattleCharacterIds([null, new ObjectId()])
+      .setName(playerName).build();
+
+    await playerService.createOne(playerToCreate);
+
+    const dbData = await playerModel.findOne({ name: playerName });
+
+    const clearedResp = clearDBRespDefaultFields(dbData);
+
+    const { profile_id, ...expectedPlayer } = { ...playerToCreate, points: 0 };
+
+    expect(clearedResp).toEqual(expect.objectContaining(expectedPlayer));
+  });
+
   it('Should return response in appropriate shape', async () => {
     const playerName = 'john';
     const playerToCreate = playerBuilder.setName(playerName).build();

--- a/src/__tests__/player/PlayerService/createOne.test.ts
+++ b/src/__tests__/player/PlayerService/createOne.test.ts
@@ -47,6 +47,23 @@ describe('PlayerService.createOne() test suite', () => {
     expect(clearedResp).toEqual(expect.objectContaining(expectedPlayer));
   });
 
+  it('Should create a player in DB if input is valid and battleCharacterIds is null', async () => {
+    const playerName = 'john';
+    const playerToCreate = playerBuilder
+      .setBattleCharacterIds(null)
+      .setName(playerName).build();
+
+    await playerService.createOne(playerToCreate);
+
+    const dbData = await playerModel.findOne({ name: playerName });
+
+    const clearedResp = clearDBRespDefaultFields(dbData);
+
+    const { profile_id, ...expectedPlayer } = { ...playerToCreate, points: 0 };
+
+    expect(clearedResp).toEqual(expect.objectContaining(expectedPlayer));
+  });
+
   it('Should return response in appropriate shape', async () => {
     const playerName = 'john';
     const playerToCreate = playerBuilder.setName(playerName).build();

--- a/src/__tests__/player/PlayerService/updateOneById.test.ts
+++ b/src/__tests__/player/PlayerService/updateOneById.test.ts
@@ -31,6 +31,17 @@ describe('PlayerService.updateOneById() test suite', () => {
     expect(updatedPlayer.name).toBe(updateData.name);
   });
 
+  it('Should successfully update an existing player battleCharacterId ', async () => {
+    const updateData = { _id: existingPlayer._id, battleCharacter_ids: [null, new Object()] };
+    const resp = await playerService.updateOneById(updateData);
+
+    expect(resp).toBeTruthy();
+
+    const updatedPlayer = await playerModel.findById(existingPlayer._id);
+    expect(updatedPlayer.battleCharacter_ids[0]).toBe(updateData.battleCharacter_ids[0]);
+    expect(updatedPlayer.battleCharacter_ids[1]).toStrictEqual(updateData.battleCharacter_ids[1]);
+  });
+
   //TODO: sometimes it fails and does not throw any error
   it('Should throw error if the name already exists', async () => {
     const notUniqueName = 'anotherName';

--- a/src/__tests__/player/PlayerService/updateOneById.test.ts
+++ b/src/__tests__/player/PlayerService/updateOneById.test.ts
@@ -42,6 +42,16 @@ describe('PlayerService.updateOneById() test suite', () => {
     expect(updatedPlayer.battleCharacter_ids[1]).toStrictEqual(updateData.battleCharacter_ids[1]);
   });
 
+  it('Should successfully update an existing player battleCharacterId, that has null value', async () => {
+    const updateData = { _id: existingPlayer._id, battleCharacter_ids: null };
+    const resp = await playerService.updateOneById(updateData);
+
+    expect(resp).toBeTruthy();
+
+    const updatedPlayer = await playerModel.findById(existingPlayer._id);
+    expect(updatedPlayer.battleCharacter_ids).toBe(null);
+  });
+
   //TODO: sometimes it fails and does not throw any error
   it('Should throw error if the name already exists', async () => {
     const notUniqueName = 'anotherName';

--- a/src/__tests__/player/data/player/createPlayerDtoBuilder.ts
+++ b/src/__tests__/player/data/player/createPlayerDtoBuilder.ts
@@ -73,7 +73,7 @@ export default class CreatePlayerDtoBuilder
     return this;
   }
 
-  setBattleCharacterIds(_ids: string[] | ObjectId[]) {
+  setBattleCharacterIds(_ids?: string[] | ObjectId[]) {
     this.base.battleCharacter_ids = _ids as any;
     return this;
   }

--- a/src/__tests__/player/data/player/playerBuilder.ts
+++ b/src/__tests__/player/data/player/playerBuilder.ts
@@ -101,7 +101,7 @@ export default class PlayerBuilder {
     return this;
   }
 
-  setBattleCharacterIds(_ids: string[] | ObjectId[]) {
+  setBattleCharacterIds(_ids?: string[] | ObjectId[]) {
     this.base.battleCharacter_ids = _ids as any;
     return this;
   }

--- a/src/__tests__/player/data/player/playerDtoBuilder.ts
+++ b/src/__tests__/player/data/player/playerDtoBuilder.ts
@@ -105,7 +105,7 @@ export default class PlayerDtoBuilder implements IDataBuilder<PlayerDto> {
     return this;
   }
 
-  setBattleCharacterIds(_ids: string[] | ObjectId[]) {
+  setBattleCharacterIds(_ids?: string[] | ObjectId[]) {
     this.base.battleCharacter_ids = _ids as any;
     return this;
   }

--- a/src/__tests__/player/data/player/updatePlayerDtoBuilder.ts
+++ b/src/__tests__/player/data/player/updatePlayerDtoBuilder.ts
@@ -71,7 +71,7 @@ export default class UpdatePlayerDtoBuilder {
     return this;
   }
 
-  setBattleCharacterIds(_ids: string[] | ObjectId[]) {
+  setBattleCharacterIds(_ids?: string[] | ObjectId[]) {
     this.base.battleCharacter_ids = _ids as any;
     return this;
   }

--- a/src/common/decorator/validation/IsMongoIdOrNull.decorator.ts
+++ b/src/common/decorator/validation/IsMongoIdOrNull.decorator.ts
@@ -4,7 +4,6 @@ import { registerDecorator,
    ValidatorConstraint, 
    ValidatorConstraintInterface } from 'class-validator';
 
-
 export function IsMongoIdOrNull(validationOptions?: ValidationOptions) {
   return function (object: object, propertyName: string) {
     registerDecorator({

--- a/src/common/decorator/validation/IsMongoIdOrNull.decorator.ts
+++ b/src/common/decorator/validation/IsMongoIdOrNull.decorator.ts
@@ -1,4 +1,4 @@
-import { registerDecorator,
+import { isMongoId, registerDecorator,
    ValidationArguments,
    ValidationOptions, 
    ValidatorConstraint, 
@@ -20,13 +20,7 @@ export function IsMongoIdOrNull(validationOptions?: ValidationOptions) {
 class IsMongoIdOrNullConstraint implements ValidatorConstraintInterface {
   validate(value: any) {
     
-    const mongoIdRegexPattern = /^[a-f\d]{24}$/i;
-
-    if (value === null) return true;
-    if (Array.isArray(value)) {
-      return value.every((item) => item == null || mongoIdRegexPattern.test(item));
-    }
-    return mongoIdRegexPattern.test(value);
+    return value === null || isMongoId(value);
   }
 
   defaultMessage(_args: ValidationArguments) {

--- a/src/player/dto/createPlayer.dto.ts
+++ b/src/player/dto/createPlayer.dto.ts
@@ -36,7 +36,7 @@ export class CreatePlayerDto {
   @IsOptional()
   @IsArray()
   @ArrayMaxSize(3)
-  @IsMongoIdOrNull()
+  @IsMongoIdOrNull({ each: true })
   battleCharacter_ids?: string[];
 
   @IsOptional()

--- a/src/player/dto/createPlayer.dto.ts
+++ b/src/player/dto/createPlayer.dto.ts
@@ -12,6 +12,7 @@ import { IsProfileExists } from '../../profile/decorator/validation/IsProfileExi
 import AddType from '../../common/base/decorator/AddType.decorator';
 import { Type } from 'class-transformer';
 import { ModifyAvatarDto } from './modifyAvatar.dto';
+import { IsMongoIdOrNull } from '../../common/decorator/validation/IsMongoIdOrNull.decorator';
 
 @AddType('CreatePlayerDto')
 export class CreatePlayerDto {
@@ -35,7 +36,7 @@ export class CreatePlayerDto {
   @IsOptional()
   @IsArray()
   @ArrayMaxSize(3)
-  @IsMongoId({ each: true })
+  @IsMongoIdOrNull()
   battleCharacter_ids?: string[];
 
   @IsOptional()

--- a/src/player/dto/updatePlayer.dto.ts
+++ b/src/player/dto/updatePlayer.dto.ts
@@ -44,7 +44,7 @@ export class UpdatePlayerDto {
   @IsOptional()
   @IsArray()
   @ArrayMaxSize(3)
-  @IsMongoIdOrNull()
+  @IsMongoIdOrNull({ each: true })
   battleCharacter_ids?: string[];
 
   @IsOptional()

--- a/src/player/dto/updatePlayer.dto.ts
+++ b/src/player/dto/updatePlayer.dto.ts
@@ -13,6 +13,7 @@ import { IsPlayerExists } from '../decorator/validation/IsPlayerExists.decorator
 import AddType from '../../common/base/decorator/AddType.decorator';
 import { Type } from 'class-transformer';
 import { ModifyAvatarDto } from './modifyAvatar.dto';
+import { IsMongoIdOrNull } from '../../common/decorator/validation/IsMongoIdOrNull.decorator';
 
 @AddType('UpdatePlayerDto')
 export class UpdatePlayerDto {
@@ -43,7 +44,7 @@ export class UpdatePlayerDto {
   @IsOptional()
   @IsArray()
   @ArrayMaxSize(3)
-  @IsMongoId({ each: true })
+  @IsMongoIdOrNull()
   battleCharacter_ids?: string[];
 
   @IsOptional()


### PR DESCRIPTION
### Brief description

Change validation of Player.battleCharacter_ids to also accept null as a value.

### Change list

- Add @IsMongoIdOrNull() decorator
- Replace the battleCharacter_ids @IsMongoId() decorator with @IsMongoIdOrNull() in the createPlayer/updatePlayer DTOs
- Made all player (DTO and schema) battleCharacter_ids nullable
- Extends tests to cover the changes
