### PR TITLE
Change/add clan data return on sucessfull clan join request 623

### DIFF
--- a/src/__tests__/clan/join/JoinService/handleJoinRequest.test.ts
+++ b/src/__tests__/clan/join/JoinService/handleJoinRequest.test.ts
@@ -39,7 +39,7 @@ describe('JoinService.handleJoinRequest() test suite', () => {
   it(`Should set clan role for the joined player to ${MemberClanRole.name}`, async () => {
     const joinToCreate = joinBuilder.setClanId(openClan._id).build();
 
-    await joinService.handleJoinRequest(joinToCreate.clan_id, player._id);
+    const [clanDto, error] = await joinService.handleJoinRequest(joinToCreate.clan_id, player._id);
 
     const clanInDB = await clanModel.findById(openClan._id);
     const memberRole = clanInDB.roles.find(
@@ -49,6 +49,9 @@ describe('JoinService.handleJoinRequest() test suite', () => {
     const playerInDB = await playerModel.findById(player._id);
 
     expect(playerInDB.clanRole_id.toString()).toBe(memberRole._id.toString());
+    expect(clanDto).toBeDefined();
+    expect(error).toBeNull();
+    expect(clanDto.name).toBe(openClan.name);
   });
 
   it('Should throw NotFoundException if clan with that _id does not exists', async () => {

--- a/src/__tests__/clan/join/JoinService/handleJoinRequest.test.ts
+++ b/src/__tests__/clan/join/JoinService/handleJoinRequest.test.ts
@@ -39,7 +39,10 @@ describe('JoinService.handleJoinRequest() test suite', () => {
   it(`Should set clan role for the joined player to ${MemberClanRole.name}`, async () => {
     const joinToCreate = joinBuilder.setClanId(openClan._id).build();
 
-    const [clanDto, error] = await joinService.handleJoinRequest(joinToCreate.clan_id, player._id);
+    const [clanDto, error] = await joinService.handleJoinRequest(
+      joinToCreate.clan_id,
+      player._id,
+    );
 
     const clanInDB = await clanModel.findById(openClan._id);
     const memberRole = clanInDB.roles.find(

--- a/src/clan/clan.controller.ts
+++ b/src/clan/clan.controller.ts
@@ -49,6 +49,7 @@ import { ApiExtraModels } from '@nestjs/swagger';
 import { ItemDto } from '../clanInventory/item/dto/item.dto';
 import { ClanChatService } from '../chat/service/clanChat.service';
 import { PasswordGenerator } from '../common/function/passwordGenerator';
+import SwaggerTags from '../common/swagger/tags/SwaggerTags.decorator';
 
 @Controller('clan')
 export class ClanController {
@@ -261,6 +262,7 @@ export class ClanController {
     errors: [400, 401, 403, 404],
   })
   @UniformResponse()
+  @SwaggerTags('Release on 24.08.2025', 'Clan')
   @Post('join')
   public async createJoin(
     @Body() body: JoinRequestDto,

--- a/src/clan/join/join.service.ts
+++ b/src/clan/join/join.service.ts
@@ -12,7 +12,7 @@ import ICounter from '../../common/service/counter/ICounter';
 import { Player } from '../../player/schemas/player.schema';
 import { MemberClanRole } from '../role/initializationClanRoles';
 import { ClanDto } from '../dto/clan.dto';
-import { IServiceReturn } from 'src/common/service/basicService/IService';
+import { IServiceReturn } from '../../common/service/basicService/IService';
 
 @Injectable()
 export class JoinService {

--- a/src/clan/join/join.service.ts
+++ b/src/clan/join/join.service.ts
@@ -11,6 +11,8 @@ import { PlayerCounterFactory } from '../clan.counters';
 import ICounter from '../../common/service/counter/ICounter';
 import { Player } from '../../player/schemas/player.schema';
 import { MemberClanRole } from '../role/initializationClanRoles';
+import { ClanDto } from '../dto/clan.dto';
+import { IServiceReturn } from 'src/common/service/basicService/IService';
 
 @Injectable()
 export class JoinService {
@@ -37,12 +39,13 @@ export class JoinService {
    * @param clan_id Id of the clan to join.
    * @param player_id Id of the player trying to join.
    * @param password Password to a closed clan (optional)
+   * @returns ClanDto with the clan data or throws NotFoundException if the clan is not found
    */
   public async handleJoinRequest(
     clan_id: string,
     player_id: string,
     password?: string,
-  ) {
+  ): Promise<IServiceReturn<ClanDto>> {
     const [clan] = await this.clanService.readOneById(clan_id);
     if (!clan) throw new NotFoundException('Clan with that _id is not found');
 
@@ -71,6 +74,8 @@ export class JoinService {
     }
 
     await this.joinClan(player_id, clan_id);
+
+    return [clan, null];
   }
 
   /**


### PR DESCRIPTION
### Brief description

The /clan/join POST endpoint should not return empty response but instead the clan data, to which the logged-in player have joined.


### Change list

- /clan/join POST endpoint returns with the clan data
- Updated the relevant tests
