### PR TITLE
Feature/automatic clan join on player creation 726

### DIFF
--- a/src/__tests__/clan/join/JoinService/findClanForNewPlayer.test.ts
+++ b/src/__tests__/clan/join/JoinService/findClanForNewPlayer.test.ts
@@ -1,0 +1,43 @@
+import { JoinService } from '../../../../clan/join/join.service';
+import PlayerBuilderFactory from '../../../player/data/playerBuilderFactory';
+import PlayerModule from '../../../player/modules/player.module';
+import ClanBuilderFactory from '../../data/clanBuilderFactory';
+import ClanModule from '../../modules/clan.module';
+
+describe('JoinService.findClanForNewPlayer() test suite', () => {
+  let joinService: JoinService;
+
+  const clanModel = ClanModule.getClanModel();
+  const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
+  const clan = clanBuilder.setPlayerCount(1).setIsOpen(true).build();
+
+  const playerModel = PlayerModule.getPlayerModel();
+  const playerBuilder = PlayerBuilderFactory.getBuilder('Player');
+  const player = playerBuilder.build();
+
+  beforeEach(async () => {
+    joinService = await ClanModule.getJoinService();
+  });
+
+  it('should join player to clan if open clan with room is found', async () => {
+    const playerResp = await playerModel.create(player);
+    player._id = playerResp._id.toString();
+    const clanResp = await clanModel.create(clan);
+    clan._id = clanResp._id.toString();
+
+    await joinService.findClanForNewPlayer(player._id);
+
+    const updatedPlayer = await playerModel.findById(player._id);
+    expect(updatedPlayer.clan_id.toString()).toEqual(clan._id);
+  });
+
+  it('should not join player to clan if no open clan with room is found', async () => {
+    const playerResp = await playerModel.create(player);
+    player._id = playerResp._id.toString();
+
+    await joinService.findClanForNewPlayer(player._id);
+
+    const updatedPlayer = await playerModel.findById(player._id);
+    expect(updatedPlayer.clan_id).toBeUndefined();
+  });
+});

--- a/src/__tests__/player/PlayerService/createOne.test.ts
+++ b/src/__tests__/player/PlayerService/createOne.test.ts
@@ -156,4 +156,27 @@ describe('PlayerService.createOne() test suite', () => {
 
     expect(_idBefore.toString()).toBe(_idAfter.toString());
   });
+
+  it('should trigger the create one post hook', async () => {
+    const spy = jest.spyOn(playerService, 'createOnePostHook');
+
+    const playerName = 'john';
+    const playerToCreate = playerBuilder.setName(playerName).build();
+
+    await playerService.createOne(playerToCreate);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should emit player.created event', async () => {
+    const eventEmitter = await PlayerModule.getEventEmitter();
+    const emitSpy = jest.spyOn(eventEmitter, 'EmitPlayerCreatedEvent');
+    const output = { _id: new ObjectId().toString() } as any;
+
+    await playerService.createOnePostHook({}, output);
+
+    expect(emitSpy).toHaveBeenCalledWith('player.created', {
+      playerId: output._id.toString(),
+    });
+  });
 });

--- a/src/__tests__/player/PlayerService/createOne.test.ts
+++ b/src/__tests__/player/PlayerService/createOne.test.ts
@@ -175,8 +175,6 @@ describe('PlayerService.createOne() test suite', () => {
 
     await playerService.createOnePostHook({}, output);
 
-    expect(emitSpy).toHaveBeenCalledWith('player.created', {
-      playerId: output._id.toString(),
-    });
+    expect(emitSpy).toHaveBeenCalledWith(output._id);
   });
 });

--- a/src/__tests__/player/modules/player.module.ts
+++ b/src/__tests__/player/modules/player.module.ts
@@ -4,6 +4,7 @@ import PlayerCommonModule from './playerCommon.module';
 import { PlayerService } from '../../../player/player.service';
 import { isPlayerExists } from '../../../player/decorator/validation/IsPlayerExists.decorator';
 import { PlayerSchema } from '../../../player/schemas/player.schema';
+import EventEmitterService from '../../../common/service/EventEmitterService/EventEmitter.service';
 
 export default class PlayerModule {
   private constructor() {}
@@ -20,5 +21,10 @@ export default class PlayerModule {
 
   static getPlayerModel() {
     return mongoose.model(ModelName.PLAYER, PlayerSchema);
+  }
+
+  static async getEventEmitter() {
+    const module = await PlayerCommonModule.getModule();
+    return await module.resolve(EventEmitterService);
   }
 }

--- a/src/common/service/EventEmitterService/EventEmitter.service.ts
+++ b/src/common/service/EventEmitterService/EventEmitter.service.ts
@@ -26,4 +26,14 @@ export default class EventEmitterService {
       needsClanReward,
     });
   }
+
+  /**
+   * Emit a player created event
+   *  @param playerId of the created player
+   */
+  public async EmitPlayerCreatedEvent(playerId: string) {
+    this.eventEmitter.emit('player.created', {
+      playerId,
+    });
+  }
 }


### PR DESCRIPTION
### Brief description

This pull request introduces an event-driven mechanism to automatically assign newly created players to open clans, along with corresponding tests. The core logic listends for a `player.created` event and attempts to join the new player to a random open clan with available space. Included are also the tests for the new methods and updates to event emitter service and post-create hook in player service.

### Change list

-  Added a `findClanForNewPlayer` method to `JoinService`, decorated with `@OnEvent('player.created')`, which finds a random open clan with available space and joins the new player to it.
- Updated the `EventEmitterService` to include an `EmitPlayerCreatedEvent` method for emitting the `player.created` event when a player is created.
- Modified `PlayerService` to inject `EventEmitterService` and added a `createOnePostHook` that emits the `player.created` event after a player is created. [[1]](diffhunk://#diff-526b1d66786ad36caab4433d9ae86695a3d28e843180c8733f5f6ab6f5ff3f88R25) [[2]](diffhunk://#diff-526b1d66786ad36caab4433d9ae86695a3d28e843180c8733f5f6ab6f5ff3f88R37) [[3]](diffhunk://#diff-526b1d66786ad36caab4433d9ae86695a3d28e843180c8733f5f6ab6f5ff3f88R96-R106)
- Added tests for `JoinService.findClanForNewPlayer` to verify that a new player is joined to an open clan when available.
- Added tests to ensure the player creation post-hook is triggered and that the `player.created` event is emitted.
- Updated `PlayerModule` to provide access to the `EventEmitterService` for testing purposes. [[1]](diffhunk://#diff-2f738203444ae9ce9b6a3612a6aad75a87433521251cade5aa6d99c314dcd80aR7) [[2]](diffhunk://#diff-2f738203444ae9ce9b6a3612a6aad75a87433521251cade5aa6d99c314dcd80aR25-R29)
