### PR TITLE
Enhance and register the v2 box schema

### DIFF
--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -31,10 +31,12 @@ import AccountClaimerService from './accountClaimer/accountClaimer.service';
 import { TesterAccountService } from './accountClaimer/testerAccount.service';
 import UniqueFieldGenerator from './util/UniqueFieldGenerator';
 import { ItemSchema } from '../clanInventory/item/item.schema';
+import { BoxSchema as v2BoxSchema } from './schemas/box.v2.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
+      { name: 'v2Box', schema: v2BoxSchema },
       { name: ModelName.BOX, schema: BoxSchema },
       { name: ModelName.GROUP_ADMIN, schema: GroupAdminSchema },
       { name: ModelName.PROFILE, schema: ProfileSchema },

--- a/src/box/box.service.ts
+++ b/src/box/box.service.ts
@@ -21,11 +21,13 @@ import {
 import { ObjectId } from 'mongodb';
 import { SessionStage } from './enum/SessionStage.enum';
 import { Profile } from '../profile/profile.schema';
+import { Box as v2Box } from './schemas/box.v2.schema';
 
 @Injectable()
 export class BoxService {
   public constructor(
     @InjectModel(Box.name) public readonly model: Model<Box>,
+    @InjectModel('v2Box') public readonly v2model: Model<v2Box>,
     @InjectModel(Player.name) public readonly playerModel: Model<Player>,
     @InjectModel(Profile.name) private readonly profileModel: Model<Profile>,
     @InjectModel(Clan.name) public readonly clanModel: Model<Clan>,
@@ -36,11 +38,13 @@ export class BoxService {
   ) {
     this.refsInModel = publicReferences;
     this.basicService = new BasicService(model);
+    this.v2basicService = new BasicService(v2model);
     this.adminBasicService = new BasicService(groupAdminModel);
   }
 
   public readonly refsInModel: BoxReference[];
   public readonly basicService: BasicService;
+  public readonly v2basicService: BasicService;
   private readonly adminBasicService: BasicService;
 
   /**

--- a/src/box/boxCreator.ts
+++ b/src/box/boxCreator.ts
@@ -178,7 +178,7 @@ export default class BoxCreator {
     );
     boxToCreate.clansToCreate = [{ name: clanName1 }, { name: clanName2 }];
 
-    return await this.boxService.basicService.createOne(boxToCreate);
+    return await this.boxService.v2basicService.createOne(boxToCreate);
   }
 
   /**

--- a/src/box/schemas/ClanToCreate.v2.schema.ts
+++ b/src/box/schemas/ClanToCreate.v2.schema.ts
@@ -1,0 +1,10 @@
+import { Prop, Schema } from '@nestjs/mongoose';
+
+@Schema({ _id: false })
+export class ClanToCreate {
+  @Prop({ type: String, required: true })
+  name: string;
+
+  @Prop({ type: Boolean, default: true })
+  isOpen?: boolean = true;
+}

--- a/src/box/schemas/box.v2.schema.ts
+++ b/src/box/schemas/box.v2.schema.ts
@@ -1,15 +1,14 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 import { ModelName } from '../../common/enum/modelName.enum';
-import { ObjectId } from 'mongodb';
 import { SessionStage } from '../enum/SessionStage.enum';
 import { ExtractField } from '../../common/decorator/response/ExtractField';
 import { BoxReference } from '../enum/BoxReference.enum';
+import { ClanToCreate } from './ClanToCreate.v2.schema';
 import {
   PredefinedDailyTask,
   PredefinedDailyTaskSchema,
 } from '../dailyTask/predefinedDailyTask.schema';
-import { ClanToCreate, ClanToCreateSchema } from './ClanToCreate.schema';
 import { defaultPredefinedDailyTasks } from '../dailyTask/defaultPredefinedDailyTasks';
 
 export type BoxDocument = HydratedDocument<Box>;
@@ -69,20 +68,20 @@ export class Box {
   /**
    * Group teacher profile _id
    */
-  @Prop({ type: ObjectId, required: true })
-  teacherProfile_id: ObjectId;
+  @Prop({ type: Types.ObjectId, required: true })
+  teacherProfile_id: Types.ObjectId;
 
   /**
    * Clan data to be created when session goes to testing stage.
    */
-  @Prop({ type: [ClanToCreateSchema] })
+  @Prop({ type: [ClanToCreate] })
   clansToCreate: ClanToCreate[];
 
   /**
    * IDs of created clans when session goes to testing stage.
    */
-  @Prop({ type: [ObjectId] })
-  createdClan_ids: ObjectId[];
+  @Prop({ type: [Types.ObjectId] })
+  createdClan_ids: Types.ObjectId[];
 
   /**
    * Amount of testers accounts required for the testing session.
@@ -115,11 +114,12 @@ export class Box {
   dailyTasks: PredefinedDailyTask[];
 
   @ExtractField()
-  _id: ObjectId;
+  _id: Types.ObjectId;
 }
 
 export const BoxSchema = SchemaFactory.createForClass(Box);
-BoxSchema.set('collection', ModelName.BOX);
+// BoxSchema.set('collection', ModelName.BOX);
+BoxSchema.set('collection', 'v2Box');
 BoxSchema.virtual(BoxReference.TEACHER_PROFILE, {
   ref: ModelName.TEACHER_PROFILE,
   localField: 'teacherProfile_id',


### PR DESCRIPTION
### Brief description

Changed the box schema to use Types.ObjectId instead of plain ObjectId like documentation suggests. Added the `@Schema` decorator to clanToCreate schema to make the default value work and removed the unnecessary _id from that schema.

Register the new schema in box module
Inject the new model in box.service