### PR TITLE
addBoxIdToSchema changes

### DIFF
--- a/src/common/plugin/addBoxIdToSchema.plugin.ts
+++ b/src/common/plugin/addBoxIdToSchema.plugin.ts
@@ -1,4 +1,5 @@
 import { Schema } from 'mongoose';
+import { ModelName } from '../enum/modelName.enum';
 
 /**
  * Adds box_id field to a DB schema
@@ -6,6 +7,16 @@ import { Schema } from 'mongoose';
  * @param schema where box_id field to add
  */
 export function addBoxIdToSchemaPlugin(schema: Schema) {
+  const collection = schema.get('collection');
+  //TODO: Delete v2box later
+  if (
+    collection === ModelName.TEACHER_PROFILE ||
+    collection === ModelName.BOX ||
+    collection === 'v2Box' ||
+    !collection
+  )
+    return;
+
   schema.add({
     box_id: {
       type: String,


### PR DESCRIPTION
### Brief description

The plugin was adding the box_id to all schemas which was unnecessary. The teacher profile and box do not need that and neither do the subschemas like clansToCreate.