### PR TITLE
Add the Expose decorator to organizer dto

### DIFF
--- a/src/voting/dto/organizer.dto.ts
+++ b/src/voting/dto/organizer.dto.ts
@@ -1,3 +1,4 @@
+import { Expose } from 'class-transformer';
 import { IsMongoId, IsOptional } from 'class-validator';
 
 export class Organizer {
@@ -6,6 +7,7 @@ export class Organizer {
    *
    * @example "662f4f1235faaf001ef7b5aa"
    */
+  @Expose()
   @IsMongoId()
   player_id: string;
 
@@ -14,6 +16,7 @@ export class Organizer {
    *
    * @example "662f4f1235faaf001ef7b5ab"
    */
+  @Expose()
   @IsMongoId()
   @IsOptional()
   clan_id: string;


### PR DESCRIPTION
### Brief description

Organizer data wasn't showing in voting responses due to missing `Expose()` decorator in dto.

### Change list

- Added Expose decorator to dto props
