### PR TITLE
Change/add character base stats

### DIFF
--- a/src/player/customCharacter/const/CharacterBaseStats.ts
+++ b/src/player/customCharacter/const/CharacterBaseStats.ts
@@ -11,92 +11,219 @@ type Stats = {
   speed: number;
 };
 
+// Max level amount for character stat
+type Level = 1 | 2 | 3 | 4 | 5 | 6;
+
+type LevelStats = Record<Level, number>;
+
+// Table for character defence stats per level
+const defence: LevelStats = {
+  1: 250,
+  2: 375,
+  3: 500,
+  4: 625,
+  5: 750,
+  6: 875,
+};
+
+// Table for character hp stats per level
+const hp: LevelStats = {
+  1: 15,
+  2: 30,
+  3: 45,
+  4: 60,
+  5: 75,
+  6: 90,
+};
+
+// Table for character size stats per level
+const size: LevelStats = {
+  1: 8,
+  2: 8,
+  3: 8,
+  4: 14,
+  5: 14,
+  6: 14,
+};
+
+// Table for character attack stats per level
+const attack: LevelStats = {
+  1: 10,
+  2: 15,
+  3: 20,
+  4: 25,
+  5: 30,
+  6: 35,
+};
+
+// Table for character speed stats per level
+const speed: LevelStats = {
+  1: 10,
+  2: 12,
+  3: 14,
+  4: 16,
+  5: 18,
+  6: 20,
+};
+
 /**
  * Defines base stats for the different characters ids
  */
 export const CharacterBaseStats: Record<CharacterId, Stats> = {
   [CharacterId.Racist_101]: {
-    defence: 14,
-    hp: 1,
-    size: 8,
-    attack: 6,
-    speed: 3,
+    defence: defence[2],
+    hp: hp[1],
+    size: size[3],
+    attack: attack[2],
+    speed: speed[2],
   },
   [CharacterId.BodyBuilder_102]: {
-    defence: 12,
-    hp: 1,
-    size: 8,
-    attack: 6,
-    speed: 3,
+    defence: defence[3],
+    hp: hp[1],
+    size: size[3],
+    attack: attack[3],
+    speed: speed[2],
+  },
+  [CharacterId.Bully_104]: {
+    defence: defence[3],
+    hp: hp[1],
+    size: size[2],
+    attack: attack[2],
+    speed: speed[2],
   },
 
-  [CharacterId.Joker_201]: { defence: 5, hp: 2, size: 6, attack: 7, speed: 10 },
+  [CharacterId.Joker_201]: {
+    defence: defence[2],
+    hp: hp[1],
+    size: size[2],
+    attack: attack[2],
+    speed: speed[4],
+  },
   [CharacterId.Prankster_202]: {
-    defence: 3,
-    hp: 2,
-    size: 4,
-    attack: 8,
-    speed: 10,
+    defence: defence[1],
+    hp: hp[2],
+    size: size[2],
+    attack: attack[2],
+    speed: speed[4],
   },
   [CharacterId.Conman_203]: {
-    defence: 5,
-    hp: 2,
-    size: 6,
-    attack: 7,
-    speed: 10,
+    defence: defence[2],
+    hp: hp[2],
+    size: size[2],
+    attack: attack[2],
+    speed: speed[4],
+  },
+  [CharacterId.Seduction_204]: {
+    defence: defence[3],
+    hp: hp[2],
+    size: size[2],
+    attack: attack[1],
+    speed: speed[4],
   },
 
   [CharacterId.CaseHardened_301]: {
-    defence: 10,
-    hp: 10,
-    size: 10,
-    attack: 10,
-    speed: 10,
+    defence: defence[4],
+    hp: hp[3],
+    size: size[4],
+    attack: attack[4],
+    speed: speed[5],
+  },
+  [CharacterId.Pleasing_302]: {
+    defence: defence[4],
+    hp: hp[4],
+    size: size[3],
+    attack: attack[4],
+    speed: speed[5],
   },
 
+  // 400 code characters don't have HP
+  // currently server should just set the default
+  // hp for 400 code characters as 1
   [CharacterId.Provocateur_401]: {
-    defence: 10,
-    hp: 3,
-    size: 8,
-    attack: 7,
-    speed: 4,
+    defence: defence[3],
+    hp: 1,
+    size: size[3],
+    attack: attack[2],
+    speed: speed[3],
+  },
+  [CharacterId.Scapegoat_402]: {
+    defence: defence[3],
+    hp: 1,
+    size: size[2],
+    attack: attack[3],
+    speed: speed[3],
+  },
+  [CharacterId.Projection_403]: {
+    defence: defence[3],
+    hp: 1,
+    size: size[2],
+    attack: attack[3],
+    speed: speed[3],
+  },
+  [CharacterId.Delusion_404]: {
+    defence: defence[2],
+    hp: 1,
+    size: size[2],
+    attack: attack[3],
+    speed: speed[3],
   },
 
   [CharacterId.Glutton_501]: {
-    defence: 5,
-    hp: 2,
-    size: 12,
-    attack: 8,
-    speed: 8,
+    defence: defence[2],
+    hp: hp[1],
+    size: size[3],
+    attack: attack[3],
+    speed: speed[3],
   },
   [CharacterId.Alcoholic_502]: {
-    defence: 8,
-    hp: 1,
-    size: 10,
-    attack: 9,
-    speed: 8,
+    defence: defence[3],
+    hp: hp[1],
+    size: size[3],
+    attack: attack[3],
+    speed: speed[3],
+  },
+  [CharacterId.Martyrdom_505]: {
+    defence: defence[3],
+    hp: hp[1],
+    size: size[3],
+    attack: attack[3],
+    speed: speed[3],
   },
 
   [CharacterId.SoulSisters_601]: {
-    defence: 11,
-    hp: 2,
-    size: 12,
-    attack: 2,
-    speed: 2,
+    defence: defence[1],
+    hp: hp[2],
+    size: size[3],
+    attack: attack[1],
+    speed: speed[1],
+  },
+  [CharacterId.Limerence_602]: {
+    defence: defence[1],
+    hp: hp[2],
+    size: size[3],
+    attack: attack[1],
+    speed: speed[1],
   },
   [CharacterId.WakefulnessEvader_603]: {
-    defence: 11,
-    hp: 2,
-    size: 12,
-    attack: 2,
-    speed: 2,
+    defence: defence[1],
+    hp: hp[2],
+    size: size[3],
+    attack: attack[1],
+    speed: speed[1],
   },
 
   [CharacterId.Wiseacre_701]: {
-    defence: 3,
-    hp: 8,
-    size: 8,
-    attack: 10,
-    speed: 6,
+    defence: defence[1],
+    hp: hp[2],
+    size: size[2],
+    attack: attack[3],
+    speed: speed[6],
+  },
+  [CharacterId.Ocd_703]: {
+    defence: defence[1],
+    hp: hp[3],
+    size: size[2],
+    attack: attack[2],
+    speed: speed[6],
   },
 };

