### PR TITLE
Feature/add battle points for clans 630

### DIFF
--- a/src/__tests__/clan/data/clan/ClanBuilder.ts
+++ b/src/__tests__/clan/data/clan/ClanBuilder.ts
@@ -23,6 +23,7 @@ export default class ClanBuilder implements IDataBuilder<Clan> {
     itemCount: 0,
     stockCount: 0,
     points: 0,
+    battlePoints: 0,
     gameCoins: 0,
     isOpen: true,
     password: undefined,
@@ -74,6 +75,11 @@ export default class ClanBuilder implements IDataBuilder<Clan> {
 
   setPoints(points: number) {
     this.base.points = points;
+    return this;
+  }
+
+  setBattlePoints(battlePoints: number) {
+    this.base.battlePoints = battlePoints;
     return this;
   }
 

--- a/src/__tests__/clan/data/clan/ClanDtoBuilder.ts
+++ b/src/__tests__/clan/data/clan/ClanDtoBuilder.ts
@@ -16,6 +16,7 @@ export default class ClanDtoBuilder implements IDataBuilder<ClanDto> {
     labels: [],
     gameCoins: 0,
     points: 0,
+    battlePoints: 0,
     admin_ids: [],
     playerCount: 0,
     itemCount: 0,
@@ -63,6 +64,11 @@ export default class ClanDtoBuilder implements IDataBuilder<ClanDto> {
 
   setPoints(points: number) {
     this.base.points = points;
+    return this;
+  }
+
+  setBattlePoints(battlePoints: number) {
+    this.base.battlePoints = battlePoints;
     return this;
   }
 

--- a/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
+++ b/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
@@ -27,7 +27,11 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
     rewarder = await RewarderModule.getClanRewarder();
     existingClan = clanBuilder.setPoints(0).setBattlePoints(30).build();
     createdClan = await clanModel.create(existingClan);
-    existingPlayer = playerBuilder.setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+    existingPlayer = playerBuilder
+      .setClanId(createdClan._id)
+      .setPoints(0)
+      .setBattlePoints(30)
+      .build();
 
     const createdPlayer = await playerModel.create(existingPlayer);
     existingPlayer._id = createdPlayer._id;
@@ -80,7 +84,12 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
 
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
-    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+    existingPlayer = playerBuilder
+      .setUniqueIdentifier('loserPlayer')
+      .setClanId(createdClan._id)
+      .setPoints(0)
+      .setBattlePoints(30)
+      .build();
 
     const createdPlayer = await playerModel.create(existingPlayer);
     existingPlayer._id = createdPlayer._id;
@@ -112,7 +121,12 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
 
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
-    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+    existingPlayer = playerBuilder
+      .setUniqueIdentifier('loserPlayer')
+      .setClanId(createdClan._id)
+      .setPoints(0)
+      .setBattlePoints(30)
+      .build();
 
     const createdPlayer = await playerModel.create(existingPlayer);
     existingPlayer._id = createdPlayer._id;
@@ -161,7 +175,12 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
 
     const createdClan = await clanModel.create(existingClan);
     existingClan._id = createdClan._id;
-    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(null).setPoints(0).setBattlePoints(30).build();
+    existingPlayer = playerBuilder
+      .setUniqueIdentifier('loserPlayer')
+      .setClanId(null)
+      .setPoints(0)
+      .setBattlePoints(30)
+      .build();
 
     const createdPlayer = await playerModel.create(existingPlayer);
     existingPlayer._id = createdPlayer._id;

--- a/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
+++ b/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
@@ -1,0 +1,184 @@
+import RewarderModule from '../modules/clanRewarder.module';
+import { ClanRewarder } from '../../../rewarder/clanRewarder/clanRewarder.service';
+import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
+import PlayerModule from '../../player/modules/player.module';
+import { Player } from '../../../player/schemas/player.schema';
+import ClanBuilderFactory from '../../clan/data/clanBuilderFactory';
+import { Clan } from '../../../clan/clan.schema';
+import ClanModule from '../../clan/modules/clan.module';
+
+describe('ClanRewarder.rewardForClanEvent() test suite', () => {
+  let rewarder: ClanRewarder;
+
+  const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
+  const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+
+  let existingPlayer: Player;
+  let existingClan: Clan;
+
+  const playerModel = PlayerModule.getPlayerModel();
+  const clanModel = ClanModule.getClanModel();
+  let createdClan: Clan;
+
+  beforeEach(async () => {
+    await playerModel.deleteMany({});
+    await clanModel.deleteMany({});
+
+    rewarder = await RewarderModule.getClanRewarder();
+    existingClan = clanBuilder.setPoints(0).setBattlePoints(30).build();
+    createdClan = await clanModel.create(existingClan);
+    existingPlayer = playerBuilder.setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+
+    const createdPlayer = await playerModel.create(existingPlayer);
+    existingPlayer._id = createdPlayer._id;
+  });
+
+  it('Should update clans battles points if event type is battle_won', async () => {
+    const event = 'battle_won' as any;
+    const clanBefore = await clanModel.findById(createdClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(createdClan._id);
+    expect(clanAfter.points).toBe(clanBefore.points);
+    expect(clanAfter.battlePoints).toBe(130);
+    expect(isSuccess).toBe(true);
+    expect(errors).toBeNull();
+  });
+
+  it('Should update clans battles points if event type is battle_lose and has enough battle points', async () => {
+    clanModel.deleteMany({});
+    const event = 'battle_lose' as any;
+
+    const clanBefore = await clanModel.findById(createdClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(createdClan._id);
+    expect(clanAfter.points).toBe(clanBefore.points);
+    expect(clanAfter.battlePoints).toBe(10);
+    expect(isSuccess).toBe(true);
+    expect(errors).toBeNull();
+  });
+
+  it('Should update clans battles points if event type is battle_lose, but battle points could not be negative', async () => {
+    const event = 'battle_lose' as any;
+    await clanModel.deleteMany({});
+    await playerModel.deleteMany({});
+
+    existingClan = clanBuilder
+      .setName('loserClan')
+      .setPoints(0)
+      .setBattlePoints(10)
+      .build();
+
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+
+    const createdPlayer = await playerModel.create(existingPlayer);
+    existingPlayer._id = createdPlayer._id;
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+    expect(clanAfter.points).toBe(clanBefore.points);
+    expect(clanAfter.battlePoints).toBe(0);
+    expect(isSuccess).toBe(true);
+    expect(errors).toBeNull();
+  });
+
+  it('Should not update clans battles points if event type is battle_lose and battle points is 0', async () => {
+    const event = 'battle_lose' as any;
+    await clanModel.deleteMany({});
+    await playerModel.deleteMany({});
+
+    existingClan = clanBuilder
+      .setName('loserClan')
+      .setPoints(0)
+      .setBattlePoints(0)
+      .build();
+
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(createdClan._id).setPoints(0).setBattlePoints(30).build();
+
+    const createdPlayer = await playerModel.create(existingPlayer);
+    existingPlayer._id = createdPlayer._id;
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+    expect(clanAfter.points).toBe(clanBefore.points);
+    expect(clanAfter.battlePoints).toBe(0);
+    expect(isSuccess).toBe(false);
+    expect(errors).toBeNull();
+  });
+
+  it('Should not update points amount if the specified event does not exists and should return with WRONG_ENUM ServiceError', async () => {
+    const event = 'Non-existing-event' as any;
+    const clanBefore = await clanModel.findById(createdClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(createdClan._id);
+    expect(clanAfter.battlePoints).toBe(clanBefore.battlePoints);
+    expect(isSuccess).toBeNull();
+    expect(errors).toContainSE_WRONG_ENUM();
+    expect(errors[0].field).toBe('clanEvent');
+    expect(errors[0].value).toBe(event);
+  });
+
+  it('Should return with ServiceError if the player does not have a clan_id', async () => {
+    const event = 'battle_lose' as any;
+    await clanModel.deleteMany({});
+    await playerModel.deleteMany({});
+
+    existingClan = clanBuilder
+      .setName('loserClan')
+      .setPoints(0)
+      .setBattlePoints(0)
+      .build();
+
+    const createdClan = await clanModel.create(existingClan);
+    existingClan._id = createdClan._id;
+    existingPlayer = playerBuilder.setUniqueIdentifier('loserPlayer').setClanId(null).setPoints(0).setBattlePoints(30).build();
+
+    const createdPlayer = await playerModel.create(existingPlayer);
+    existingPlayer._id = createdPlayer._id;
+
+    const clanBefore = await clanModel.findById(existingClan._id);
+
+    const [isSuccess, errors] = await rewarder.rewardForClanEvent(
+      existingPlayer._id,
+      event,
+    );
+
+    const clanAfter = await clanModel.findById(existingClan._id);
+    expect(clanAfter.points).toBe(clanBefore.points);
+    expect(clanAfter.battlePoints).toBe(0);
+    expect(isSuccess).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+    expect(errors[0].message).toBe('Player does not belong to a clan');
+    expect(errors[0].field).toBe('clan_id');
+  });
+});

--- a/src/__tests__/rewarder/modules/rewarderCommon.ts
+++ b/src/__tests__/rewarder/modules/rewarderCommon.ts
@@ -7,6 +7,7 @@ import { PlayerRewarder } from '../../../rewarder/playerRewarder/playerRewarder.
 import { ClanRewarder } from '../../../rewarder/clanRewarder/clanRewarder.service';
 import { ModelName } from '../../../common/enum/modelName.enum';
 import { PlayerSchema } from '../../../player/schemas/player.schema';
+import { ClanSchema } from '../../../clan/clan.schema';
 
 export default class RewarderCommonModule {
   private constructor() {}
@@ -20,6 +21,7 @@ export default class RewarderCommonModule {
           MongooseModule.forRoot(mongoString, mongooseOptions),
           MongooseModule.forFeature([
             { name: ModelName.PLAYER, schema: PlayerSchema },
+            { name: ModelName.CLAN, schema: ClanSchema },
           ]),
           PlayerModule,
           ClanModule,

--- a/src/__tests__/voting/data/voting/createStartItemVotingParamsDtoBuilder.ts
+++ b/src/__tests__/voting/data/voting/createStartItemVotingParamsDtoBuilder.ts
@@ -45,7 +45,7 @@ export default class CreateStartItemVotingParamsDtoBuilder
         Stock: null,
         SoulHome: null,
         roles: [],
-        battlePoints: 0
+        battlePoints: 0,
       },
       CustomCharacter: [],
     },

--- a/src/__tests__/voting/data/voting/createStartItemVotingParamsDtoBuilder.ts
+++ b/src/__tests__/voting/data/voting/createStartItemVotingParamsDtoBuilder.ts
@@ -45,6 +45,7 @@ export default class CreateStartItemVotingParamsDtoBuilder
         Stock: null,
         SoulHome: null,
         roles: [],
+        battlePoints: 0
       },
       CustomCharacter: [],
     },
@@ -82,6 +83,13 @@ export default class CreateStartItemVotingParamsDtoBuilder
 
   setClanId(clanId: string | ObjectId) {
     this.base.clanId = clanId.toString();
+    return this;
+  }
+
+  setBattlePoints(battlePoints: number) {
+    if (this.base.voterPlayer) {
+      this.base.voterPlayer.battlePoints = battlePoints;
+    }
     return this;
   }
 }

--- a/src/clan/clan.schema.ts
+++ b/src/clan/clan.schema.ts
@@ -34,6 +34,9 @@ export class Clan {
   @Prop({ type: Number, default: 0 })
   points: number;
 
+  @Prop({ type: Number, default: 0, min: 0 })
+  battlePoints: number;
+
   @Prop({ type: [String], default: [] })
   admin_ids: string[];
 
@@ -102,6 +105,7 @@ ClanSchema.virtual(ModelName.SOULHOME, {
   justOne: true,
 });
 ClanSchema.index({ points: -1 });
+ClanSchema.index({ battlePoints: -1 });
 
 export const publicReferences = [
   ModelName.PLAYER,

--- a/src/clan/dto/clan.dto.ts
+++ b/src/clan/dto/clan.dto.ts
@@ -71,6 +71,14 @@ export class ClanDto {
   points: number;
 
   /**
+   * Total battle points accumulated by the clan
+   *
+   * @example 320
+   */
+  @Expose()
+  battlePoints: number;
+
+  /**
    * List of user IDs that are administrators of the clan
    *
    * @example ["67fe4e2d8a54d4cc39266a41", "67fe4e2d8a54d4cc39266a42"]

--- a/src/gameEventsHandler/clanEventHandler.ts
+++ b/src/gameEventsHandler/clanEventHandler.ts
@@ -31,7 +31,7 @@ export class ClanEventHandler {
     }
   }
 
-  /** Handles clan events that are not related to daily tasks
+  /** Handles clan events
    * @param player_id player _id that triggered the event
    * @param event happened event
    * @returns true if handled successfully or ServiceErrors
@@ -39,9 +39,8 @@ export class ClanEventHandler {
   async handleClanEvent(
     player_id: string,
     event: ClanEvent,
-  ): Promise<[boolean, ServiceError[]]> {
-    await this.clanRewarder.rewardForClanEvent(player_id, event);
-    return [true, null];
+  ): Promise<IServiceReturn<boolean>> {
+    return await this.clanRewarder.rewardForClanEvent(player_id, event);
   }
 
   /**

--- a/src/gameEventsHandler/clanEventHandler.ts
+++ b/src/gameEventsHandler/clanEventHandler.ts
@@ -8,6 +8,7 @@ import { OnGameEvent } from '../gameEventsEmitter/onGameEvent';
 import UIDailyTasksService from '../dailyTasks/uiDailyTasks/uiDailyTasks.service';
 import { GameEventPayload } from '../gameEventsEmitter/gameEvent';
 import { IServiceReturn } from '../common/service/basicService/IService';
+import { ClanEvent } from '../rewarder/clanRewarder/enum/ClanEvent.enum';
 
 @Injectable()
 export class ClanEventHandler {
@@ -28,6 +29,19 @@ export class ClanEventHandler {
     ) {
       return [true, null];
     }
+  }
+
+/** Handles clan events that are not related to daily tasks
+   * @param player_id player _id that triggered the event
+   * @param event happened event
+   * @returns true if handled successfully or ServiceErrors
+   */
+async handleClanEvent(
+    player_id: string,
+    event: ClanEvent,
+  ): Promise<[boolean, ServiceError[]]> {
+    await this.clanRewarder.rewardForClanEvent(player_id, event);
+    return [true, null];
   }
 
   /**

--- a/src/gameEventsHandler/clanEventHandler.ts
+++ b/src/gameEventsHandler/clanEventHandler.ts
@@ -31,12 +31,12 @@ export class ClanEventHandler {
     }
   }
 
-/** Handles clan events that are not related to daily tasks
+  /** Handles clan events that are not related to daily tasks
    * @param player_id player _id that triggered the event
    * @param event happened event
    * @returns true if handled successfully or ServiceErrors
    */
-async handleClanEvent(
+  async handleClanEvent(
     player_id: string,
     event: ClanEvent,
   ): Promise<[boolean, ServiceError[]]> {

--- a/src/gameEventsHandler/gameEventsHandler.ts
+++ b/src/gameEventsHandler/gameEventsHandler.ts
@@ -4,6 +4,7 @@ import ServiceError from '../common/service/basicService/ServiceError';
 import { PlayerEventHandler } from './playerEventHandler';
 import { ClanEventHandler } from './clanEventHandler';
 import { PlayerEvent } from '../rewarder/playerRewarder/enum/PlayerEvent.enum';
+import { ClanEvent } from '../rewarder/clanRewarder/enum/ClanEvent.enum';
 
 @Injectable()
 export class GameEventsHandler {
@@ -41,6 +42,12 @@ export class GameEventsHandler {
     const [, clanErrors] =
       await this.clanEventHandler.handlePlayerTask(player_id);
 
+      const [, clanEventErrors] =
+      await this.clanEventHandler.handleClanEvent(player_id, ClanEvent.BATTLE_WON);
+
+      if (clanEventErrors) 
+        return [null, clanEventErrors];
+
     if (playerErrors || clanErrors)
       return [null, this.concatArrays(playerErrors, clanErrors)];
 
@@ -55,6 +62,12 @@ export class GameEventsHandler {
 
     if (playerErrors) return [null, playerErrors];
 
+    const [, clanEventErrors] =
+      await this.clanEventHandler.handleClanEvent(player_id, ClanEvent.BATTLE_LOSE);
+
+    if (clanEventErrors) 
+        return [null, clanEventErrors];
+      
     return [true, null];
   }
 

--- a/src/gameEventsHandler/gameEventsHandler.ts
+++ b/src/gameEventsHandler/gameEventsHandler.ts
@@ -42,11 +42,12 @@ export class GameEventsHandler {
     const [, clanErrors] =
       await this.clanEventHandler.handlePlayerTask(player_id);
 
-      const [, clanEventErrors] =
-      await this.clanEventHandler.handleClanEvent(player_id, ClanEvent.BATTLE_WON);
+    const [, clanEventErrors] = await this.clanEventHandler.handleClanEvent(
+      player_id,
+      ClanEvent.BATTLE_WON,
+    );
 
-      if (clanEventErrors) 
-        return [null, clanEventErrors];
+    if (clanEventErrors) return [null, clanEventErrors];
 
     if (playerErrors || clanErrors)
       return [null, this.concatArrays(playerErrors, clanErrors)];
@@ -62,12 +63,13 @@ export class GameEventsHandler {
 
     if (playerErrors) return [null, playerErrors];
 
-    const [, clanEventErrors] =
-      await this.clanEventHandler.handleClanEvent(player_id, ClanEvent.BATTLE_LOSE);
+    const [, clanEventErrors] = await this.clanEventHandler.handleClanEvent(
+      player_id,
+      ClanEvent.BATTLE_LOSE,
+    );
 
-    if (clanEventErrors) 
-        return [null, clanEventErrors];
-      
+    if (clanEventErrors) return [null, clanEventErrors];
+
     return [true, null];
   }
 

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -137,7 +137,7 @@ export class ClanRewarder {
 
   /**
    * Update specified clan battle points amount
-   * @param clan_id player _id
+   * @param clan_id clan _id
    * @param battlePoints amount of battle points to increase
    * @throws MongooseError if any occurred
    * @returns true if clan was rewarded successfully

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -9,8 +9,8 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Clan } from '../../clan/clan.schema';
 import { Model } from 'mongoose';
 import { ClanDto } from '../../clan/dto/clan.dto';
-import { PlayerDto } from 'src/player/dto/player.dto';
-import { Player } from 'src/player/schemas/player.schema';
+import { PlayerDto } from '../../player/dto/player.dto';
+import { Player } from '../../player/schemas/player.schema';
 
 /**
  * Handles clan rewarding logic
@@ -119,6 +119,7 @@ export class ClanRewarder {
     const [player, playerErrors] =
       await this.playerService.readOneById<PlayerDto>(player_id);
     if (playerErrors) return [null, playerErrors];
+
     if (!player.clan_id) {
       return [
         null,

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -21,14 +21,14 @@ export class ClanRewarder {
 
   private readonly clanService: BasicService;
   private readonly playerService: BasicService;
-  
-    constructor(
-      @InjectModel(Clan.name) public readonly clanModel: Model<Clan>,
-      @InjectModel(Player.name) public readonly playerModel: Model<Player>,
-    ) {
-      this.clanService = new BasicService(clanModel);
-      this.playerService = new BasicService(playerModel);
-    }
+
+  constructor(
+    @InjectModel(Clan.name) public readonly clanModel: Model<Clan>,
+    @InjectModel(Player.name) public readonly playerModel: Model<Player>,
+  ) {
+    this.clanService = new BasicService(clanModel);
+    this.playerService = new BasicService(playerModel);
+  }
 
   clanMaxPoints = 10000;
 
@@ -92,69 +92,69 @@ export class ClanRewarder {
     );
   }
 
-    /**
-     * Rewards specified clan for an event happen
-     * @param player_id player _id to reward
-     * @param clanEvent happen event
-     * @throws MongooseError if any occurred
-     * @returns true if clan was rewarded successfully
-     */
-    async rewardForClanEvent(
-      player_id: string,
-      clanEvent: ClanEvent,
-    ): Promise<IServiceReturn<boolean>> {
-      const pointAmount = points[clanEvent];
-      if (pointAmount === undefined)
-        return [
-          null,
-          [
-            new ServiceError({
-              reason: SEReason.WRONG_ENUM,
-              field: 'clanEvent',
-              value: clanEvent,
-              message: 'This clanEvent does not exist',
-            }),
-          ],
-        ];
-      const [player, playerErrors] = await this.playerService.readOneById<PlayerDto>(player_id);
-      if (playerErrors) return [null, playerErrors];
-      if (!player.clan_id) {
-        return [
-          null,
-          [
-            new ServiceError({
-              reason: SEReason.NOT_FOUND,
-              field: 'clan_id',
-              value: player.clan_id,
-              message: 'Player does not belong to a clan',
-            }),
-          ],
-        ];
-      }
-      
-      return this.updateClanBattlePoints(player.clan_id, pointAmount);
+  /**
+   * Rewards specified clan for an event happen
+   * @param player_id player _id to reward
+   * @param clanEvent happen event
+   * @throws MongooseError if any occurred
+   * @returns true if clan was rewarded successfully
+   */
+  async rewardForClanEvent(
+    player_id: string,
+    clanEvent: ClanEvent,
+  ): Promise<IServiceReturn<boolean>> {
+    const pointAmount = points[clanEvent];
+    if (pointAmount === undefined)
+      return [
+        null,
+        [
+          new ServiceError({
+            reason: SEReason.WRONG_ENUM,
+            field: 'clanEvent',
+            value: clanEvent,
+            message: 'This clanEvent does not exist',
+          }),
+        ],
+      ];
+    const [player, playerErrors] =
+      await this.playerService.readOneById<PlayerDto>(player_id);
+    if (playerErrors) return [null, playerErrors];
+    if (!player.clan_id) {
+      return [
+        null,
+        [
+          new ServiceError({
+            reason: SEReason.NOT_FOUND,
+            field: 'clan_id',
+            value: player.clan_id,
+            message: 'Player does not belong to a clan',
+          }),
+        ],
+      ];
     }
-  
-    /**
-       * Update specified clan battle points amount
-       * @param clan_id player _id
-       * @param battlePoints amount of battle points to increase
-       * @throws MongooseError if any occurred
-       * @returns true if clan was rewarded successfully
-       */
-      private async updateClanBattlePoints(
-        clan_id: string,
-        battlePoints: number,
-      ): Promise<IServiceReturn<boolean>> {
-        const [clan, errors] =
-          await this.clanService.readOneById<ClanDto>(clan_id);
-    
-        if (errors) return [null, errors];
-    
-        battlePoints = Math.max(0, clan.battlePoints + battlePoints);
-    
-        return await this.clanService.updateOneById(clan_id, {
-          $set: { battlePoints },
-        });
-      }
+
+    return this.updateClanBattlePoints(player.clan_id, pointAmount);
+  }
+
+  /**
+   * Update specified clan battle points amount
+   * @param clan_id player _id
+   * @param battlePoints amount of battle points to increase
+   * @throws MongooseError if any occurred
+   * @returns true if clan was rewarded successfully
+   */
+  private async updateClanBattlePoints(
+    clan_id: string,
+    battlePoints: number,
+  ): Promise<IServiceReturn<boolean>> {
+    const [clan, errors] = await this.clanService.readOneById<ClanDto>(clan_id);
+
+    if (errors) return [null, errors];
+
+    battlePoints = Math.max(0, clan.battlePoints + battlePoints);
+
+    return await this.clanService.updateOneById(clan_id, {
+      $set: { battlePoints },
+    });
+  }
 }

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -1,14 +1,34 @@
 import { Injectable } from '@nestjs/common';
-import { ClanService } from '../../clan/clan.service';
 import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
+import { ClanEvent } from './enum/ClanEvent.enum';
+import { IServiceReturn } from '../../common/service/basicService/IService';
+import { points } from './points';
+import BasicService from '../../common/service/basicService/BasicService';
+import { InjectModel } from '@nestjs/mongoose';
+import { Clan } from '../../clan/clan.schema';
+import { Model } from 'mongoose';
+import { ClanDto } from '../../clan/dto/clan.dto';
+import { PlayerDto } from 'src/player/dto/player.dto';
+import { Player } from 'src/player/schemas/player.schema';
 
 /**
  * Handles clan rewarding logic
  */
 @Injectable()
 export class ClanRewarder {
-  constructor(private readonly clanService: ClanService) {}
+  //constructor(private readonly clanService: ClanService) {}
+
+  private readonly clanService: BasicService;
+  private readonly playerService: BasicService;
+  
+    constructor(
+      @InjectModel(Clan.name) public readonly clanModel: Model<Clan>,
+      @InjectModel(Player.name) public readonly playerModel: Model<Player>,
+    ) {
+      this.clanService = new BasicService(clanModel);
+      this.playerService = new BasicService(playerModel);
+    }
 
   clanMaxPoints = 10000;
 
@@ -71,4 +91,70 @@ export class ClanRewarder {
       { filter: { _id: clan_id } },
     );
   }
+
+    /**
+     * Rewards specified clan for an event happen
+     * @param player_id player _id to reward
+     * @param clanEvent happen event
+     * @throws MongooseError if any occurred
+     * @returns true if clan was rewarded successfully
+     */
+    async rewardForClanEvent(
+      player_id: string,
+      clanEvent: ClanEvent,
+    ): Promise<IServiceReturn<boolean>> {
+      const pointAmount = points[clanEvent];
+      if (pointAmount === undefined)
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.WRONG_ENUM,
+              field: 'clanEvent',
+              value: clanEvent,
+              message: 'This clanEvent does not exist',
+            }),
+          ],
+        ];
+      const [player, playerErrors] = await this.playerService.readOneById<PlayerDto>(player_id);
+      if (playerErrors) return [null, playerErrors];
+      if (!player.clan_id) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.NOT_FOUND,
+              field: 'clan_id',
+              value: player.clan_id,
+              message: 'Player does not belong to a clan',
+            }),
+          ],
+        ];
+      }
+      
+      return this.updateClanBattlePoints(player.clan_id, pointAmount);
+    }
+  
+    /**
+       * Update specified clan battle points amount
+       * @param clan_id player _id
+       * @param battlePoints amount of battle points to increase
+       * @throws MongooseError if any occurred
+       * @returns true if clan was rewarded successfully
+       */
+      private async updateClanBattlePoints(
+        clan_id: string,
+        battlePoints: number,
+      ): Promise<IServiceReturn<boolean>> {
+        const [clan, errors] =
+          await this.clanService.readOneById<ClanDto>(clan_id);
+    
+        if (errors) return [null, errors];
+    
+        battlePoints = Math.max(0, clan.battlePoints + battlePoints);
+    
+        return await this.clanService.updateOneById(clan_id, {
+          $set: { battlePoints },
+        });
+      }
 }

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -92,8 +92,8 @@ export class ClanRewarder {
 
   /**
    * Rewards specified clan for an event happen
-   * @param player_id player _id to reward
-   * @param clanEvent happen event
+   * @param player_id player _id that belongs to the clan to reward
+   * @param clanEvent clan event that happened
    * @throws MongooseError if any occurred
    * @returns true if clan was rewarded successfully
    */

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -17,7 +17,6 @@ import { Player } from '../../player/schemas/player.schema';
  */
 @Injectable()
 export class ClanRewarder {
-  //constructor(private readonly clanService: ClanService) {}
 
   private readonly clanService: BasicService;
   private readonly playerService: BasicService;

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -17,7 +17,6 @@ import { Player } from '../../player/schemas/player.schema';
  */
 @Injectable()
 export class ClanRewarder {
-
   private readonly clanService: BasicService;
   private readonly playerService: BasicService;
 

--- a/src/rewarder/clanRewarder/enum/ClanEvent.enum.ts
+++ b/src/rewarder/clanRewarder/enum/ClanEvent.enum.ts
@@ -1,0 +1,4 @@
+export enum ClanEvent {
+  BATTLE_WON = 'battle_won',
+  BATTLE_LOSE = 'battle_lose',
+}

--- a/src/rewarder/clanRewarder/points.ts
+++ b/src/rewarder/clanRewarder/points.ts
@@ -1,0 +1,6 @@
+import { ClanEvent } from './enum/ClanEvent.enum';
+
+export const points: Record<ClanEvent, number> = {
+  [ClanEvent.BATTLE_WON]: 100,
+  [ClanEvent.BATTLE_LOSE]: -20,
+};

--- a/src/rewarder/rewarder.module.ts
+++ b/src/rewarder/rewarder.module.ts
@@ -6,11 +6,13 @@ import { ClanRewarder } from './clanRewarder/clanRewarder.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ModelName } from '../common/enum/modelName.enum';
 import { PlayerSchema } from '../player/schemas/player.schema';
+import { ClanSchema } from '../clan/clan.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: ModelName.PLAYER, schema: PlayerSchema },
+      { name: ModelName.CLAN, schema: ClanSchema },
     ]),
     PlayerModule,
     ClanModule,


### PR DESCRIPTION
### Brief description
As a clan member, I want to get points for my clan when I win a battle, so that my clan can rise in a battle leaderboard.

### Change list

- Add battlePoints to the clan schema and relevant DTOs
- Extend the ClanRewarder service with a logic that can update the clans battlePoints similary how its works for the Players battlePoints
- use the ClanRewarder from the ClanEventHandler and GameEventHandler
- Add tests to cover the new code
