### PR TITLE
feat: add tests for moving flea market items to stock

### DIFF
--- a/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStock.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStock.test.ts
@@ -26,6 +26,13 @@ describe('FleaMarketService.moveFleaMarketItemToStock() integration', () => {
     stockModel = FleaMarketModule.getStockModel();
   });
 
+  afterEach(async () => {
+    await itemModel.deleteMany();
+    await clanModel.deleteMany();
+    await stockModel.deleteMany();
+    await fleaMarketItemModel.deleteMany();
+  });
+
   it('should move flea market item to clan stock and delete flea market item', async () => {
     const clanId = new ObjectId().toString();
     const stockId = new ObjectId().toString();

--- a/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStock.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStock.test.ts
@@ -1,0 +1,111 @@
+import FleaMarketModule from '../modules/fleaMarketModule';
+import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
+import { ObjectId } from 'mongodb';
+import FleaMarketItemBuilder from '../data/fleaMarket/FleaMarketItemBuilder';
+import ClanBuilder from '../../clan/data/clan/ClanBuilder';
+import StockBuilder from '../../clanInventory/data/stock/StockBuilder';
+import { Model } from 'mongoose';
+import { Status } from '../../../fleaMarket/enum/status.enum';
+import { Stock } from '../../../clanInventory/stock/stock.schema';
+import { Item } from '../../../clanInventory/item/item.schema';
+import { Clan } from '../../../clan/clan.schema';
+import { ItemBookedError } from '../../../fleaMarket/errors/itemBooked.error';
+
+describe('FleaMarketService.moveFleaMarketItemToStock() integration', () => {
+  let fleaMarketService: FleaMarketService;
+  let fleaMarketItemModel: Model<any>;
+  let clanModel: Model<Clan>;
+  let itemModel: Model<Item>;
+  let stockModel: Model<Stock>;
+
+  beforeAll(async () => {
+    fleaMarketService = await FleaMarketModule.getFleaMarketService();
+    fleaMarketItemModel = FleaMarketModule.getFleaMarketItemModel();
+    clanModel = (await FleaMarketModule.getClanService()).model;
+    itemModel = (await FleaMarketModule.getItemService()).model;
+    stockModel = FleaMarketModule.getStockModel();
+  });
+
+  it('should move flea market item to clan stock and delete flea market item', async () => {
+    const clanId = new ObjectId().toString();
+    const stockId = new ObjectId().toString();
+
+    // Create clan
+    const clan = new ClanBuilder().setId(clanId).build();
+    await clanModel.create(clan);
+
+    // Create stock and link to clan
+    const stock = new StockBuilder().setId(stockId).setClanId(clanId).build();
+    await stockModel.create(stock);
+
+    // Create flea market item
+    const fleaMarketItem = new FleaMarketItemBuilder()
+      .setClanId(clanId)
+      .setStatus(Status.AVAILABLE)
+      .setPrice(100)
+      .build();
+    const createdFMItem = await fleaMarketItemModel.create(fleaMarketItem);
+
+    // Move item to stock
+    const [result, error] = await fleaMarketService.moveFleaMarketItemToStock(
+      createdFMItem._id.toString(),
+      clanId,
+    );
+
+    expect(result).toBeTruthy();
+    expect(error).toBeNull();
+
+    // Flea market item should be deleted
+    const fmItemInDb = await fleaMarketItemModel.findById(createdFMItem._id);
+    expect(fmItemInDb).toBeNull();
+
+    // Item should be in stock
+    const itemsInStock = await itemModel.find({ stock_id: stockId });
+    expect(itemsInStock).toHaveLength(1);
+    const item = itemsInStock[0];
+
+    expect(item.stock_id.toString()).toBe(stockId);
+    expect(item.price).toBe(100);
+    expect(item.name).toBe(createdFMItem.name);
+  });
+
+  it('should return error if flea market item status is BOOKED', async () => {
+    const clanId = new ObjectId().toString();
+    const stockId = new ObjectId().toString();
+
+    // Create clan
+    const clan = new ClanBuilder().setId(clanId).build();
+    await clanModel.create(clan);
+
+    // Create stock and link to clan
+    const stock = new StockBuilder().setId(stockId).setClanId(clanId).build();
+    await stockModel.create(stock);
+
+    // Create flea market item with status BOOKED
+    const fleaMarketItem = new FleaMarketItemBuilder()
+      .setClanId(clanId)
+      .setStatus(Status.BOOKED)
+      .setPrice(100)
+      .build();
+    const createdFMItem = await fleaMarketItemModel.create(fleaMarketItem);
+
+    // Try to move item to stock
+    const [result, error] = await fleaMarketService.moveFleaMarketItemToStock(
+      createdFMItem._id.toString(),
+      clanId,
+    );
+
+    expect(result).toBeFalsy();
+    expect(error).toBeTruthy();
+    expect(error).toContainSE_NOT_ALLOWED();
+    expect(error[0]).toMatchObject(ItemBookedError);
+
+    // Flea market item should still exist
+    const fmItemInDb = await fleaMarketItemModel.findById(createdFMItem._id);
+    expect(fmItemInDb).not.toBeNull();
+
+    // No item should be added to stock
+    const itemsInStock = await itemModel.find({ stock_id: stockId });
+    expect(itemsInStock).toHaveLength(0);
+  });
+});

--- a/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStockTransaction.test.ts
+++ b/src/__tests__/fleaMarket/FleaMarketService/moveFleaMarketItemToStockTransaction.test.ts
@@ -1,0 +1,160 @@
+import FleaMarketModule from '../modules/fleaMarketModule';
+import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
+import { ObjectId } from 'mongodb';
+import FleaMarketItemBuilder from '../data/fleaMarket/FleaMarketItemBuilder';
+import ClanBuilder from '../../clan/data/clan/ClanBuilder';
+import StockBuilder from '../../clanInventory/data/stock/StockBuilder';
+import { Status } from '../../../fleaMarket/enum/status.enum';
+import { Model } from 'mongoose';
+import { Item } from '../../../clanInventory/item/item.schema';
+import { Stock } from '../../../clanInventory/stock/stock.schema';
+import { Clan } from '../../../clan/clan.schema';
+import { FleaMarketItem } from '../../../fleaMarket/fleaMarketItem.schema';
+
+describe('FleaMarketService.moveFleaMarketItemToStockTransaction() integration', () => {
+  let fleaMarketService: FleaMarketService;
+  let fleaMarketItemModel: Model<FleaMarketItem>;
+  let itemModel: Model<Item>;
+  let stockModel: Model<Stock>;
+  let clanModel: Model<Clan>;
+
+  beforeAll(async () => {
+    fleaMarketService = await FleaMarketModule.getFleaMarketService();
+    fleaMarketItemModel = FleaMarketModule.getFleaMarketItemModel();
+    itemModel = (await FleaMarketModule.getItemService()).model;
+    stockModel = FleaMarketModule.getStockModel();
+    clanModel = (await FleaMarketModule.getClanService()).model;
+  });
+
+  beforeEach(async () => {
+    await fleaMarketItemModel.deleteMany();
+    await itemModel.deleteMany();
+    await stockModel.deleteMany();
+    await clanModel.deleteMany();
+  });
+
+  it('should create item in stock and delete flea market item in a transaction', async () => {
+    const clanId = new ObjectId().toString();
+    const stockId = new ObjectId().toString();
+
+    // Create clan and stock
+    const clan = new ClanBuilder().setId(clanId).build();
+    await clanModel.create(clan);
+    const stock = new StockBuilder().setId(stockId).setClanId(clanId).build();
+    await stockModel.create(stock);
+
+    // Create flea market item
+    const fleaMarketItem = new FleaMarketItemBuilder()
+      .setClanId(clanId)
+      .setStatus(Status.AVAILABLE)
+      .setPrice(100)
+      .build();
+    const createdFMItem = await fleaMarketItemModel.create(fleaMarketItem);
+
+    // Prepare CreateItemDto using the helper
+    const createItemDto = fleaMarketService[
+      'helperService'
+    ].fleaMarketItemToCreateItemDto(createdFMItem, stockId);
+
+    // Call transaction
+    const [result, error] = await fleaMarketService[
+      'moveFleaMarketItemToStockTransaction'
+    ](createItemDto, createdFMItem._id.toString());
+
+    expect(result).toBeTruthy();
+    expect(error).toBeNull();
+
+    // Flea market item should be deleted
+    const fmItemInDb = await fleaMarketItemModel.findById(createdFMItem._id);
+    expect(fmItemInDb).toBeNull();
+
+    // Item should be in stock
+    const itemsInStock = await itemModel.find({ stock_id: stockId });
+    expect(itemsInStock).toHaveLength(1);
+    expect(itemsInStock[0].price).toBe(100);
+    expect(itemsInStock[0].stock_id.toString()).toBe(stockId);
+  });
+
+  it('should rollback if item creation fails', async () => {
+    const clanId = new ObjectId().toString();
+    const stockId = new ObjectId().toString();
+
+    // Create clan and stock
+    const clan = new ClanBuilder().setId(clanId).build();
+    await clanModel.create(clan);
+    const stock = new StockBuilder().setId(stockId).setClanId(clanId).build();
+    await stockModel.create(stock);
+
+    // Create flea market item
+    const fleaMarketItem = new FleaMarketItemBuilder()
+      .setClanId(clanId)
+      .setStatus(Status.AVAILABLE)
+      .setPrice(100)
+      .build();
+    const createdFMItem = await fleaMarketItemModel.create(fleaMarketItem);
+
+    // Prepare invalid CreateItemDto (missing required field, e.g. name)
+    const createItemDto = {
+      ...fleaMarketService['helperService'].fleaMarketItemToCreateItemDto(
+        createdFMItem,
+        stockId,
+      ),
+      name: null,
+    };
+
+    // Call transaction
+    const [result, error] = await fleaMarketService[
+      'moveFleaMarketItemToStockTransaction'
+    ](createItemDto, createdFMItem._id.toString());
+
+    expect(result).toBeNull();
+    expect(error).toBeTruthy();
+
+    // Flea market item should still exist
+    const fmItemInDb = await fleaMarketItemModel.findById(createdFMItem._id);
+    expect(fmItemInDb).not.toBeNull();
+
+    // No item should be added to stock
+    const itemsInStock = await itemModel.find({ stock_id: stockId });
+    expect(itemsInStock).toHaveLength(0);
+  });
+
+  it('should rollback if flea market item deletion fails', async () => {
+    const clanId = new ObjectId().toString();
+    const stockId = new ObjectId().toString();
+
+    // Create clan and stock
+    const clan = new ClanBuilder().setId(clanId).build();
+    await clanModel.create(clan);
+    const stock = new StockBuilder().setId(stockId).setClanId(clanId).build();
+    await stockModel.create(stock);
+
+    // Create flea market item
+    const fleaMarketItem = new FleaMarketItemBuilder()
+      .setClanId(clanId)
+      .setStatus(Status.AVAILABLE)
+      .setPrice(100)
+      .build();
+    const createdFMItem = await fleaMarketItemModel.create(fleaMarketItem);
+
+    // Prepare CreateItemDto
+    const createItemDto = fleaMarketService[
+      'helperService'
+    ].fleaMarketItemToCreateItemDto(createdFMItem, stockId);
+
+    // Delete flea market item before transaction to force deletion error
+    await fleaMarketItemModel.deleteOne({ _id: createdFMItem._id });
+
+    // Call transaction
+    const [result, error] = await fleaMarketService[
+      'moveFleaMarketItemToStockTransaction'
+    ](createItemDto, createdFMItem._id.toString());
+
+    expect(result).toBeNull();
+    expect(error).toBeTruthy();
+
+    // Item should not be added to stock (transaction should rollback)
+    const itemsInStock = await itemModel.find({ stock_id: stockId });
+    expect(itemsInStock).toHaveLength(0);
+  });
+});

--- a/src/__tests__/fleaMarket/modules/fleaMarketModule.ts
+++ b/src/__tests__/fleaMarket/modules/fleaMarketModule.ts
@@ -13,6 +13,7 @@ import { VotingQueue } from '../../../voting/voting.queue';
 import { ClanService } from '../../../clan/clan.service';
 import BasicService from '../../../common/service/basicService/BasicService';
 import { StallService } from '../../../fleaMarket/stall/stall.service';
+import { StockSchema } from '../../../clanInventory/stock/stock.schema';
 
 export default class FleaMarketModule {
   private constructor() {}
@@ -74,5 +75,9 @@ export default class FleaMarketModule {
 
   static getFleaMarketItemModel() {
     return mongoose.model(ModelName.FLEA_MARKET_ITEM, FleaMarketItemSchema);
+  }
+
+  static getStockModel() {
+    return mongoose.model(ModelName.STOCK, StockSchema);
   }
 }

--- a/src/fleaMarket/errors/itemBooked.error.ts
+++ b/src/fleaMarket/errors/itemBooked.error.ts
@@ -1,0 +1,10 @@
+import { SEReason } from '../../common/service/basicService/SEReason';
+import ServiceError from '../../common/service/basicService/ServiceError';
+import { Status } from '../enum/status.enum';
+
+export const ItemBookedError = new ServiceError({
+  reason: SEReason.NOT_ALLOWED,
+  field: 'status',
+  value: Status.BOOKED,
+  message: 'Item is booked',
+});

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -262,6 +262,6 @@ export class FleaMarketController {
       param._id,
       clanId,
     );
-    if (errors) return [null, errors];
+    if (errors) throw errors;
   }
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -21,7 +21,6 @@ import { VotingDto } from '../voting/dto/voting.dto';
 import { ChangeItemStatusDto } from './dto/changeItemStatus.dto';
 import { Status } from './enum/status.enum';
 import SwaggerTags from '../common/swagger/tags/SwaggerTags.decorator';
-import { swaggerTags } from '../common/swagger/tags/tags';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -225,5 +224,44 @@ export class FleaMarketController {
     );
 
     if (updateError) throw updateError;
+  }
+
+  /**
+   * Move item from fleamarket to stock.
+   *
+   * @remarks Moves the item from fleamarket to stock.
+   * Player will need a SHOP clan right.
+   * Item can't be moved if it's booked.
+   * Item must belong to the players clan.
+   */
+  @SwaggerTags('Release on 07.09.2025')
+  @ApiResponseDescription({
+    success: {
+      status: 204,
+    },
+    errors: [400, 403, 404],
+  })
+  @HasClanRights([ClanBasicRight.SHOP])
+  @UniformResponse()
+  @Post('move-to-stock/:_id')
+  async removeItemFromFleaMarket(
+    @Param() param: _idDto,
+    @LoggedUser() user: User,
+  ) {
+    const clanId = await this.service.getFleaMarketItemClanId(
+      param._id,
+      user.player_id,
+    );
+    if (!clanId)
+      throw new APIError({
+        reason: APIErrorReason.NOT_AUTHORIZED,
+        message: 'The item does not belong to the clan of logged in player',
+      });
+
+    const [_, errors] = await this.service.removeItemFromFleaMarket(
+      param._id,
+      clanId,
+    );
+    if (errors) return [null, errors];
   }
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -258,7 +258,7 @@ export class FleaMarketController {
         message: 'The item does not belong to the clan of logged in player',
       });
 
