### PR TITLE
Buy item endpoint not adding errors to responses.

### DIFF
--- a/src/clanShop/clanShop.controller.ts
+++ b/src/clanShop/clanShop.controller.ts
@@ -79,6 +79,6 @@ export class ClanShopController {
         message: `Item ${body.itemName} not available in shop.`,
       });
 
-    await this.service.buyItem(user.player_id, user.clan_id, item);
+    return await this.service.buyItem(user.player_id, user.clan_id, item);
   }
 }


### PR DESCRIPTION
### Brief description

Possible `clanShop/buy` endpoint errors were missing from the response due to missing return statement in the method call.

### Change list

- Added return statement to return possible errors from buyItem call
