### PR TITLE
Fix duplicate AdPosterDto by changing dto name

### DIFF
--- a/src/__tests__/fleaMarket/stall/StallService/updateAdPosterByClanId.test.ts
+++ b/src/__tests__/fleaMarket/stall/StallService/updateAdPosterByClanId.test.ts
@@ -7,7 +7,7 @@ import FleaMarketBuilderFactory from '../../data/fleaMarketBuilderFactory';
 import { ClanDto } from '../../../../clan/dto/clan.dto';
 import { ObjectId } from 'mongodb';
 import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
-import { AdPosterDto } from '../../../../fleaMarket/stall/dto/adPoster.dto';
+import { FleaMarketAdPosterDto } from '../../../../fleaMarket/stall/dto/adPoster.dto';
 
 describe('StallService.updateAdPosterByClanId() test suite', () => {
   let stallService: StallService;
@@ -19,7 +19,7 @@ describe('StallService.updateAdPosterByClanId() test suite', () => {
   const stallBuilder = ClanBuilderFactory.getBuilder('Stall');
 
   let adPoster: AdPoster;
-  let adPosterDto: AdPosterDto;
+  let adPosterDto: FleaMarketAdPosterDto;
   let stall: Stall;
   let clanToCreate: ClanDto;
 

--- a/src/__tests__/fleaMarket/stall/data/AdPosterDtoBuilder.ts
+++ b/src/__tests__/fleaMarket/stall/data/AdPosterDtoBuilder.ts
@@ -1,8 +1,8 @@
 import IDataBuilder from '../../../test_utils/interface/IDataBuilder';
-import { AdPosterDto } from '../../../../fleaMarket/stall/dto/adPoster.dto';
+import { FleaMarketAdPosterDto } from '../../../../fleaMarket/stall/dto/adPoster.dto';
 
-export default class AdPosterDtoBuilder implements IDataBuilder<AdPosterDto> {
-  private readonly base: AdPosterDto = {
+export default class AdPosterDtoBuilder implements IDataBuilder<FleaMarketAdPosterDto> {
+  private readonly base: FleaMarketAdPosterDto = {
     border: 'defaultBorder',
     colour: 'defaultColour',
     mainFurniture: 'defaultFurniture',
@@ -21,7 +21,7 @@ export default class AdPosterDtoBuilder implements IDataBuilder<AdPosterDto> {
     return this;
   }
 
-  build(): AdPosterDto {
+  build(): FleaMarketAdPosterDto {
     return { ...this.base };
   }
 }

--- a/src/clan/dto/stall.dto.ts
+++ b/src/clan/dto/stall.dto.ts
@@ -1,7 +1,7 @@
 /**
  * DTO for AdPoster embedded document in Stall
  */
-export class AdPosterDto {
+export class ClanAdPosterDto {
   /** Border style of the stall's advertisement poster */
   border: string;
 
@@ -17,7 +17,7 @@ export class AdPosterDto {
  */
 export class StallDto {
   /** Stall's advertisement poster */
-  adPoster: AdPosterDto;
+  adPoster: ClanAdPosterDto;
 
   /** Maximum number of item slots in this stall */
   maxSlots: number;

--- a/src/fleaMarket/stall/dto/adPoster.dto.ts
+++ b/src/fleaMarket/stall/dto/adPoster.dto.ts
@@ -1,8 +1,8 @@
 import { IsOptional, IsString } from 'class-validator';
 import AddType from '../../../common/base/decorator/AddType.decorator';
 
-@AddType('AdPosterDto')
-export class AdPosterDto {
+@AddType('FleaMarketAdPosterDto')
+export class FleaMarketAdPosterDto {
   /**
    * Border style of the stall's advertisement poster
    * @example "border1"

--- a/src/fleaMarket/stall/stall.controller.ts
+++ b/src/fleaMarket/stall/stall.controller.ts
@@ -11,7 +11,7 @@ import { User } from '../../auth/user';
 import HasClanRights from '../../clan/role/decorator/guard/HasClanRights';
 import { ClanBasicRight } from '../../clan/role/enum/clanBasicRight.enum';
 import { BuyStallSlotDto } from './dto/buyStallSlot.dto';
-import { AdPosterDto } from './dto/adPoster.dto';
+import { FleaMarketAdPosterDto } from './dto/adPoster.dto';
 import DetermineClanId from '../../common/guard/clanId.guard';
 
 @Controller('stall')
@@ -91,7 +91,7 @@ export class StallController {
   @UniformResponse()
   @DetermineClanId()
   @HasClanRights([ClanBasicRight.SHOP])
-  async updateAdPoster(@LoggedUser() user: User, @Body() body: AdPosterDto) {
+  async updateAdPoster(@LoggedUser() user: User, @Body() body: FleaMarketAdPosterDto) {
     const [, error] = await this.service.updateAdPosterByClanId(
       user.clan_id,
       body,

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -6,7 +6,7 @@ import { IServiceReturn } from 'src/common/service/basicService/IService';
 import { getStallDefaultValues } from '../../clan/defaultValues/stall';
 import { StallResponse } from './dto/stallResponse.dto';
 import { Stall } from '../../clan/stall/stall.schema';
-import { AdPosterDto } from './dto/adPoster.dto';
+import { FleaMarketAdPosterDto } from './dto/adPoster.dto';
 
 @Injectable()
 export class StallService {
@@ -99,7 +99,7 @@ export class StallService {
    */
   async updateAdPosterByClanId(
     clan_id: string,
-    adPosterToUpdate: AdPosterDto,
+    adPosterToUpdate: FleaMarketAdPosterDto,
   ): Promise<IServiceReturn<boolean>> {
     const [clan, error] = await this.clanService.readOneById(clan_id);
     if (error) {
@@ -134,7 +134,7 @@ export class StallService {
    */
   private async mapAdPosterDtoToAdPoster(
     stall: Stall,
-    adPosterToUpdate: AdPosterDto,
+    adPosterToUpdate: FleaMarketAdPosterDto,
   ): Promise<Stall> {
     if (adPosterToUpdate.border) {
       stall.adPoster.border = adPosterToUpdate.border;


### PR DESCRIPTION
### Brief description

Following issue: Bug: Duplicate DTO #680
ERROR Duplicate DTO detected: "AdPosterDto" is defined multiple times with different schemas.
Fix: Renamed AdPosterDto with different names (FleaMarketAdPosterDto & ClanAdPosterDto)

### Change list

- __tests__/fleaMarket/stall/StallService/updateAdPosterByClanId.test.ts
- __tests__/fleaMarket/stall/data/AdPosterDtoBuilder.ts
- clan/dto/stall.dto.ts
- fleaMarket/stall/dto/adPoster.dto.ts
- fleaMarket/stall/stall.controller.ts
- fleaMarket/stall/stall.service.ts