-    const [_, errors] = await this.service.removeItemFromFleaMarket(
+    const [_, errors] = await this.service.moveFleaMarketItemToStock(
       param._id,
       clanId,
     );

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -34,6 +34,8 @@ import { itemNotAuthorizedError } from './errors/itemNotAuthorized.error';
 import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
 import { maxSlotsReachedError } from './errors/maxSlotsReached.error';
+import { ItemBookedError } from './errors/itemBooked.error';
+import { CreateItemDto } from 'src/clanInventory/item/dto/createItem.dto';
 
 @Injectable()
 export class FleaMarketService {
@@ -673,6 +675,76 @@ export class FleaMarketService {
 
     if (items.length >= clan.stall.maxSlots)
       return [false, [maxSlotsReachedError]];
+
+    return [true, null];
+  }
+
+  /**
+   * Moves a flea market item to the clan's stock.
+   *
+   * This method performs the following steps:
+   * 1. Reads the flea market item by its ID.
+   * 2. Returns an error if the item is booked or if there are read errors.
+   * 3. Reads the clan by its ID, including its stock reference.
+   * 4. Converts the flea market item to a DTO suitable for stock creation.
+   * 5. Executes a transaction to move the item to stock.
+   *
+   * @param itemId - The ID of the flea market item to move.
+   * @param clanId - The ID of the clan whose stock will receive the item.
+   * @returns A promise resolving to the result of the move operation or errors encountered.
+   */
+  async moveFleaMarketItemToStock(itemId: string, clanId: string) {
+    const [item, errors] =
+      await this.basicService.readOneById<FleaMarketItem>(itemId);
+
+    if (errors) return [null, errors];
+    if (item.status === Status.BOOKED) return [null, [ItemBookedError]];
+
+    const [clan, clanErrors] = await this.clanService.readOneById(clanId, {
+      includeRefs: [ModelName.STOCK],
+    });
+    if (clanErrors) return [null, clanErrors];
+
+    const createItemDto = this.helperService.fleaMarketItemToCreateItemDto(
+      item,
+      clan.Stock._id,
+    );
+
+    return await this.moveFleaMarketItemToStockTransaction(
+      createItemDto,
+      itemId,
+    );
+  }
+
+  /**
+   * Moves an item from the flea market to stock within a database transaction.
+   *
+   * This method performs the following steps in a transaction:
+   * 1. Creates a new item in stock using the provided item data.
+   * 2. Deletes the corresponding item from the flea market by its ID.
+   * 3. Commits the transaction if both operations succeed.
+   * 4. Cancels the transaction and returns errors if any operation fails.
+   *
+   * @param itemDto - Data transfer object containing the item details to be created in stock.
+   * @param fleaMarketItemId - The ID of the flea market item to be removed.
+   * @returns A tuple where the first element indicates success and the second contains any errors.
+   */
+  private async moveFleaMarketItemToStockTransaction(
+    itemDto: CreateItemDto,
+    fleaMarketItemId: string,
+  ) {
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
+    const [, createErrors] = await this.itemService.createOne(itemDto);
+    if (createErrors) return await cancelTransaction(session, createErrors);
+
+    const [, deleteErrors] =
+      await this.basicService.deleteOneById(fleaMarketItemId);
+    if (deleteErrors) return await cancelTransaction(session, deleteErrors);
+
+    await session.commitTransaction();
+    await session.endSession();
 
     return [true, null];
   }

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -35,7 +35,7 @@ import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
 import { maxSlotsReachedError } from './errors/maxSlotsReached.error';
 import { ItemBookedError } from './errors/itemBooked.error';
-import { CreateItemDto } from 'src/clanInventory/item/dto/createItem.dto';
+import { CreateItemDto } from '../clanInventory/item/dto/createItem.dto';
 
 @Injectable()
 export class FleaMarketService {

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -736,11 +736,16 @@ export class FleaMarketService {
     const session = await this.connection.startSession();
     session.startTransaction();
 
-    const [, createErrors] = await this.itemService.createOne(itemDto);
+    const [, createErrors] = await this.itemService.createOne(itemDto, {
+      session,
+    });
     if (createErrors) return await cancelTransaction(session, createErrors);
 
-    const [, deleteErrors] =
-      await this.basicService.deleteOneById(fleaMarketItemId);
+    const [, deleteErrors] = await this.basicService.deleteOneById(
+      fleaMarketItemId,
+      { session },
+    );
+
     if (deleteErrors) return await cancelTransaction(session, deleteErrors);
 
     await session.commitTransaction();


### PR DESCRIPTION
### Brief description
Add new endpoint to move items from fleamarket to stock.


### Change list

- Add `POST /move-to-stock/:_id` endpoint
- Add service methods to handle the item moving
- Add tests for the service methods
