### PR TITLE
Feature/add transaction support 576

### DIFF
--- a/src/__tests__/box/BoxService/deleteBox.test.ts
+++ b/src/__tests__/box/BoxService/deleteBox.test.ts
@@ -219,7 +219,10 @@ describe('BoxService.deleteBox() test suite', () => {
 
   it('Should throw an error if the box does not exist', async () => {
     const nonExistentBoxId = new ObjectId().toString();
-    await expect(boxService.deleteBox(nonExistentBoxId)).rejects.toEqual(
+
+    const [_, err] = await boxService.deleteBox(nonExistentBoxId);
+
+    expect(err).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           reason: SEReason.NOT_FOUND,

--- a/src/__tests__/test_utils/globalSetup.ts
+++ b/src/__tests__/test_utils/globalSetup.ts
@@ -1,18 +1,19 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryReplSet, MongoMemoryServer } from 'mongodb-memory-server';
 import fs from 'fs';
 import path from 'path';
 
 const globalConfigPath = path.join(__dirname, 'globalConfig.json');
 
 export default async function globalSetup() {
-  const mongod = await MongoMemoryServer.create();
-  const mongoUri = mongod.getUri();
+  const replSet = await MongoMemoryReplSet.create({ replSet: { count: 1 } });
+  await replSet.waitUntilRunning();
+  const mongoUri = replSet.getUri();
 
   // Save URI and instance metadata to file
   fs.writeFileSync(globalConfigPath, JSON.stringify({ mongoUri }, null, 2));
 
   // Save to globalThis if needed elsewhere
-  (globalThis as any).__MONGOD__ = mongod;
+  (globalThis as any).__MONGOD__ = replSet;
 
   process.env.TEST_MONGO_URI = mongoUri;
 }

--- a/src/box/box.service.ts
+++ b/src/box/box.service.ts
@@ -364,15 +364,16 @@ export class BoxService {
     session.startTransaction();
 
     const [box, boxError] = await this.readOneById(boxId);
-    if (boxError) await cancelTransaction(session, boxError);
+    if (boxError) return await cancelTransaction(session, boxError);
 
     const [, deleteBoxError] = await this.deleteOneById(boxId);
-    if (deleteBoxError) await cancelTransaction(session, deleteBoxError);
+    if (deleteBoxError) return await cancelTransaction(session, deleteBoxError);
 
     const [, adminDeleteError] = await this.adminBasicService.deleteOne({
       filter: { password: box.adminPassword },
     });
-    if (adminDeleteError) await cancelTransaction(session, adminDeleteError);
+    if (adminDeleteError)
+      return await cancelTransaction(session, adminDeleteError);
 
     session.commitTransaction();
     session.endSession();

--- a/src/clan/clan.service.ts
+++ b/src/clan/clan.service.ts
@@ -6,7 +6,7 @@ import { PlayerDto } from '../player/dto/player.dto';
 import { Injectable } from '@nestjs/common';
 import { Clan, publicReferences } from './clan.schema';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { ClientSession, Model } from 'mongoose';
 import { ClanDto } from './dto/clan.dto';
 import BasicService from '../common/service/basicService/BasicService';
 import ServiceError from '../common/service/basicService/ServiceError';
@@ -215,8 +215,9 @@ export class ClanService {
   async updateOne(
     updateInfo: Partial<Clan>,
     options: TIServiceUpdateOneOptions,
+    session?: ClientSession,
   ) {
-    return this.basicService.updateOne(updateInfo, options);
+    return this.basicService.updateOne(updateInfo, options, session);
   }
 
   /**

--- a/src/clanInventory/item/item.service.ts
+++ b/src/clanInventory/item/item.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Model } from 'mongoose';
+import { ClientSession, Model } from 'mongoose';
 import { InjectModel } from '@nestjs/mongoose';
 import { Item } from './item.schema';
 import { CreateItemDto } from './dto/createItem.dto';
@@ -31,10 +31,11 @@ export class ItemService {
    * Creates an new Item in DB.
    *
    * @param item - The Item data to create.
+   * @param session - Optional DB session.
    * @returns  created Item or an array of service errors if any occurred.
    */
-  async createOne(item: CreateItemDto) {
-    return this.basicService.createOne<CreateItemDto, ItemDto>(item);
+  async createOne(item: CreateItemDto, session?: ClientSession) {
+    return this.basicService.createOne<CreateItemDto, ItemDto>(item, session);
   }
 
   /**

--- a/src/common/function/cancelTransaction.ts
+++ b/src/common/function/cancelTransaction.ts
@@ -1,5 +1,6 @@
 import { ClientSession } from 'mongoose';
 import ServiceError from '../service/basicService/ServiceError';
+import { IServiceReturn } from '../service/basicService/IService';
 
 /**
  * Aborts the database transaction and ends the session.
@@ -12,8 +13,8 @@ import ServiceError from '../service/basicService/ServiceError';
 export async function cancelTransaction(
   session: ClientSession,
   error: ServiceError[],
-) {
+): Promise<IServiceReturn<any>> {
   await session.abortTransaction();
   await session.endSession();
-  throw error;
+  return [false, error];
 }

--- a/src/common/service/basicService/BasicService.ts
+++ b/src/common/service/basicService/BasicService.ts
@@ -1,4 +1,4 @@
-import { Error, Model } from 'mongoose';
+import { ClientSession, Error, Model } from 'mongoose';
 import {
   IService,
   IServiceReturn,
@@ -29,10 +29,12 @@ export default class BasicService implements IService {
 
   async createOne<TInput = any, TOutput = any>(
     input: TInput,
+    session?: ClientSession,
   ): Promise<IServiceReturn<TOutput>> {
     try {
-      const data = await this.model.create(input);
-      return [data, null];
+      const options = session ? { session } : undefined;
+      const data = await this.model.create([input], options);
+      return [data[0], null];
     } catch (error) {
       const errors = convertMongooseToServiceErrors(error);
       return [null, errors];
@@ -41,9 +43,11 @@ export default class BasicService implements IService {
 
   async createMany<TInput = any, TOutput = any>(
     input: TInput[],
+    session?: ClientSession,
   ): Promise<IServiceReturn<TOutput[]>> {
     try {
-      const data = await this.model.create(input);
+      const options = session ? { session } : undefined;
+      const data = await this.model.create(input, options);
       return [data, null];
     } catch (error) {
       const errors = convertMongooseToServiceErrors(error);
@@ -145,9 +149,11 @@ export default class BasicService implements IService {
   async updateOneById<TInput = any>(
     _id: string,
     input: TInput,
+    session?: ClientSession,
   ): Promise<IServiceReturn<boolean>> {
     try {
-      const resp = await this.model.updateOne({ _id }, input);
+      const options = session ? { session } : undefined;
+      const resp = await this.model.updateOne({ _id }, input, options);
       if (resp.matchedCount === 0)
         return [
           null,
@@ -172,12 +178,19 @@ export default class BasicService implements IService {
   async updateOne<TInput = any>(
     input: TInput,
     options: TIServiceUpdateOneOptions,
+    session?: ClientSession,
   ): Promise<IServiceReturn<boolean>> {
     try {
       const { filter } = options ? options : { filter: undefined };
       const filterToApply = Array.isArray(filter) ? { $or: filter } : filter;
 
-      const resp = await this.model.updateOne(filterToApply, input);
+      const mongooseOptions = session ? { session } : undefined;
+
+      const resp = await this.model.updateOne(
+        filterToApply,
+        input,
+        mongooseOptions,
+      );
       if (resp.matchedCount === 0)
         return [
           null,
@@ -200,11 +213,18 @@ export default class BasicService implements IService {
   async updateMany<TInput = any>(
     input: TInput[],
     options: TIServiceUpdateManyOptions,
+    session?: ClientSession,
   ): Promise<IServiceReturn<boolean>> {
     try {
       const { filter } = options ? options : { filter: undefined };
       const filterToApply = Array.isArray(filter) ? { $or: filter } : filter;
-      const resp = await this.model.updateMany(filterToApply, input);
+
+      const mongooseOptions = session ? { session } : undefined;
+      const resp = await this.model.updateMany(
+        filterToApply,
+        input,
+        mongooseOptions,
+      );
       if (resp.matchedCount === 0)
         return [
           null,
@@ -224,9 +244,13 @@ export default class BasicService implements IService {
     }
   }
 
-  async deleteOneById(_id: string): Promise<IServiceReturn<true>> {
+  async deleteOneById(
+    _id: string,
+    session?: ClientSession,
+  ): Promise<IServiceReturn<true>> {
     try {
-      const resp = await this.model.deleteOne({ _id });
+      const mongooseOptions = session ? { session } : undefined;
+      const resp = await this.model.deleteOne({ _id }, mongooseOptions);
       if (resp.deletedCount === 0)
         return [
           null,
@@ -249,10 +273,12 @@ export default class BasicService implements IService {
 
   async deleteOne(
     options: TIServiceDeleteOneOptions,
+    session?: ClientSession,
   ): Promise<IServiceReturn<true>> {
     try {
       const { filter } = options ? options : { filter: undefined };
-      const resp = await this.model.deleteOne(filter);
+      const mongooseOptions = session ? { session } : undefined;
+      const resp = await this.model.deleteOne(filter, mongooseOptions);
       if (resp.deletedCount === 0)
         return [
           null,
@@ -273,10 +299,12 @@ export default class BasicService implements IService {
 
   async deleteMany(
     options: TIServiceDeleteManyOptions,
+    session?: ClientSession,
   ): Promise<IServiceReturn<true>> {
     try {
       const { filter } = options ? options : { filter: undefined };
-      const resp = await this.model.deleteMany(filter);
+      const mongooseOptions = session ? { session } : undefined;
+      const resp = await this.model.deleteMany(filter, mongooseOptions);
       if (resp.deletedCount === 0)
         return [
           null,

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
+import { InjectConnection, InjectModel } from '@nestjs/mongoose';
 import { FleaMarketItem, publicReferences } from './fleaMarketItem.schema';
 import BasicService from '../common/service/basicService/BasicService';
-import { ClientSession, Model } from 'mongoose';
+import { ClientSession, Connection, Model } from 'mongoose';
 import {
+  IServiceReturn,
   TIServiceReadManyOptions,
   TReadByIdOptions,
 } from '../common/service/basicService/IService';
@@ -13,7 +14,6 @@ import { PlayerService } from '../player/player.service';
 import { CreateFleaMarketItemDto } from './dto/createFleaMarketItem.dto';
 import { ItemService } from '../clanInventory/item/item.service';
 import { Status } from './enum/status.enum';
-import ServiceError from '../common/service/basicService/ServiceError';
 import { VotingType } from '../voting/enum/VotingType.enum';
 import { ClanService } from '../clan/clan.service';
 import { VotingDto } from '../voting/dto/voting.dto';
@@ -28,6 +28,7 @@ import { VotingService } from '../voting/voting.service';
 import { PlayerDto } from '../player/dto/player.dto';
 import { VotingQueue } from '../voting/voting.queue';
 import { VotingQueueName } from '../voting/enum/VotingQueue.enum';
+import { cancelTransaction } from '../common/function/cancelTransaction';
 
 @Injectable()
 export class FleaMarketService {
@@ -41,6 +42,7 @@ export class FleaMarketService {
     private readonly votingService: VotingService,
     private readonly votingQueue: VotingQueue,
     private readonly clanService: ClanService,
+    @InjectConnection() private readonly connection: Connection,
   ) {
     this.basicService = new BasicService(model);
   }
@@ -53,11 +55,11 @@ export class FleaMarketService {
    * @param item - The Item data to create.
    * @returns  created Item or an array of service errors if any occurred.
    */
-  async createOne(item: CreateFleaMarketItemDto) {
+  async createOne(item: CreateFleaMarketItemDto, session?: ClientSession) {
     return this.basicService.createOne<
       CreateFleaMarketItemDto,
       FleaMarketItemDto
-    >(item);
+    >(item, session);
   }
   /**
    * Reads an Item by its _id in DB.
@@ -115,20 +117,33 @@ export class FleaMarketService {
    * @param clanId - The ID of the clan to which the item belongs to.
    * @param playerId - The ID of the player starting the process.
    */
-  async handleSellItem(itemId: string, clanId: string, playerId: string) {
+  async handleSellItem(
+    itemId: string,
+    clanId: string,
+    playerId: string,
+  ): Promise<IServiceReturn<boolean>> {
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
     const [item, itemErrors] = await this.itemService.readOneById(itemId);
-    if (itemErrors) throw itemErrors;
-    if (!item.stock_id) throw itemNotInStockError;
+    if (itemErrors) return await cancelTransaction(session, itemErrors);
+    if (!item.stock_id)
+      return await cancelTransaction(session, [itemNotInStockError]);
 
     const [player, playerErrors] =
       await this.playerService.getPlayerById(playerId);
-    if (playerErrors) throw playerErrors;
+    if (playerErrors) return await cancelTransaction(session, playerErrors);
 
     const newItem = await this.helperService.itemToCreateFleaMarketItem(
       item,
       clanId,
     );
-    const createdItem = await this.moveItemToFleaMarket(newItem, itemId);
+    const [createdItem, err] = await this.moveItemToFleaMarket(
+      newItem,
+      itemId,
+      session,
+    );
+    if (err) return await cancelTransaction(session, err);
     const [voting, errors] = await this.votingService.startVoting({
       voterPlayer: player,
       type: VotingType.FLEA_MARKET_SELL_ITEM,
@@ -136,14 +151,19 @@ export class FleaMarketService {
       fleaMarketItem: createdItem,
       queue: VotingQueueName.FLEA_MARKET,
     });
-    if (errors) throw errors;
+    if (errors) return await cancelTransaction(session, errors);
 
-    this.votingQueue.addVotingCheckJob({
+    await this.votingQueue.addVotingCheckJob({
       voting,
       fleaMarketItemId: createdItem._id.toString(),
       stockId: item.stock_id.toString(),
       queue: VotingQueueName.FLEA_MARKET,
     });
+
+    await session.commitTransaction();
+    await session.endSession();
+
+    return [true, null];
   }
 
   /**
@@ -160,37 +180,23 @@ export class FleaMarketService {
   private async moveItemToFleaMarket(
     newItem: CreateFleaMarketItemDto,
     oldItemId: string,
-  ) {
-    const session: ClientSession = await this.model.db.startSession();
-    session.startTransaction();
+    session?: ClientSession,
+  ): Promise<IServiceReturn<FleaMarketItemDto>> {
+    if (!session) {
+      session = await this.connection.startSession();
+      session.startTransaction();
+    }
 
-    const [created, createErrors] = await this.createOne(newItem);
-    if (createErrors) await this.cancelTransaction(session, createErrors);
+    const [created, createErrors] = await this.createOne(newItem, session);
+    if (createErrors) return await cancelTransaction(session, createErrors);
 
     const [_, deleteErrors] = await this.itemService.deleteOneById(oldItemId);
-    if (deleteErrors) await this.cancelTransaction(session, deleteErrors);
+    if (deleteErrors) return await cancelTransaction(session, deleteErrors);
 
     await session.commitTransaction();
     session.endSession();
 
-    return created;
-  }
-
-  /**
-   * Aborts the database transaction and ends the session.
-   *
-   * @param session - Started database session.
-   * @param error - The error to be thrown.
-   *
-   * @throws Will throw an unexpected service error.
-   */
-  private async cancelTransaction(
-    session: ClientSession,
-    error: ServiceError[],
-  ) {
-    await session.abortTransaction();
-    await session.endSession();
-    throw error;
+    return [created, null];
   }
 
   /**
@@ -201,15 +207,18 @@ export class FleaMarketService {
    *
    * @throws Will throw if there is an error with the database transaction.
    */
-  private async handlePassedBuyVoting(voting: VotingDto, stockId: string) {
-    const session = await this.model.db.startSession();
+  private async handlePassedBuyVoting(
+    voting: VotingDto,
+    stockId: string,
+  ): Promise<IServiceReturn<boolean>> {
+    const session = await this.connection.startSession();
     session.startTransaction();
 
     const [item, itemErrors] =
       await this.basicService.readOneById<FleaMarketItemDto>(
         voting.fleaMarketItem_id,
       );
-    if (itemErrors) await this.cancelTransaction(session, itemErrors);
+    if (itemErrors) return await cancelTransaction(session, itemErrors);
 
     const newItem = await this.helperService.fleaMarketItemToCreateItemDto(
       item,
@@ -218,17 +227,19 @@ export class FleaMarketService {
 
     const [_, itemCreateErrors] = await this.itemService.createOne(newItem);
     if (itemCreateErrors) {
-      await this.cancelTransaction(session, itemCreateErrors);
+      return await cancelTransaction(session, itemCreateErrors);
     }
 
     const [__, itemDeleteErrors] = await this.basicService.deleteOneById(
       voting.fleaMarketItem_id,
     );
     if (itemDeleteErrors)
-      await this.cancelTransaction(session, itemDeleteErrors);
+      return await cancelTransaction(session, itemDeleteErrors);
 
-    session.commitTransaction();
-    session.endSession();
+    await session.commitTransaction();
+    await session.endSession();
+
+    return [true, null];
   }
 
   /**
@@ -244,7 +255,7 @@ export class FleaMarketService {
     voting: VotingDto,
     clanId: string,
     itemPrice: number,
-  ) {
+  ): Promise<IServiceReturn<boolean>> {
     const session = await this.model.db.startSession();
     session.startTransaction();
 
@@ -252,20 +263,22 @@ export class FleaMarketService {
       voting.fleaMarketItem_id,
       { status: Status.AVAILABLE },
     );
-    if (updateErrors) await this.cancelTransaction(session, updateErrors);
+    if (updateErrors) return await cancelTransaction(session, updateErrors);
 
     const [clan, clanErrors] = await this.clanService.readOneById(clanId);
-    if (clanErrors) await this.cancelTransaction(session, clanErrors);
+    if (clanErrors) return await cancelTransaction(session, clanErrors);
 
     const [__, clanUpdateErrors] = await this.clanService.updateOne(
       { gameCoins: clan.gameCoins + itemPrice },
       { filter: { _id: clanId } },
     );
     if (clanUpdateErrors)
-      await this.cancelTransaction(session, clanUpdateErrors);
+      return await cancelTransaction(session, clanUpdateErrors);
 
-    session.commitTransaction();
-    session.endSession();
+    await session.commitTransaction();
+    await session.endSession();
+
+    return [true, null];
   }
 
   /**
@@ -291,28 +304,34 @@ export class FleaMarketService {
    *
    * @throws Will throw if there is an error with the database transaction.
    */
-  private async handleRejectedSellVoting(fmItemId: string, stockId: string) {
+  private async handleRejectedSellVoting(
+    fmItemId: string,
+    stockId: string,
+  ): Promise<IServiceReturn<boolean>> {
     const [fmItem, fmItemErrors] =
       await this.basicService.readOneById(fmItemId);
     if (fmItemErrors) throw fmItemErrors;
 
-    const session = await this.model.startSession();
+    const session = await this.connection.startSession();
     session.startTransaction();
 
     const [_, deleteErrors] = await this.basicService.deleteOneById(
       fmItem._id.toString(),
+      session,
     );
-    if (deleteErrors) this.cancelTransaction(session, deleteErrors);
+    if (deleteErrors) return cancelTransaction(session, deleteErrors);
 
     const item = await this.helperService.fleaMarketItemToCreateItemDto(
       fmItem,
       stockId,
     );
-    const [__, createErrors] = await this.itemService.createOne(item);
-    if (createErrors) this.cancelTransaction(session, createErrors);
+    const [__, createErrors] = await this.itemService.createOne(item, session);
+    if (createErrors) return cancelTransaction(session, createErrors);
 
     await session.commitTransaction();
     await session.endSession();
+
+    return [true, null];
   }
 
   /**
@@ -325,23 +344,29 @@ export class FleaMarketService {
    * @throws Will throw a service error if item is not available
    * or if the clan doesn't have enough coins for the item.
    */
-  async handleBuyItem(clanId: string, itemId: string, playerId: string) {
+  async handleBuyItem(
+    clanId: string,
+    itemId: string,
+    playerId: string,
+  ): Promise<IServiceReturn<boolean>> {
     const [clan, clanErrors] = await this.clanService.readOneById(clanId, {
       includeRefs: [ModelName.STOCK],
     });
-    if (clanErrors) throw clanErrors;
+    if (clanErrors) return [false, clanErrors];
 
     const [item, itemErrors] = await this.readOneById(itemId);
-    if (itemErrors) throw itemErrors;
+    if (itemErrors) return [false, itemErrors];
 
-    if (item.status !== Status.AVAILABLE) throw itemNotAvailableError;
-    if (clan.gameCoins < item.price) throw notEnoughCoinsError;
+    if (item.status !== Status.AVAILABLE)
+      return [false, [itemNotAvailableError]];
+    if (clan.gameCoins < item.price) return [false, [notEnoughCoinsError]];
 
     const [player, playerErrors] =
       await this.playerService.getPlayerById(playerId);
-    if (playerErrors) throw playerErrors;
+    if (playerErrors) return [false, playerErrors];
 
-    const voting = await this.handleBooking(clan, item, player);
+    const [voting, err] = await this.handleBooking(clan, item, player);
+    if (err) return [false, err];
     this.votingQueue.addVotingCheckJob({
       voting,
       clanId,
@@ -349,6 +374,8 @@ export class FleaMarketService {
       stockId: clan.Stock?._id.toString(),
       queue: VotingQueueName.FLEA_MARKET,
     });
+
+    return [true, null];
   }
 
   /**
@@ -397,12 +424,16 @@ export class FleaMarketService {
     item: FleaMarketItemDto,
     status: Status,
     session: ClientSession,
-  ) {
+  ): Promise<IServiceReturn<boolean>> {
     item.status = status;
-    const [__, itemUpdateErr] = await this.basicService.updateOne(item, {
-      filter: { _id: item._id },
-    });
-    if (itemUpdateErr) this.cancelTransaction(session, itemUpdateErr);
+    const [__, itemUpdateErr] = await this.basicService.updateOne(
+      item,
+      { filter: { _id: item._id } },
+      session,
+    );
+    if (itemUpdateErr) return await cancelTransaction(session, itemUpdateErr);
+
+    return [true, null];
   }
 
   /**
@@ -418,12 +449,16 @@ export class FleaMarketService {
     clan: ClanDto,
     amount: number,
     session: ClientSession,
-  ) {
+  ): Promise<IServiceReturn<boolean>> {
     clan.gameCoins -= amount;
-    const [_, clanUpdateErr] = await this.clanService.updateOne(clan, {
-      filter: { _id: clan._id },
-    });
-    if (clanUpdateErr) this.cancelTransaction(session, clanUpdateErr);
+    const [_, clanUpdateErr] = await this.clanService.updateOne(
+      clan,
+      { filter: { _id: clan._id } },
+      session,
+    );
+    if (clanUpdateErr) return await cancelTransaction(session, clanUpdateErr);
+
+    return [true, null];
   }
 
   /**
@@ -439,7 +474,7 @@ export class FleaMarketService {
     clan: ClanDto,
     item: FleaMarketItemDto,
     player: PlayerDto,
-  ) {
+  ): Promise<IServiceReturn<VotingDto>> {
     const session = await this.model.startSession();
     session.startTransaction();
 
@@ -453,11 +488,12 @@ export class FleaMarketService {
       type: VotingType.FLEA_MARKET_BUY_ITEM,
       queue: VotingQueueName.FLEA_MARKET,
     });
-    if (createVotingErrors) this.cancelTransaction(session, createVotingErrors);
+    if (createVotingErrors)
+      return await cancelTransaction(session, createVotingErrors);
 
-    session.commitTransaction();
-    session.endSession();
+    await session.commitTransaction();
+    await session.endSession();
 
-    return voting;
+    return [voting, null];
   }
 }

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { ClientSession, Model } from 'mongoose';
 import BasicService from '../common/service/basicService/BasicService';
 import { CreateVotingDto } from './dto/createVoting.dto';
 import { VoteChoice } from './enum/choiceType.enum';
@@ -36,8 +36,11 @@ export class VotingService {
    * @param voting - The data transfer object containing the details of the voting to be created.
    * @returns A promise that resolves to the created voting entity.
    */
-  async createOne(voting: CreateVotingDto) {
-    return this.basicService.createOne<CreateVotingDto, VotingDto>(voting);
+  async createOne(voting: CreateVotingDto, session?: ClientSession) {
+    return this.basicService.createOne<CreateVotingDto, VotingDto>(
+      voting,
+      session,
+    );
   }
 
   /**
@@ -54,6 +57,7 @@ export class VotingService {
    */
   async startVoting(
     params: StartVotingParams,
+    session?: ClientSession,
   ): Promise<[VotingDto, ServiceError[]]> {
     const {
       voterPlayer,
@@ -84,7 +88,7 @@ export class VotingService {
 
     newVoting.votes = [newVote];
 
-    const [voting, errors] = await this.createOne(newVoting);
+    const [voting, errors] = await this.createOne(newVoting, session);
     if (errors) return [null, errors];
 
     this.notifier.newVoting(voting, shopItem ?? fleaMarketItem, voterPlayer);


### PR DESCRIPTION
### Code Refactoring:
* `src/clanInventory/item/item.service.ts`, `src/clan/clan.service.ts`, and other service files: Added `ClientSession` imports and integrated session support into relevant methods, ensuring uniform transaction handling across services. 

These changes collectively enhance the robustness and maintainability of the codebase while improving the developer experience during testing.

### Brief description
This pr adds transaction support to the api and unit tests.


### Change list

- Changed `cancelTransaction` helper method now returns the errors instead of throwing them.
- Changed the in memory test db to `MongoMemoryReplSet` to allow transaction testing.
- Added optional `ClientSession` parameter to all `BasicService` write methods.
- Fixed tests.
- Fixed service methods that improperly used transactions.
