### PR TITLE
Added teacher profile auth logic

### DIFF
--- a/src/box/auth/boxAuth.guard.ts
+++ b/src/box/auth/boxAuth.guard.ts
@@ -12,6 +12,7 @@ import { APIError } from '../../common/controller/APIError';
 import { APIErrorReason } from '../../common/controller/APIErrorReason';
 import { envVars } from '../../common/service/envHandler/envVars';
 import { BoxUser } from './BoxUser';
+import { BoxUserFactory } from '../box-user.factory';
 
 /**
  * Auth guard for testing sessions.
@@ -25,6 +26,7 @@ export class BoxAuthGuard implements CanActivate {
   public constructor(
     private readonly jwtService: JwtService,
     private readonly reflector: Reflector,
+    private readonly boxUserFactory: BoxUserFactory,
   ) {}
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -70,7 +72,7 @@ export class BoxAuthGuard implements CanActivate {
       };
 
       if (profile_id && groupAdmin) {
-        request['user'] = new BoxUser(payload);
+        request['user'] = this.boxUserFactory.createFromJwtPayload(payload);
         return true;
       }
 
@@ -100,7 +102,7 @@ export class BoxAuthGuard implements CanActivate {
           ],
         });
 
-      request['user'] = new BoxUser(payload);
+      request['user'] = this.boxUserFactory.createFromJwtPayload(payload);
     } catch (e: any) {
       if (e instanceof UnauthorizedException) throw e;
 

--- a/src/box/auth/boxAuth.guard.ts
+++ b/src/box/auth/boxAuth.guard.ts
@@ -69,6 +69,11 @@ export class BoxAuthGuard implements CanActivate {
         ...payload,
       };
 
+      if (profile_id && groupAdmin) {
+        request['user'] = new BoxUser(payload);
+        return true;
+      }
+
       if (profile_id && player_id && !box_id && groupAdmin === null)
         throw new UnauthorizedException({
           ...errorResponse,

--- a/src/box/box-user.factory.ts
+++ b/src/box/box-user.factory.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { BoxUser } from './auth/BoxUser';
+
+@Injectable()
+export class BoxUserFactory {
+  createFromJwtPayload(payload: BoxUser): BoxUser {
+    return new BoxUser(payload);
+  }
+}

--- a/src/box/box.module.ts
+++ b/src/box/box.module.ts
@@ -31,6 +31,7 @@ import AccountClaimerService from './accountClaimer/accountClaimer.service';
 import { TesterAccountService } from './accountClaimer/testerAccount.service';
 import UniqueFieldGenerator from './util/UniqueFieldGenerator';
 import { ItemSchema } from '../clanInventory/item/item.schema';
+import { BoxUserFactory } from './box-user.factory';
 
 @Module({
   imports: [
@@ -67,6 +68,7 @@ import { ItemSchema } from '../clanInventory/item/item.schema';
     AccountClaimerService,
     TesterAccountService,
     UniqueFieldGenerator,
+    BoxUserFactory,
   ],
   exports: [BoxService, GroupAdminGuard, BoxAuthHandler],
 })

--- a/src/teacher/teacher.service.ts
+++ b/src/teacher/teacher.service.ts
@@ -7,9 +7,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as argon2 from 'argon2';
 import { ARGON2_CONFIG } from '../profile/profile.service';
 import { IServiceReturn } from '../common/service/basicService/IService';
-import ServiceError, {
-  isServiceError,
-} from '../common/service/basicService/ServiceError';
+import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
 
 @Injectable()
@@ -42,6 +40,7 @@ export class TeacherService {
 
     const accessToken = await this.jwtService.signAsync({
       profile_id: createdProfile['_id'],
+      groupAdmin: true,
     });
 
     return [{ accessToken }, null];
@@ -77,6 +76,7 @@ export class TeacherService {
 
     const accessToken = await this.jwtService.signAsync({
       profile_id: profile['_id'],
+      groupAdmin: true,
     });
 
     return [{ accessToken }, null];


### PR DESCRIPTION
### Brief description

* Updated the `TeacherService` to include a `groupAdmin: true` property in the JWT access token when creating or logging in a teacher, ensuring downstream services can identify group admins. [[1]](diffhunk://#diff-7bea637ef65d2633fe76edc0e14ae20cedf306b37cb1b189f7c8ec01d28305ccR43) [[2]](diffhunk://#diff-7bea637ef65d2633fe76edc0e14ae20cedf306b37cb1b189f7c8ec01d28305ccR79)
* Modified the `BoxAuthGuard` to allow requests with a valid `profile_id` and `groupAdmin` flag to pass authentication, streamlining access for group admins.
