### PR TITLE
Change/item-voting-logic-614

### DIFF
--- a/src/__tests__/clan/data/clan/ClanBuilder.ts
+++ b/src/__tests__/clan/data/clan/ClanBuilder.ts
@@ -136,4 +136,9 @@ export default class ClanBuilder implements IDataBuilder<Clan> {
     this.base.stall = stall;
     return this;
   }
+
+  setStallMaxSlots(amount: number) {
+    this.base.stall.maxSlots = amount;
+    return this;
+  }
 }

--- a/src/__tests__/fleaMarket/FleaMarketService/checkClanItemSlots.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/checkClanItemSlots.test.ts
@@ -41,7 +41,7 @@ describe('FleaMarketService.checkClanItemSlots(), test suite', () => {
     expect(error).toBeNull();
   });
 
-  it('should return [false, null] when clan has no available slots', async () => {
+  it('should return [false, error] when clan has no available slots', async () => {
     const clanId = new ObjectId().toString();
     const clan = new ClanBuilder().setId(clanId).setStallMaxSlots(2).build();
     await clanModel.create(clan);
@@ -53,7 +53,7 @@ describe('FleaMarketService.checkClanItemSlots(), test suite', () => {
 
     const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
     expect(result).toBe(false);
-    expect(error).toBeNull();
+    expect(error).toContainSE_MORE_THAN_MAX();
   });
 
   it('should return [false, clanError] if clan does not exist', async () => {
@@ -63,13 +63,13 @@ describe('FleaMarketService.checkClanItemSlots(), test suite', () => {
     expect(error).not.toBeNull();
   });
 
-  it('should return [false, null] if clan.stall is missing', async () => {
+  it('should return [false, error] if clan.stall is missing', async () => {
     const clanId = new ObjectId().toString();
-    const clan = new ClanBuilder().setId(clanId).setStall(undefined).build();
+    const clan = new ClanBuilder().setId(clanId).setStall(null).build();
     await clanModel.create(clan);
 
     const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
     expect(result).toBe(false);
-    expect(error).toBeNull();
+    expect(error).toContainSE_NOT_FOUND();
   });
 });

--- a/src/__tests__/fleaMarket/FleaMarketService/checkClanItemSlots.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/checkClanItemSlots.test.ts
@@ -1,0 +1,75 @@
+import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
+import FleaMarketModule from '../modules/fleaMarketModule';
+import ClanBuilder from '../../clan/data/clan/ClanBuilder';
+import FleaMarketItemBuilder from '../data/fleaMarket/FleaMarketItemBuilder';
+import { FleaMarketItem } from '../../../fleaMarket/fleaMarketItem.schema';
+import { Model } from 'mongoose';
+import { Clan } from '../../../clan/clan.schema';
+import { ClanService } from '../../../clan/clan.service';
+import { ObjectId } from 'mongodb';
+
+describe('FleaMarketService.checkClanItemSlots(), test suite', () => {
+  let fleaMarketService: FleaMarketService;
+  let clanService: ClanService;
+  let clanModel: Model<Clan>;
+  let fleaMarketItemModel: Model<FleaMarketItem>;
+
+  beforeAll(async () => {
+    fleaMarketItemModel = await FleaMarketModule.getFleaMarketItemModel();
+    clanService = await FleaMarketModule.getClanService();
+    fleaMarketService = await FleaMarketModule.getFleaMarketService();
+    clanModel = clanService.model;
+  });
+
+  beforeEach(async () => {
+    await clanModel.deleteMany();
+    await fleaMarketItemModel.deleteMany();
+  });
+
+  it('should return [true, null] when clan has available slots', async () => {
+    const clanId = new ObjectId().toString();
+    const clan = new ClanBuilder().setId(clanId).setStallMaxSlots(3).build();
+    await clanModel.create(clan);
+
+    const item1 = new FleaMarketItemBuilder().setClanId(clanId).build();
+    const item2 = new FleaMarketItemBuilder().setClanId(clanId).build();
+    await fleaMarketItemModel.create(item1);
+    await fleaMarketItemModel.create(item2);
+
+    const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
+    expect(result).toBe(true);
+    expect(error).toBeNull();
+  });
+
+  it('should return [false, null] when clan has no available slots', async () => {
+    const clanId = new ObjectId().toString();
+    const clan = new ClanBuilder().setId(clanId).setStallMaxSlots(2).build();
+    await clanModel.create(clan);
+
+    const item1 = new FleaMarketItemBuilder().setClanId(clanId).build();
+    const item2 = new FleaMarketItemBuilder().setClanId(clanId).build();
+    await fleaMarketItemModel.create(item1);
+    await fleaMarketItemModel.create(item2);
+
+    const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
+    expect(result).toBe(false);
+    expect(error).toBeNull();
+  });
+
+  it('should return [false, clanError] if clan does not exist', async () => {
+    const clanId = new ObjectId().toString();
+    const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
+    expect(result).toBe(false);
+    expect(error).not.toBeNull();
+  });
+
+  it('should return [false, null] if clan.stall is missing', async () => {
+    const clanId = new ObjectId().toString();
+    const clan = new ClanBuilder().setId(clanId).setStall(undefined).build();
+    await clanModel.create(clan);
+
+    const [result, error] = await fleaMarketService.checkClanItemSlots(clanId);
+    expect(result).toBe(false);
+    expect(error).toBeNull();
+  });
+});

--- a/src/fleaMarket/dto/changeItemStatus.dto.ts
+++ b/src/fleaMarket/dto/changeItemStatus.dto.ts
@@ -1,0 +1,10 @@
+import { IsIn, IsMongoId } from 'class-validator';
+import { Status } from '../enum/status.enum';
+
+export class ChangeItemStatusDto {
+  @IsMongoId()
+  item_id: string;
+
+  @IsIn([Status.AVAILABLE, Status.SHIPPING])
+  status: Status;
+}

--- a/src/fleaMarket/errors/maxSlotsReached.error.ts
+++ b/src/fleaMarket/errors/maxSlotsReached.error.ts
@@ -1,0 +1,7 @@
+import { SEReason } from '../../common/service/basicService/SEReason';
+import ServiceError from '../../common/service/basicService/ServiceError';
+
+export const maxSlotsReachedError = new ServiceError({
+  reason: SEReason.MORE_THAN_MAX,
+  message: 'Your clan already has the maximum amount of items for sale.',
+});

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -212,8 +212,10 @@ export class FleaMarketController {
         message: 'The item does not belong to the clan of logged in player',
       });
 
-    const [_, errors] = await this.service.checkClanItemSlots(clanId);
-    if (errors) throw errors;
+    if (body.status === Status.AVAILABLE) {
+      const [_, errors] = await this.service.checkClanItemSlots(clanId);
+      if (errors) throw errors;
+    }
 
     const [_, updateError] = await this.service.basicService.updateOneById(
       body.item_id,

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -215,7 +215,7 @@ export class FleaMarketController {
     const [availableSlot, errors] =
       await this.service.checkClanItemSlots(clanId);
     if (errors) throw errors;
-    if (availableSlot === false) {
+    if (!availableSlot) {
       throw new APIError({
         reason: APIErrorReason.MORE_THAN_MAX,
         message:

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -212,16 +212,8 @@ export class FleaMarketController {
         message: 'The item does not belong to the clan of logged in player',
       });
 
-    const [availableSlot, errors] =
-      await this.service.checkClanItemSlots(clanId);
+    const [_, errors] = await this.service.checkClanItemSlots(clanId);
     if (errors) throw errors;
-    if (!availableSlot) {
-      throw new APIError({
-        reason: APIErrorReason.MORE_THAN_MAX,
-        message:
-          'Max amount of flea market items reached. Buy more slots or remove items from flea market.',
-      });
-    }
 
     const [_, updateError] = await this.service.basicService.updateOneById(
       body.item_id,

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -18,6 +18,8 @@ import { ClanBasicRight } from '../clan/role/enum/clanBasicRight.enum';
 import ApiResponseDescription from '../common/swagger/response/ApiResponseDescription';
 import { ItemIdDto } from './dto/itemId.dto';
 import { VotingDto } from '../voting/dto/voting.dto';
+import { ChangeItemStatusDto } from './dto/changeItemStatus.dto';
+import { Status } from './enum/status.enum';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -166,5 +168,65 @@ export class FleaMarketController {
       body.price,
       user.player_id,
     );
+  }
+
+  /**
+   * Change the status of a flea market item.
+   *
+   * @remarks Changes the status of a flea market item belonging to the players clan.
+   * Player will need a SHOP clan right.
+   * The status can only be changed between available and shipping.
+   * If the item is booked it's status can't be changed.
+   */
+  @ApiResponseDescription({
+    success: {
+      status: 204,
+    },
+    errors: [400, 403, 404],
+  })
+  @HasClanRights([ClanBasicRight.SHOP])
+  @Post('change-item-status')
+  @UniformResponse()
+  async changeItemStatus(
+    @Body() body: ChangeItemStatusDto,
+    @LoggedUser() user: User,
+  ) {
+    const [item, itemError] = await this.service.readOneById(body.item_id);
+    if (itemError) throw itemError;
+    if (item.status === Status.BOOKED)
+      throw new APIError({
+        reason: APIErrorReason.NOT_ALLOWED,
+        message: `The item is booked so it's status can't be currently changed.`,
+      });
+
+    const clanId = await this.service.getFleaMarketItemClanId(
+      body.item_id,
+      user.player_id,
+    );
+    if (!clanId)
+      throw new APIError({
+        reason: APIErrorReason.NOT_AUTHORIZED,
+        message: 'The item does not belong to the clan of logged in player',
+      });
+
+    const [availableSlot, errors] =
+      await this.service.checkClanItemSlots(clanId);
+    if (errors) throw errors;
+    if (availableSlot === false) {
+      throw new APIError({
+        reason: APIErrorReason.MORE_THAN_MAX,
+        message:
+          'Max amount of flea market items reached. Buy more slots or remove items from flea market.',
+      });
+    }
+
+    const [_, updateError] = await this.service.basicService.updateOneById(
+      body.item_id,
+      {
+        status: body.status,
+      },
+    );
+
+    if (updateError) throw updateError;
   }
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -20,6 +20,8 @@ import { ItemIdDto } from './dto/itemId.dto';
 import { VotingDto } from '../voting/dto/voting.dto';
 import { ChangeItemStatusDto } from './dto/changeItemStatus.dto';
 import { Status } from './enum/status.enum';
+import SwaggerTags from '../common/swagger/tags/SwaggerTags.decorator';
+import { swaggerTags } from '../common/swagger/tags/tags';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -178,6 +180,7 @@ export class FleaMarketController {
    * The status can only be changed between available and shipping.
    * If the item is booked it's status can't be changed.
    */
+  @SwaggerTags('Release on 07.09.2025')
   @ApiResponseDescription({
     success: {
       status: 204,

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -33,6 +33,7 @@ import { SellFleaMarketItemDto } from './dto/sellFleaMarketItem.dto';
 import { itemNotAuthorizedError } from './errors/itemNotAuthorized.error';
 import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
+import { maxSlotsReachedError } from './errors/maxSlotsReached.error';
 
 @Injectable()
 export class FleaMarketService {
@@ -663,11 +664,15 @@ export class FleaMarketService {
 
     const [items, itemError] =
       await this.basicService.readMany<FleaMarketItemDto>({
-        filter: { clan_id },
+        filter: {
+          clan_id,
+          status: { $in: [Status.AVAILABLE, Status.BOOKED] },
+        },
       });
     if (itemError) return [false, itemError];
 
-    if (items.length >= clan.stall.maxSlots) return [false, null];
+    if (items.length >= clan.stall.maxSlots)
+      return [false, [maxSlotsReachedError]];
 
     return [true, null];
   }

--- a/src/fleaMarket/fleaMarketItem.schema.ts
+++ b/src/fleaMarket/fleaMarketItem.schema.ts
@@ -33,7 +33,7 @@ export class FleaMarketItem {
     type: String,
     enum: Status,
     required: true,
-    default: Status.AVAILABLE,
+    default: Status.SHIPPING,
   })
   status: Status;
 


### PR DESCRIPTION
### Brief description

Changed item selling logic on fleamarket items. Now when a sell fleamarket item vote passes the item is moved to fleamarket but its' status will be shipping not available. The new `POST /change-item-status` endpoint can be used to change the status to make items available or unavailable for other clans.



### Change list

- Add `POST /change-item-status` endpoint.
- Add getFleaMarketItemClanId helper method for validation
- Add checkClanItemSlots method for available slot validation
- Chang default status of fleamarket item from available to shipping.
- Add tests for the service methods.
- Add change item status dto 
