### PR TITLE
Feature/add add an item to the flea market daily task 647

### DIFF
--- a/src/__tests__/fleaMarket/modules/fleaMarketCommon.ts
+++ b/src/__tests__/fleaMarket/modules/fleaMarketCommon.ts
@@ -14,6 +14,7 @@ import { FleaMarketHelperService } from '../../../fleaMarket/fleaMarketHelper.se
 import { FleaMarketVotingProcessor } from '../../../fleaMarket/fleaMarketVoting.processor';
 import { StallService } from '../../../fleaMarket/stall/stall.service';
 import { VotingSchema } from '../../../voting/schemas/voting.schema';
+import { EventEmitterCommonModule } from '../../../common/service/EventEmitterService/EventEmitterCommon.module';
 
 export default class FleaMarketCommonModule {
   private constructor() {}
@@ -37,6 +38,7 @@ export default class FleaMarketCommonModule {
           VotingModule,
           ClanModule,
           RequestHelperModule,
+          EventEmitterCommonModule,
         ],
         providers: [
           FleaMarketService,

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -36,6 +36,8 @@ import { SEReason } from '../common/service/basicService/SEReason';
 import { maxSlotsReachedError } from './errors/maxSlotsReached.error';
 import { ItemBookedError } from './errors/itemBooked.error';
 import { CreateItemDto } from '../clanInventory/item/dto/createItem.dto';
+import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
+import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 
 @Injectable()
 export class FleaMarketService {
@@ -49,6 +51,7 @@ export class FleaMarketService {
     private readonly votingService: VotingService,
     private readonly votingQueue: VotingQueue,
     private readonly clanService: ClanService,
+    private readonly emitterService: EventEmitterService,
     @InjectConnection() private readonly connection: Connection,
   ) {
     this.basicService = new BasicService(model);
@@ -175,6 +178,12 @@ export class FleaMarketService {
       session,
     );
     if (err) return await cancelTransaction(session, err);
+
+    this.emitterService.EmitNewDailyTaskEvent(
+          playerId,
+          ServerTaskName.ADD_ITEM_TO_FLEA_MARKET,
+        );
+
     const [voting, errors] = await this.votingService.startVoting({
       voterPlayer: player,
       type: VotingType.FLEA_MARKET_SELL_ITEM,

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -180,9 +180,9 @@ export class FleaMarketService {
     if (err) return await cancelTransaction(session, err);
 
     this.emitterService.EmitNewDailyTaskEvent(
-          playerId,
-          ServerTaskName.ADD_ITEM_TO_FLEA_MARKET,
-        );
+      playerId,
+      ServerTaskName.ADD_ITEM_TO_FLEA_MARKET,
+    );
 
     const [voting, errors] = await this.votingService.startVoting({
       voterPlayer: player,


### PR DESCRIPTION
### Brief description

Add support for "add an item to the flea market" daily task.

### Change list

- Emit server event with ADD_ITEM_TO_FLEA_MARKET type when moving approved for sale item to the flea market
- Fix the failed tests


