### PR TITLE
Add change-item-price voting functionality

### DIFF
--- a/src/__tests__/fleaMarket/FleaMarketService/changeItemPrice.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/changeItemPrice.test.ts
@@ -1,0 +1,170 @@
+import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
+import FleaMarketModule from '../modules/fleaMarketModule';
+import { PlayerService } from '../../../player/player.service';
+import { VotingService } from '../../../voting/voting.service';
+import { VotingQueue } from '../../../voting/voting.queue';
+import FleaMarketBuilderFactory from '../data/fleaMarketBuilderFactory';
+import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
+import VotingBuilderFactory from '../../voting/data/voting/VotingBuilderFactory';
+import { Status } from '../../../fleaMarket/enum/status.enum';
+
+describe('FleaMarketService.changeItemPrice() test suite', () => {
+  let fleaMarketService: FleaMarketService;
+  let playerService: PlayerService;
+  let votingService: VotingService;
+  let votingQueue: VotingQueue;
+
+  const fleaMarketItemBuilder =
+    FleaMarketBuilderFactory.getBuilder('FleaMarketItemDto');
+  const PlayerDtoBuilder = PlayerBuilderFactory.getBuilder('PlayerDto');
+  const votingBuilder = VotingBuilderFactory.getBuilder('VotingDto');
+
+  const itemId = 'item';
+  const playerId = 'player';
+  const price = 123;
+
+  let playerDto: any;
+  let fleaMarketItemDto: any;
+  let votingDto: any;
+  const error = [];
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    fleaMarketService = await FleaMarketModule.getFleaMarketService();
+    playerService = await FleaMarketModule.getPlayerService();
+    votingService = await FleaMarketModule.getVotingService();
+    votingQueue = await FleaMarketModule.getVotingQueue();
+
+    playerDto = PlayerDtoBuilder.setClanId('clan').build();
+    fleaMarketItemDto = fleaMarketItemBuilder
+      .setStatus(Status.AVAILABLE)
+      .setClanId('clan')
+      .build();
+    votingDto = votingBuilder.build();
+
+    jest
+      .spyOn(playerService, 'getPlayerById')
+      .mockResolvedValue([playerDto, null]);
+    jest
+      .spyOn(fleaMarketService.basicService, 'readOneById')
+      .mockResolvedValue([fleaMarketItemDto, null]);
+    jest
+      .spyOn(fleaMarketService.basicService, 'updateOneById')
+      .mockResolvedValue([null, null]);
+    jest
+      .spyOn(votingService, 'startVoting')
+      .mockResolvedValue([votingDto, null]);
+    jest.spyOn(votingQueue, 'addVotingCheckJob').mockImplementation();
+  });
+
+  it('should start price change voting and add job', async () => {
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBe(votingDto);
+    expect(err).toBeNull();
+    expect(playerService.getPlayerById).toHaveBeenCalledWith(playerId);
+    expect(fleaMarketService.basicService.readOneById).toHaveBeenCalledWith(
+      itemId,
+    );
+    expect(fleaMarketService.basicService.updateOneById).toHaveBeenCalledWith(
+      fleaMarketItemDto._id,
+      { status: Status.SHIPPING },
+      expect.any(Object),
+    );
+    expect(votingService.startVoting).toHaveBeenCalled();
+    expect(votingQueue.addVotingCheckJob).toHaveBeenCalledWith(
+      expect.objectContaining({ voting: votingDto, queue: expect.any(String) }),
+    );
+  });
+
+  it('should return error if playerService.getPlayerById fails', async () => {
+    jest.spyOn(playerService, 'getPlayerById').mockResolvedValue([null, error]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBe(error);
+  });
+
+  it('should return error if basicService.readOneById fails', async () => {
+    jest
+      .spyOn(fleaMarketService.basicService, 'readOneById')
+      .mockResolvedValue([null, error]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBe(error);
+  });
+
+  it('should return error if item is not available', async () => {
+    const unavailableItem = { ...fleaMarketItemDto, status: Status.BOOKED };
+    jest
+      .spyOn(fleaMarketService.basicService, 'readOneById')
+      .mockResolvedValue([unavailableItem, null]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBeDefined();
+  });
+
+  it('should return error if item not authorized', async () => {
+    const otherClanItem = { ...fleaMarketItemDto, clan_id: 'otherClan' };
+    jest
+      .spyOn(fleaMarketService.basicService, 'readOneById')
+      .mockResolvedValue([otherClanItem, null]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBeDefined();
+  });
+
+  it('should return error if updateOneById fails', async () => {
+    jest
+      .spyOn(fleaMarketService.basicService, 'updateOneById')
+      .mockResolvedValue([null, error]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBe(error);
+  });
+
+  it('should return error if votingService.startVoting fails', async () => {
+    jest.spyOn(votingService, 'startVoting').mockResolvedValue([null, error]);
+    const [ret, err] = await fleaMarketService.changeItemPrice(
+      itemId,
+      price,
+      playerId,
+    );
+    expect(ret).toBeNull();
+    expect(err).toBe(error);
+  });
+
+  it('should throw if addVotingCheckJob throws', async () => {
+    jest.spyOn(votingQueue, 'addVotingCheckJob').mockImplementation(() => {
+      throw new Error('addVotingCheckJob error');
+    });
+    jest
+      .spyOn(votingService, 'startVoting')
+      .mockResolvedValue([votingDto, null]);
+    await expect(
+      fleaMarketService.changeItemPrice(itemId, price, playerId),
+    ).rejects.toThrow('addVotingCheckJob error');
+  });
+});

--- a/src/__tests__/fleaMarket/FleaMarketService/handleSellItem.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/handleSellItem.test.ts
@@ -144,7 +144,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 
@@ -158,7 +158,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 
@@ -170,7 +170,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 
@@ -182,7 +182,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 
@@ -194,7 +194,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 
@@ -206,7 +206,7 @@ describe('FleaMarketService.handleSellItem() test suit', () => {
       clanId,
       playerId,
     );
-    expect(ret).toBe(false);
+    expect(ret).toBe(null);
     expect(err).toBeDefined();
   });
 

--- a/src/__tests__/voting/data/voting/createVotingDtoBuilder.ts
+++ b/src/__tests__/voting/data/voting/createVotingDtoBuilder.ts
@@ -61,4 +61,11 @@ export default class CreateVotingDtoBuilder
     this.base.votes.push(vote);
     return this;
   }
+
+  setPrice(price: number) {
+    if (price >= 0) {
+      this.base.price = price;
+    }
+    return this;
+  }
 }

