### PR TITLE
Add buy extra stall slot endpoint

### DIFF
--- a/src/__tests__/box/accountClaimer/TesterAccountService/createTester.test.ts
+++ b/src/__tests__/box/accountClaimer/TesterAccountService/createTester.test.ts
@@ -49,7 +49,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     const username = 'my-username';
     generatePasswordMock.mockReturnValueOnce(username);
 
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
 
     const profilesInDB = await profileModel.findOne({ username });
 
@@ -60,7 +60,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     const name = 'my-player';
     generatePasswordMock.mockReturnValueOnce(name);
 
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
 
     const playersInDB = await playerModel.findOne({ name });
 
@@ -69,7 +69,9 @@ describe('TesterAccountService.createTester() test suite', () => {
 
   it('Should return created tester', async () => {
     generatePasswordMock.mockReturnValueOnce('tester');
-    const [createdTester, errors] = await service.createTester();
+    const [createdTester, errors] = await service.createTester(
+      existingBox._id.toString(),
+    );
 
     expect(errors).toBeNull();
     expect(createdTester.Profile).not.toBeNull();
@@ -91,7 +93,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingUsername1);
 
     const profilesInDBBefore = await profileModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const profilesInDBAfter = await profileModel.find();
 
     expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + 1);
@@ -106,7 +108,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingUsername);
 
     const profilesInDBBefore = await profileModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const profilesInDBAfter = await profileModel.find();
 
     expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + 1);
@@ -128,7 +130,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingName1);
 
     const playersInDBBefore = await playerModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const playersInDBAfter = await playerModel.find();
 
     expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + 1);
@@ -144,7 +146,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingName);
 
     const playersInDBBefore = await playerModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const playersInDBAfter = await playerModel.find();
 
     expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + 1);
@@ -166,7 +168,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingId1);
 
     const playersInDBBefore = await playerModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const playersInDBAfter = await playerModel.find();
 
     expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + 1);
@@ -182,7 +184,7 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValueOnce(existingId);
 
     const playersInDBBefore = await playerModel.find();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
     const playersInDBAfter = await playerModel.find();
 
     expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + 1);
@@ -193,9 +195,9 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValue(sameUsername);
 
     const profilesInDBBefore = await profileModel.find();
-    await service.createTester();
-    await service.createTester();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
+    await service.createTester(existingBox._id.toString());
+    await service.createTester(existingBox._id.toString());
     const profilesInDBAfter = await profileModel.find();
 
     expect(profilesInDBAfter).toHaveLength(profilesInDBBefore.length + 3);
@@ -206,9 +208,9 @@ describe('TesterAccountService.createTester() test suite', () => {
     generatePasswordMock.mockReturnValue(sameName);
 
     const playersInDBBefore = await playerModel.find();
-    await service.createTester();
-    await service.createTester();
-    await service.createTester();
+    await service.createTester(existingBox._id.toString());
+    await service.createTester(existingBox._id.toString());
+    await service.createTester(existingBox._id.toString());
     const playersInDBAfter = await playerModel.find();
 
     expect(playersInDBAfter).toHaveLength(playersInDBBefore.length + 3);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import BoxAuthService from './box/BoxAuthService';
 import ApiResponseDescription from '../common/swagger/response/ApiResponseDescription';
 import { ModelName } from '../common/enum/modelName.enum';
 import { ProfileDto } from '../profile/dto/profile.dto';
+import { NoBoxIdFilter } from '../box/auth/decorator/NoBoxIdFilter.decorator';
 
 @NoAuth()
 @Controller('auth')
@@ -32,9 +33,10 @@ export class AuthController {
     },
     errors: [400, 401],
   })
+  @NoBoxIdFilter()
   @Post('/signIn')
   @ThrowAuthErrorIfFound()
-  public signIn(@Body() body: SignInDto) {
+  public async signIn(@Body() body: SignInDto) {
     return this.authService.signIn(body.username, body.password);
   }
 }

--- a/src/auth/box/BoxAuthService.ts
+++ b/src/auth/box/BoxAuthService.ts
@@ -69,20 +69,17 @@ export default class BoxAuthService extends AuthService {
       clan_id: playerResp.clan_id?.toString(),
     };
 
-    let box_id: string,
-      groupAdmin = false;
+    let box_id: string;
+    let groupAdmin = false;
     const box = await this.boxModel.findOne({
       adminProfile_id: new ObjectId(profile._id),
     });
 
     //TODO: add logic for determining box _id based on the player or profile collection box_id field, when this field is added to every schema
     if (!box) {
-      const boxWithTester = await this.boxModel.findOne({
-        'testers.profile_id': new ObjectId(profile._id),
-      });
-      if (!boxWithTester) return null;
+      if (!(profile as any).box_id) return null;
 
-      box_id = boxWithTester.id.toString();
+      box_id = (profile as any).box_id.toString();
     } else {
       box_id = box._id.toString();
       groupAdmin = true;

--- a/src/auth/box/BoxAuthService.ts
+++ b/src/auth/box/BoxAuthService.ts
@@ -75,7 +75,6 @@ export default class BoxAuthService extends AuthService {
       adminProfile_id: new ObjectId(profile._id),
     });
 
