### PR TITLE
Bug/jukebox is frozen 723

### DIFF
--- a/src/__tests__/jukebox/jukeboxService/addSongToClanJukebox.test.ts
+++ b/src/__tests__/jukebox/jukeboxService/addSongToClanJukebox.test.ts
@@ -1,26 +1,19 @@
 import { ClanService } from '../../../clan/clan.service';
 import JukeboxNotifier from '../../../jukebox/jukebox.notifier';
-import { JukeboxQueue } from '../../../jukebox/jukebox.queue';
 import { JukeboxService } from '../../../jukebox/jukebox.service';
 
 describe('jukeboxService.addSongToclanJukebox() test suite', () => {
   let jukeboxService: JukeboxService;
   let jukeboxNotifier: JukeboxNotifier;
-  let jukeboxScheduler: JukeboxQueue;
   let clanService: ClanService;
 
   beforeEach(async () => {
     jukeboxNotifier = { songChange: jest.fn() } as any;
-    jukeboxScheduler = { scheduleNextSong: jest.fn() } as any;
     clanService = {
       readOneById: jest.fn().mockResolvedValue([{ playerCount: 3 }]),
     } as any;
 
-    jukeboxService = new JukeboxService(
-      jukeboxScheduler,
-      jukeboxNotifier,
-      clanService,
-    );
+    jukeboxService = new JukeboxService(jukeboxNotifier, clanService);
   });
 
   it('should call scheduler and notifier for first song', async () => {
@@ -38,11 +31,6 @@ describe('jukeboxService.addSongToclanJukebox() test suite', () => {
     expect(notifiedArg.songId).toBe(song.songId);
     expect(notifiedArg.startedAt).toBe(startTime);
     expect(typeof notifiedArg.startedAt).toBe('number');
-
-    expect(jukeboxScheduler.scheduleNextSong).toHaveBeenCalledWith(
-      clanId,
-      song.songDurationSeconds,
-    );
   });
 
   it('should throw MORE_THAN_MAX error when player has too many songs', async () => {

--- a/src/__tests__/jukebox/jukeboxService/startNextSong.test.ts
+++ b/src/__tests__/jukebox/jukeboxService/startNextSong.test.ts
@@ -1,26 +1,19 @@
 import { ClanService } from '../../../clan/clan.service';
 import JukeboxNotifier from '../../../jukebox/jukebox.notifier';
-import { JukeboxQueue } from '../../../jukebox/jukebox.queue';
 import { JukeboxService } from '../../../jukebox/jukebox.service';
 
 describe('jukeboxService.startNextSong() test suite', () => {
   let jukeboxService: JukeboxService;
   let jukeboxNotifier: JukeboxNotifier;
-  let jukeboxScheduler: JukeboxQueue;
   let clanService: ClanService;
 
   beforeEach(async () => {
     jukeboxNotifier = { songChange: jest.fn() } as any;
-    jukeboxScheduler = { scheduleNextSong: jest.fn() } as any;
     clanService = {
       readOneById: jest.fn().mockResolvedValue([{ playerCount: 3 }]),
     } as any;
 
-    jukeboxService = new JukeboxService(
-      jukeboxScheduler,
-      jukeboxNotifier,
-      clanService,
-    );
+    jukeboxService = new JukeboxService(jukeboxNotifier, clanService);
   });
 
   it('should start next song', async () => {
@@ -51,7 +44,6 @@ describe('jukeboxService.startNextSong() test suite', () => {
     expect(updatedJukebox).not.toEqual(oldCurrentSong);
     expect(updatedJukebox.songQueue).toHaveLength(2);
     expect(jukeboxNotifier.songChange).toHaveBeenCalledTimes(1);
-    expect(jukeboxScheduler.scheduleNextSong).toHaveBeenCalledTimes(1);
   });
 
   it('delete the jukebox if the queue is empty', async () => {
@@ -76,6 +68,5 @@ describe('jukeboxService.startNextSong() test suite', () => {
     const updatedJukebox = jukeboxService['clanJukeboxMap'].get(clanId);
     expect(updatedJukebox).toBeFalsy();
     expect(jukeboxNotifier.songChange).not.toHaveBeenCalled();
-    expect(jukeboxScheduler.scheduleNextSong).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Brief description

This PR changes the jukebox service to use node's built in `setTimeout` instead of the JukeboxQueue and BullMQ.
This solves the issue of some jobs not triggering after timeout in bullmq. Additionally, there is a fix in the logic of determining the max number of songs per player. It previously used the wrong value.

### Change list

- Removed the `JukeboxQueue` dependency from `JukeboxService` and replaced calls to `scheduler.scheduleNextSong` with `setTimeout` to schedule the next song directly. (`src/jukebox/jukebox.service.ts`) [[1]](diffhunk://#diff-ce1917ce67d2e21a08dcf4679c79beb85ca55048cfef18a9620a110c3886795aL2) [[2]](diffhunk://#diff-ce1917ce67d2e21a08dcf4679c79beb85ca55048cfef18a9620a110c3886795aL15) [[3]](diffhunk://#diff-ce1917ce67d2e21a08dcf4679c79beb85ca55048cfef18a9620a110c3886795aL88-R88) [[4]](diffhunk://#diff-ce1917ce67d2e21a08dcf4679c79beb85ca55048cfef18a9620a110c3886795aL124-R123)
- Updated unit tests to remove references to `JukeboxQueue` and assertions related to the scheduler, ensuring tests only check for the notifier and song queue behavior. (`src/__tests__/jukebox/jukeboxService/addSongToClanJukebox.test.ts`, `src/__tests__/jukebox/jukeboxService/startNextSong.test.ts`) [[1]](diffhunk://#diff-d8564483a2676ee254f70fe206a39c56ea4891700140848ea3b402df1866d920L3-R16) [[2]](diffhunk://#diff-d8564483a2676ee254f70fe206a39c56ea4891700140848ea3b402df1866d920L41-L45) [[3]](diffhunk://#diff-d9fb044c2c18a1b92a304abae5174d0b8bc2b412fd54b5ca1b3e571ae7c99e03L3-R16) [[4]](diffhunk://#diff-d9fb044c2c18a1b92a304abae5174d0b8bc2b412fd54b5ca1b3e571ae7c99e03L54) [[5]](diffhunk://#diff-d9fb044c2c18a1b92a304abae5174d0b8bc2b412fd54b5ca1b3e571ae7c99e03L79)
- Changed the default value for the maximum number of songs per player to use `JUKEBOX_MAX_SONG_AMOUNT_SMALL` instead of `JUKEBOX_MAX_SONG_AMOUNT_BIG` in `getMaxSongAmount`. (`src/jukebox/jukebox.service.ts`)