--- a/src/common/function/cancelTransaction.ts
+++ b/src/common/function/cancelTransaction.ts
@@ -16,5 +16,5 @@ export async function cancelTransaction(
 ): Promise<IServiceReturn<any>> {
   await session.abortTransaction();
   await session.endSession();
-  return [false, error];
+  return [null, error];
 }

--- a/src/fleaMarket/errors/itemNotAuthorized.error.ts
+++ b/src/fleaMarket/errors/itemNotAuthorized.error.ts
@@ -1,0 +1,7 @@
+import { SEReason } from '../../common/service/basicService/SEReason';
+import ServiceError from '../../common/service/basicService/ServiceError';
+
+export const itemNotAuthorizedError = new ServiceError({
+  reason: SEReason.NOT_AUTHORIZED,
+  message: 'The item does not belong to the clan of logged in player',
+});

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -18,6 +18,7 @@ import { ClanBasicRight } from '../clan/role/enum/clanBasicRight.enum';
 import ApiResponseDescription from '../common/swagger/response/ApiResponseDescription';
 import { ItemIdDto } from './dto/itemId.dto';
 import SwaggerTags from '../common/swagger/tags/SwaggerTags.decorator';
+import { VotingDto } from '../voting/dto/voting.dto';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -139,5 +140,33 @@ export class FleaMarketController {
       });
 
     await this.service.handleBuyItem(clanId, itemIdDto.item_id, user.player_id);