-    //TODO: add logic for determining box _id based on the player or profile collection box_id field, when this field is added to every schema
     if (!box) {
       if (!(profile as any).box_id) return null;
 

--- a/src/box/accountClaimer/accountClaimer.service.ts
+++ b/src/box/accountClaimer/accountClaimer.service.ts
@@ -65,7 +65,7 @@ export default class AccountClaimerService {
       ];
 
     const [account, accountCreationErrors] =
-      await this.testerService.createTester();
+      await this.testerService.createTester(box._id.toString());
     if (accountCreationErrors) return [null, accountCreationErrors];
 
     const [accountClan, clanAssigningErrors] =
@@ -80,6 +80,7 @@ export default class AccountClaimerService {
       profile_id: account.Profile._id.toString(),
       clan_id: accountClan._id.toString(),
       box_id: box._id.toString(),
+      groupAdmin: false,
     });
 
     return [

--- a/src/box/auth/boxAuth.guard.ts
+++ b/src/box/auth/boxAuth.guard.ts
@@ -83,7 +83,7 @@ export class BoxAuthGuard implements CanActivate {
           ],
         });
 
-      if (!profile_id || !player_id || !box_id)
+      if (!profile_id || !player_id || !box_id || groupAdmin === null)
         throw new UnauthorizedException({
           ...errorResponse,
           message: 'Incorrect token provided.',

--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -10,6 +10,7 @@ import { ClanLogo } from './clanLogo.schema';
 import { ClanRole, ClanRoleSchema } from './role/ClanRole.schema';
 import { initializationClanRoles } from './role/initializationClanRoles';
 import { Stall } from './stall/stall.schema';
+import { getDefaultStall } from './defaultValues/stall';
 
 export type ClanDocument = HydratedDocument<Clan>;
 
@@ -70,8 +71,12 @@ export class Clan {
   })
   roles: ClanRole[];
 
-  @Prop({ type: Stall, required: false })
-  stall?: Stall;
+  @Prop({
+    type: Stall,
+    required: false,
+    default: getDefaultStall(),
+  })
+  stall: Stall;
 
   @ExtractField()
   _id: string;

--- a/src/clan/defaultValues/stall.ts
+++ b/src/clan/defaultValues/stall.ts
@@ -1,8 +1,26 @@
+import { Stall } from '../stall/stall.schema';
+
 /**
  * Function where to define stall related default values
  */
 export function getStallDefaultValues() {
   return {
     stallSlotPrice: 200,
+  };
+}
+
+/**
+ * Get default stall to be saved in DB
+ *
+ * @returns default stall
+ */
+export function getDefaultStall(): Stall {
+  return {
+    adPoster: {
+      border: '#000000',
+      colour: '#FFFFFF',
+      mainFurniture: '',
+    },
+    maxSlots: 10,
   };
 }

--- a/src/fleaMarket/stall/dto/buyStallSlot.dto.ts
+++ b/src/fleaMarket/stall/dto/buyStallSlot.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, IsOptional } from 'class-validator';
+import AddType from '../../../common/base/decorator/AddType.decorator';
+
+@AddType('BuyStallSlot')
+export class BuyStallSlotDto {
+  @IsInt()
+  @IsOptional()
+  amount: number = 1;
+}

--- a/src/fleaMarket/stall/stall.controller.ts
+++ b/src/fleaMarket/stall/stall.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { StallService } from './stall.service';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
 import { ModelName } from '../../common/enum/modelName.enum';
@@ -11,6 +11,7 @@ import { LoggedUser } from 'src/common/decorator/param/LoggedUser.decorator';
 import { User } from 'src/auth/user';
 import HasClanRights from 'src/clan/role/decorator/guard/HasClanRights';
 import { ClanBasicRight } from 'src/clan/role/enum/clanBasicRight.enum';
+import { BuyStallSlotDto } from './dto/buyStallSlot.dto';
 
 @Controller('stall')
 export class StallController {
@@ -50,7 +51,9 @@ export class StallController {
   }
 
   /**
-   * Buy additional stall slot
+   * Buy additional stall slots
+   *
+   * @remarks Buy additional stall slots
    */
   @ApiResponseDescription({
     success: {
@@ -62,8 +65,11 @@ export class StallController {
   @SwaggerTags('Release on 10.08.2025', 'Stall')
   @UniformResponse()
   @HasClanRights([ClanBasicRight.SHOP])
-  async buyStallSlot(@LoggedUser() user: User) {
-    const [, error] = await this.service.buyStallSlot(user.clan_id);
+  async buyStallSlot(@LoggedUser() user: User, @Body() body: BuyStallSlotDto) {
+    const [, error] = await this.service.buyStallSlot(
+      user.clan_id,
+      body.amount,
+    );
     if (error) return [null, error];
   }
 }


### PR DESCRIPTION
### Brief description
Added endpoint to buy more stall slots.


### Change list

- Added `POST /buy-slot` endpoint
- Added service method for buying the logic
- Added tests for the service method
- Added get default values function for stalls
- Removed the groupAdmin requirements from auth guard to make it possible for all test players to use the endpoints.
