### PR TITLE
Fix error handling in updateUIDailyTask

### DIFF
--- a/src/dailyTasks/dailyTasks.controller.ts
+++ b/src/dailyTasks/dailyTasks.controller.ts
@@ -147,11 +147,12 @@ export class DailyTasksController {
     @LoggedUser() user: User,
     @Body() body: UpdateUIDailyTaskDto,
   ) {
-    const [[status, task], errors] = await this.uiDailyTasksService.updateTask(
+    const [data, errors] = await this.uiDailyTasksService.updateTask(
       user.player_id,
       body.amount,
     );
-    if (errors) return [null, errors];
+    if (errors) throw errors;
+    const [status, task] = data;
 
     await this.emitter.emitAsync('dailyTask.updateUIBasicTask', {
       status,


### PR DESCRIPTION
### Brief description
On any error the endpoint was always returning a 500 unexpected error since the updateTask return data on error was `[null, [ServiceErrors]]` and the desctructuring with `const [[status, task], errors]` threw an error since you can't destructure null as an array.


### Change list

- Moved the data destructuring after the error check.
