### PR TITLE
Feature/add send a message in global chat daily task 644

### DIFF
--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -102,6 +102,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @ConnectedSocket() client: WebSocketUser,
   ) {
     await this.globalChatService.handleNewGlobalMessage(message, client);
+
+    await this.eventEmitter.emitAsync('newDailyTaskEvent', {
+      playerId: client.user.playerId,
+      message,
+      serverTaskName: ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
+    });
   }
 
   @SubscribeMessage('globalMessageReaction')

--- a/src/dailyTasks/enum/serverTaskName.enum.ts
+++ b/src/dailyTasks/enum/serverTaskName.enum.ts
@@ -125,7 +125,6 @@ export enum ServerTaskName {
    */
   WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
 
-
   /**
    * laita privaviesti toiselle pelaajalle
    */

--- a/src/dailyTasks/enum/serverTaskName.enum.ts
+++ b/src/dailyTasks/enum/serverTaskName.enum.ts
@@ -118,6 +118,14 @@ export enum ServerTaskName {
    * laita viesti klaanissa
    */
   WRITE_CHAT_MESSAGE_CLAN = 'write_chat_message_clan',
+
+  //Server
+  /**
+   * laita viesti globalissa
+   */
+  WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
+
+
   /**
    * laita privaviesti toiselle pelaajalle
    */


### PR DESCRIPTION
### Brief description

Add support for "send a message in global chat" daily task.

### Change list

- Add the WRITE_CHAT_MESSAGE_GLOBAL item to the ServerTaskName enum
- Emit new event with WRITE_CHAT_MESSAGE_GLOBAL server task from the chat gateway (globalMessage)
- The event handler is already done
