### PR TITLE
Change leaderboard update interval

### DIFF
--- a/src/common/service/envHandler/envVars.ts
+++ b/src/common/service/envHandler/envVars.ts
@@ -101,6 +101,9 @@ interface EnvVars {
 
   /** How many days before a voting expires. */
   VOTING_EXPIRATION_DAYS: string;
+
+  /** How often leaderboard updates. In seconds */
+  LEADERBOARD_UPDATE_DELAY_SECONDS: string;
 }
 
 /**
@@ -144,4 +147,7 @@ export const envVars: EnvVars = {
   MIN_GAME_BUILD_VERSION: process.env.MIN_GAME_BUILD_VERSION,
 
   VOTING_EXPIRATION_DAYS: process.env.VOTING_EXPIRATION_DAYS ?? '7',
+
+  LEADERBOARD_UPDATE_DELAY_SECONDS:
+    process.env.LEADERBOARD_UPDATE_DELAY ?? '60',
 };

--- a/src/leaderboard/leaderboard.service.ts
+++ b/src/leaderboard/leaderboard.service.ts
@@ -8,6 +8,7 @@ import mongoose, { Model } from 'mongoose';
 import { CacheKeys } from '../common/service/redis/cacheKeys.enum';
 import { RedisService } from '../common/service/redis/redis.service';
 import { PlayerDocument } from '../player/schemas/player.schema';
+import { envVars } from '../common/service/envHandler/envVars';
 
 @Injectable()
 export class LeaderboardService {
@@ -18,9 +19,12 @@ export class LeaderboardService {
   ) {}
 
   /**
-   * Leaderboard data update interval in second, 3h
+   * Leaderboard data update interval in seconds
    */
-  private readonly LEADERBOARD_TTL_S = 10800;
+  private readonly LEADERBOARD_TTL_S = parseInt(
+    envVars.LEADERBOARD_UPDATE_DELAY_SECONDS,
+    10,
+  );
 
   /**
    * Retrieves the clan leaderboard data.


### PR DESCRIPTION
### Brief description

Leaderboard should update more often while the game is still in testing. I changed the static value for leaderboard update interval in leaderboard service to come from env vars so it's easier to change in the future depending the current needs. The current default value is now 1 minute.

