### PR TITLE
Update mongo image in init-script files to pull exact and correct version

### DIFF
--- a/init-db-on-linux.sh
+++ b/init-db-on-linux.sh
@@ -25,7 +25,7 @@ docker run -d \
   -e MONGO_INITDB_DATABASE=$DATABASE \
   -v $VOLUME_NAME:/data/db \
   -p $MONGO_PORT:27017 \
-  mongo:8
+  mongo:8.0.12-rc0-noble
 
 # Step 2: Wait for Mongo to be ready
 echo "2. Waiting for MongoDB to start..."

--- a/init-db-on-windows.ps1
+++ b/init-db-on-windows.ps1
@@ -21,7 +21,7 @@ docker run -d `
   -e "MONGO_INITDB_DATABASE=$DATABASE" `
   -v "${VOLUME_NAME}:/data/db" `
   -p "${MONGO_PORT}" `
-  mongo:8
+  mongo:8.0.12-rc0-noble
 
 # Step 2: Wait for MongoDB to be ready
 Write-Host "2. Waiting for MongoDB to start..."


### PR DESCRIPTION
### Brief description

It caught error when firstly run command to set up the DB with pulling "mongo:8". The error was featureCompatibilityVersion - not support mongo usage version of 8.0.12-rc0-noble. Fix the pulling version as mongo:8.0.12-rc8-noble will make them match.

### Change list

- init-db-on-linux.sh
- init-db-on-windows.ps1