+  }
+
+  /**
+   * Start voting to change flea market item price.
+   *
+   * @remarks Change flea market item price.
+   * This will start a voting in the Clan to change a price of flea market item belonging to your clan.
+   * Voting duration is 10min and the min approval percentage is 51.
+   * During the voting an Item is in "Shipping" status and can not be bought by other players.
+   */
+  @ApiResponseDescription({
+    success: {
+      status: 200,
+    },
+    errors: [400, 404],
+  })
+  @Post('change-item-price')
+  @HasClanRights([ClanBasicRight.SHOP])
+  @UniformResponse(ModelName.VOTING, VotingDto)
+  async changePrice(
+    @Body() body: SellFleaMarketItemDto,
+    @LoggedUser() user: User,
+  ) {
+    return this.service.changeItemPrice(
+      body.item_id,
+      body.price,
+      user.player_id,
+    );
   }
 }

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -30,7 +30,6 @@ import { VotingQueue } from '../voting/voting.queue';
 import { VotingQueueName } from '../voting/enum/VotingQueue.enum';
 import { cancelTransaction } from '../common/function/cancelTransaction';
 import { SellFleaMarketItemDto } from './dto/sellFleaMarketItem.dto';
-import { Voting } from '../voting/schemas/voting.schema';
 import { itemNotAuthorizedError } from './errors/itemNotAuthorized.error';
 
 @Injectable()
