### PR TITLE
Added filtering for /online-players GET enpoint by `status` field

### DIFF
--- a/src/__tests__/onlinePlayers/OnlinePlayersService/getAllOnlinePlayers.test.ts
+++ b/src/__tests__/onlinePlayers/OnlinePlayersService/getAllOnlinePlayers.test.ts
@@ -63,6 +63,33 @@ describe('OnlinePlayersService.getAllOnlinePlayers() test suite', () => {
     expect(player_ids).toContainEqual(payload2);
   });
 
+  it('Should be able to filter returning players by status field', async () => {
+    await playerModel.create(player1);
+    await playerModel.create(player2);
+    const payload1 = {
+      name: player1.name,
+      _id: _id1,
+      status: OnlinePlayerStatus.UI,
+    };
+    const payload2 = {
+      name: player2.name,
+      _id: _id2,
+      status: OnlinePlayerStatus.BATTLE,
+    };
+
+    jest.spyOn(redisService, 'getValuesByKeyPattern').mockResolvedValue({
+      [_id1]: JSON.stringify(payload1),
+      [_id2]: JSON.stringify(payload2),
+    });
+
+    const player_ids = await service.getAllOnlinePlayers({
+      filter: { status: [OnlinePlayerStatus.UI] },
+    });
+
+    expect(player_ids).toContainEqual(payload1);
+    expect(player_ids).not.toContainEqual(payload2);
+  });
+
   it('Should not return players if there are no players', async () => {
     jest.spyOn(redisService, 'getValuesByKeyPattern').mockResolvedValue({});
 

--- a/src/onlinePlayers/dto/OnlinePlayerSearchQuery.dto.ts
+++ b/src/onlinePlayers/dto/OnlinePlayerSearchQuery.dto.ts
@@ -3,6 +3,11 @@ import { IsArray, IsEnum, IsOptional } from 'class-validator';
 import { Transform } from 'class-transformer';
 
 export default class OnlinePlayerSearchQueryDto {
+  /**
+   * Filter online players
+   *
+   * @example ?search=status="UI"
+   */
   @IsOptional()
   @IsArray()
   @IsEnum(OnlinePlayerStatus, { each: true })

--- a/src/onlinePlayers/dto/OnlinePlayerSearchQuery.dto.ts
+++ b/src/onlinePlayers/dto/OnlinePlayerSearchQuery.dto.ts
@@ -1,0 +1,18 @@
+import { OnlinePlayerStatus } from '../enum/OnlinePlayerStatus';
+import { IsArray, IsEnum, IsOptional } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export default class OnlinePlayerSearchQueryDto {
+  @IsOptional()
+  @IsArray()
+  @IsEnum(OnlinePlayerStatus, { each: true })
+  @Transform(({ value }) => {
+    if (!value) return undefined;
+
+    const matches = value.match(/status="(.*?)"/g);
+    if (!matches) return [];
+
+    return matches.map((m) => m.replace(/status="|"$/g, ''));
+  })
+  search?: OnlinePlayerStatus[];
+}

--- a/src/onlinePlayers/onlinePlayers.controller.ts
+++ b/src/onlinePlayers/onlinePlayers.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query } from '@nestjs/common';
 import { OnlinePlayersService } from './onlinePlayers.service';
 import { LoggedUser } from '../common/decorator/param/LoggedUser.decorator';
 import { User } from '../auth/user';
@@ -6,6 +6,7 @@ import { UniformResponse } from '../common/decorator/response/UniformResponse';
 import ApiResponseDescription from '../common/swagger/response/ApiResponseDescription';
 import OnlinePlayerDto from './dto/onlinePlayer.dto';
 import InformPlayerIsOnlineDto from './dto/InformPlayerIsOnline.dto';
+import OnlinePlayerSearchQueryDto from './dto/OnlinePlayerSearchQuery.dto';
 
 @Controller('online-players')
 export class OnlinePlayersController {
@@ -50,7 +51,10 @@ export class OnlinePlayersController {
   })
   @Get()
   @UniformResponse(null, OnlinePlayerDto)
-  async getAllOnlinePlayers() {
-    return this.onlinePlayersService.getAllOnlinePlayers();
+  async getAllOnlinePlayers(@Query() query: OnlinePlayerSearchQueryDto) {
+    const filter = { status: query.search };
+    return this.onlinePlayersService.getAllOnlinePlayers({
+      filter,
+    });
   }
 }

--- a/src/onlinePlayers/onlinePlayers.service.ts
+++ b/src/onlinePlayers/onlinePlayers.service.ts
@@ -56,14 +56,25 @@ export class OnlinePlayersService {
    *
    * @returns Array of OnlinePlayers or empty array if nothing found
    */
-  async getAllOnlinePlayers(): Promise<OnlinePlayer[]> {
+  async getAllOnlinePlayers(options?: {
+    filter?: { status?: OnlinePlayerStatus[] };
+  }): Promise<OnlinePlayer[]> {
     const players = await this.redisService.getValuesByKeyPattern(
       `${this.ONLINE_PLAYERS_KEY}:*`,
     );
 
     if (!players) return [];
 
-    const onlinePlayersStr = Object.values(players);
-    return onlinePlayersStr.map((playerStr) => JSON.parse(playerStr));
+    const onlinePlayers = Object.values(players).map((playerStr) =>
+      JSON.parse(playerStr),
+    ) as OnlinePlayer[];
+
+    if (options?.filter?.status) {
+      return onlinePlayers.filter((p) =>
+        options.filter.status.includes(p.status),
+      );
+    }
+
+    return onlinePlayers;
   }
 }


### PR DESCRIPTION
### Brief description

Now it is possible to filter online players by `status` field. It is possible to filter them by one or by multiple values. For example:

`?search=status="UI" //only players with status UI` 
or 
`?search=status="UI";AND;status="Battle" //only players with status UI or Battle`

### Change list

- Added search query to _/online-players GET_ endpoint
