### PR TITLE
decorate all _ids containing fields in returning data DTOs with `@ExtractField()`

### DIFF
--- a/src/clan/dto/clan.dto.ts
+++ b/src/clan/dto/clan.dto.ts
@@ -35,6 +35,7 @@ export class ClanDto {
   @Expose()
   points: number;
 
+  @ExtractField()
   @Expose()
   admin_ids: string[];
 

--- a/src/player/dto/player.dto.ts
+++ b/src/player/dto/player.dto.ts
@@ -35,6 +35,7 @@ export class PlayerDto {
   @Expose()
   gameStatistics: GameStatisticsDto;
 
+  @ExtractField()
   @Expose()
   battleCharacter_ids?: string[];
 

--- a/src/voting/dto/vote.dto.ts
+++ b/src/voting/dto/vote.dto.ts
@@ -1,12 +1,15 @@
 import { Expose } from 'class-transformer';
+import { ExtractField } from '../../common/decorator/response/ExtractField';
 
 export class VoteDto {
   @Expose()
   choice: string;
 
+  @ExtractField()
   @Expose()
   player_id: string;
 
+  @ExtractField()
   @Expose()
   _id: string;
 }

--- a/src/voting/dto/voting.dto.ts
+++ b/src/voting/dto/voting.dto.ts
@@ -28,6 +28,7 @@ export class VotingDto {
   @Expose()
   type: VotingType;
 
+  @ExtractField()
   @Expose()
   player_ids: string[];
 
@@ -38,6 +39,7 @@ export class VotingDto {
   @Type(() => VoteDto)
   votes: Vote[];
 
+  @ExtractField()
   @Expose()
   entity_id: string;
 


### PR DESCRIPTION
### Brief description

The bug with _id fields returning values was caused due to improper serialization, which is fixed by decorating then with the `@ExtractField()` decorator.

### Change list

- Decorate all DTO _id containing fields with `@ExtractField()`