@@ -38,7 +37,6 @@ export class FleaMarketService {
   constructor(
     @InjectModel(FleaMarketItem.name)
     public readonly model: Model<FleaMarketItem>,
-    @InjectModel(Voting.name)
     private readonly helperService: FleaMarketHelperService,
     private readonly itemHelperService: ItemHelperService,
     private readonly playerService: PlayerService,
@@ -52,7 +50,6 @@ export class FleaMarketService {
   }
 
   public readonly basicService: BasicService;
-  public readonly votingBasicService: BasicService;
 
   /**
    * Creates an new Item in DB.
@@ -160,11 +157,12 @@ export class FleaMarketService {
     });
     if (errors) return await cancelTransaction(session, errors);
 
-    const [, votingUpdateErrors] = await this.votingBasicService.updateOneById(
-      voting._id,
-      { price: sellFleaMarketItemDto.price },
-      { session },
-    );
+    const [, votingUpdateErrors] =
+      await this.votingService.basicService.updateOneById(
+        voting._id,
+        { price: sellFleaMarketItemDto.price },
+        { session },
+      );
     if (votingUpdateErrors)
       return cancelTransaction(session, votingUpdateErrors);
 

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -31,6 +31,7 @@ import { VotingQueueName } from '../voting/enum/VotingQueue.enum';
 import { cancelTransaction } from '../common/function/cancelTransaction';
 import { SellFleaMarketItemDto } from './dto/sellFleaMarketItem.dto';
 import { Voting } from '../voting/schemas/voting.schema';
+import { itemNotAuthorizedError } from './errors/itemNotAuthorized.error';
 
 @Injectable()
 export class FleaMarketService {
@@ -38,7 +39,6 @@ export class FleaMarketService {
     @InjectModel(FleaMarketItem.name)
     public readonly model: Model<FleaMarketItem>,
     @InjectModel(Voting.name)
-    private readonly votingModel: Model<Voting>,
     private readonly helperService: FleaMarketHelperService,
     private readonly itemHelperService: ItemHelperService,
     private readonly playerService: PlayerService,
@@ -49,7 +49,6 @@ export class FleaMarketService {
     @InjectConnection() private readonly connection: Connection,
   ) {
     this.basicService = new BasicService(model);
-    this.votingBasicService = new BasicService(votingModel);
   }
 
   public readonly basicService: BasicService;
@@ -241,20 +240,28 @@ export class FleaMarketService {
     const { voting, price, clanId, stockId, fleaMarketItemId } = params;
 
     const votePassed = await this.votingService.checkVotingSuccess(voting);
-    if (voting.type === VotingType.FLEA_MARKET_BUY_ITEM) {
-      if (votePassed) {
-        await this.handlePassedBuyVoting(voting, stockId);
-      } else {
-        await this.handleRejectedBuyVoting(voting, clanId, price);
-      }
-    }
 
-    if (voting.type === VotingType.FLEA_MARKET_SELL_ITEM) {
-      if (votePassed) {
-        await this.handlePassedSellVoting(fleaMarketItemId, price);
-      } else {
-        await this.handleRejectedSellVoting(fleaMarketItemId, stockId);
-      }
+    switch (voting.type) {
+      case VotingType.FLEA_MARKET_BUY_ITEM:
+        if (votePassed) await this.handlePassedBuyVoting(voting, stockId);
+        else await this.handleRejectedBuyVoting(voting, clanId, price);
+        break;
+      case VotingType.FLEA_MARKET_SELL_ITEM:
+        if (votePassed)
+          await this.handlePassedSellVoting(fleaMarketItemId, price);
+        else await this.handleRejectedSellVoting(fleaMarketItemId, stockId);
+        break;
+      case VotingType.FLEA_MARKET_CHANGE_ITEM_PRICE:
+        if (votePassed)
+          await this.handlePassedItemPriceChangeVoting(
+            voting.fleaMarketItem_id.toString(),
+            voting.price,
+          );
+        else
+          await this.handleRejectedItemPriceChangeVoting(
+            voting.fleaMarketItem_id,
+          );
+        break;
     }
 
     await this.votingService.basicService.deleteOneById(voting._id);
@@ -314,7 +321,7 @@ export class FleaMarketService {
       );
     if (itemErrors) return await cancelTransaction(session, itemErrors);
 
-    const newItem = await this.helperService.fleaMarketItemToCreateItemDto(
+    const newItem = this.helperService.fleaMarketItemToCreateItemDto(
       item,
       stockId,
     );
@@ -417,7 +424,7 @@ export class FleaMarketService {
     );
     if (deleteErrors) return cancelTransaction(session, deleteErrors);
 
-    const item = await this.helperService.fleaMarketItemToCreateItemDto(
+    const item = this.helperService.fleaMarketItemToCreateItemDto(
       fmItem,
       stockId,
     );
@@ -519,5 +526,96 @@ export class FleaMarketService {
     await session.endSession();
 
     return [voting, null];
+  }
+
+  /**
+   * Handles starting a voting to change a price of a flea market item.
+   *
+   * validates that there is no ongoing voting about the item
+   * updates the item status to shipping so it's unavailable to be bought while price change voting is ongoing
+   * starts a new voting and adds it to the voting queue
+   *
+   * @param item_id - _id of the item whose price to change
+   * @param price - the new price for the item
+   * @param player_id - _id of the player starting the voting
+   *
+   * @returns VotingDto or ServiceErrors
+   **/
+  async changeItemPrice(
+    item_id: string,
+    price: number,
+    player_id: string,
+  ): Promise<IServiceReturn<VotingDto>> {
+    const [player, playerErrors] =
+      await this.playerService.getPlayerById(player_id);
+    if (playerErrors) return [null, playerErrors];
+
+    const [item, itemErrors] =
+      await this.basicService.readOneById<FleaMarketItemDto>(item_id);
+    if (itemErrors) return [null, itemErrors];
+    if (item.status !== Status.AVAILABLE)
+      return [null, [itemNotAvailableError]];
+    if (item.clan_id.toString() !== player.clan_id.toString())
+      return [null, [itemNotAuthorizedError]];
+
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
+    const [_, updateErrors] = await this.basicService.updateOneById(
+      item._id,
+      { status: Status.SHIPPING },
+      { session },
+    );
+    if (updateErrors) return await cancelTransaction(session, updateErrors);
+
+    const [voting, votingErrors] = await this.votingService.startVoting(
+      {
+        voterPlayer: player,
+        type: VotingType.FLEA_MARKET_CHANGE_ITEM_PRICE,
+        queue: VotingQueueName.CLAN_SHOP,
+        clanId: player.clan_id?.toString(),
+        newItemPrice: price,
+        fleaMarketItem: item,
+      },
+      session,
+    );
+    if (votingErrors) return await cancelTransaction(session, votingErrors);
+
+    await this.votingQueue.addVotingCheckJob({
+      voting,
+      queue: VotingQueueName.FLEA_MARKET,
+    });
+
+    await session.commitTransaction();
+    await session.endSession();
+
+    return [voting, null];
+  }
+
+  /**
+   * Handles passed item price change voting by updating the status and price of the item
+   *
+   * @param item_id - _id of the item to update
+   * @param newPrice - new price of the item
+   **/
+  private async handlePassedItemPriceChangeVoting(
+    item_id: string,
+    newPrice: number,
+  ) {
+    await this.basicService.updateOneById(item_id, {
+      status: Status.AVAILABLE,
+      price: newPrice,
+    });
+  }
+
+  /**
+   * Handles rejected item price change voting by changing the item status back to available.
+   *
+   * @param item_id - _id of the item to update
+   **/
+  private async handleRejectedItemPriceChangeVoting(item_id: string) {
+    await this.basicService.updateOneById(item_id, {
+      status: Status.AVAILABLE,
+    });
   }
 }

--- a/src/voting/dto/createVoting.dto.ts
+++ b/src/voting/dto/createVoting.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsMongoId,
   IsOptional,
+  Min,
   ValidateNested,
 } from 'class-validator';
 import AddType from '../../common/base/decorator/AddType.decorator';