--- a/src/player/customCharacter/const/CharacterBaseStats.ts
+++ b/src/player/customCharacter/const/CharacterBaseStats.ts
@@ -138,31 +138,31 @@ export const CharacterBaseStats: Record<CharacterId, Stats> = {
 
   // 400 code characters don't have HP
   // currently server should just set the default
-  // hp for 400 code characters as 1
+  // hp for 400 code characters as 0
   [CharacterId.Provocateur_401]: {
     defence: defence[3],
-    hp: 1,
+    hp: 0,
     size: size[3],
     attack: attack[2],
     speed: speed[3],
   },
   [CharacterId.Scapegoat_402]: {
     defence: defence[3],
-    hp: 1,
+    hp: 0,
     size: size[2],
     attack: attack[3],
     speed: speed[3],
   },
   [CharacterId.Projection_403]: {
     defence: defence[3],
-    hp: 1,
+    hp: 0,
     size: size[2],
     attack: attack[3],
     speed: speed[3],
   },
   [CharacterId.Delusion_404]: {
     defence: defence[2],
-    hp: 1,
+    hp: 0,
     size: size[2],
     attack: attack[3],
     speed: speed[3],

--- a/src/player/customCharacter/enum/characterId.enum.ts
+++ b/src/player/customCharacter/enum/characterId.enum.ts
@@ -4,19 +4,29 @@
 export enum CharacterId {
   Racist_101 = '101',
   BodyBuilder_102 = '102',
+  Bully_104 = '104',
 
   Joker_201 = '201',
   Prankster_202 = '202',
   Conman_203 = '203',
+  Seduction_204 = '204',
 
   CaseHardened_301 = '301',
+  Pleasing_302 = '302',
+
   Provocateur_401 = '401',
+  Scapegoat_402 = '402',
+  Projection_403 = '403',
+  Delusion_404 = '404',
 
   Glutton_501 = '501',
   Alcoholic_502 = '502',
+  Martyrdom_505 = '505',
 
   SoulSisters_601 = '601',
+  Limerence_602 = '602',
   WakefulnessEvader_603 = '603',
 
   Wiseacre_701 = '701',
+  Ocd_703 = '703',
 }


### PR DESCRIPTION
### Brief description

This pull request introduces a more structured and scalable approach to defining character base stats by adding level-based stat tables and updating the character stats accordingly. It also expands the list of available character IDs to support new characters.

**Stat Table Refactoring and Character Expansion:**

*Stat Table Refactoring:*

- Introduced a `Level` type and `LevelStats` tables for each stat (`defence`, `hp`, `size`, `attack`, `speed`), allowing character stats to be defined per level and improving maintainability and scalability.
- Updated the `CharacterBaseStats` object to reference the new `LevelStats` tables for each character, replacing hardcoded values with level-based lookups.

### Change list

- Added new character IDs to the `CharacterId` enum, including `Bully_104`, `Seduction_204`, `Pleasing_302`, `Scapegoat_402`, `Projection_403`, `Delusion_404`, `Martyrdom_505`, `Limerence_602`, and `Ocd_703`.
- Added corresponding base stats for these new characters in the `CharacterBaseStats` object.
- Standardized HP for 400-series characters to 0, with a comment explaining this convention for clarity.