@@ -82,4 +83,9 @@ export class CreateVotingDto {
   @ValidateNested()
   @Type(() => SetClanRoleDto)
   setClanRole?: SetClanRoleDto;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  price?: number;
 }

--- a/src/voting/enum/VotingType.enum.ts
+++ b/src/voting/enum/VotingType.enum.ts
@@ -7,6 +7,7 @@
 export enum VotingType {
   FLEA_MARKET_SELL_ITEM = 'flea_market_sell_item',
   FLEA_MARKET_BUY_ITEM = 'flea_market_buy_item',
+  FLEA_MARKET_CHANGE_ITEM_PRICE = 'change_item_price',
   SHOP_BUY_ITEM = 'shop_buy_item',
   SET_CLAN_ROLE = 'set_clan_role',
 }

--- a/src/voting/type/startItemVoting.type.ts
+++ b/src/voting/type/startItemVoting.type.ts
@@ -14,4 +14,5 @@ export type StartVotingParams = {
   shopItem?: ItemName;
   setClanRole?: SetClanRoleDto;
   endsOn?: Date;
+  newItemPrice?: number;
 };

--- a/src/voting/voting.module.ts
+++ b/src/voting/voting.module.ts
@@ -37,6 +37,11 @@ import { FleaMarketItemVotingSchema } from './schemas/fleamarketItemVoting.schem
             value: VotingType.FLEA_MARKET_SELL_ITEM,
           },
           {
+            name: 'ChangeFleaMarketItemPriceVoting',
+            schema: FleaMarketItemVotingSchema,
+            value: VotingType.FLEA_MARKET_CHANGE_ITEM_PRICE,
+          },
+          {
             name: SetClanRoleVoting.name,
             schema: SetClanRoleVotingSchema,
             value: VotingType.SET_CLAN_ROLE,

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -95,6 +95,7 @@ export class VotingService {
       shopItem,
       setClanRole,
       endsOn,
+      newItemPrice,
     } = params;
 
     const organizer = {
@@ -113,6 +114,10 @@ export class VotingService {
       case VotingType.FLEA_MARKET_BUY_ITEM:
       case VotingType.FLEA_MARKET_SELL_ITEM:
         base.fleaMarketItem_id = fleaMarketItem._id.toString();
+        break;
+      case VotingType.FLEA_MARKET_CHANGE_ITEM_PRICE:
+        base.fleaMarketItem_id = fleaMarketItem._id.toString();
+        base.price = newItemPrice;
         break;
       case VotingType.SHOP_BUY_ITEM:
         base.shopItemName = shopItem;


### PR DESCRIPTION
### Brief description

Added `POST /change-item-price` endpoint, along with new service methods for handling the price change voting. Added the new voting type and new item price fields for relevant DTOs. 


### Change list

- Added `POST /change-item-price` endpoint
- Added service methods to handle the new voting
- Added the new voting type to VotingType enum
- Added price field to CreateVotingDto
- Added tests for new logic
- Added handling cases for new voting type
- Added newItemPrice to StartVotingParams
- Changed the return type of cancelTransaction from false to null to match the correct IService return type
- Fixed existing test