### PR TITLE
Bug/reactions to global chat messages get returned as clan messages

### DIFF
--- a/src/__tests__/chat/baseChatService/handleNewReaction.test.ts
+++ b/src/__tests__/chat/baseChatService/handleNewReaction.test.ts
@@ -49,6 +49,7 @@ describe('BaseChatService.handleNewReaction() test suite', () => {
   it('should broadcast updated message if addReaction succeeds', async () => {
     const updatedMessage = {
       id: 'mid',
+      type: ChatType.CLAN,
       reactions: [{ playerName: 'TestUser', emoji: '🔥' }],
     };
     (chatService.addReaction as jest.Mock).mockResolvedValue([

--- a/src/chat/dto/chatMessage.dto.ts
+++ b/src/chat/dto/chatMessage.dto.ts
@@ -3,6 +3,7 @@ import { ReactionDto } from './reaction.dto';
 import { Sender } from './messageSender.dto';
 import { Feeling } from '../enum/feeling.enum';
 import { ExtractField } from '../../common/decorator/response/ExtractField';
+import { ChatType } from '../enum/chatMessageType.enum';
 
 export class ChatMessageDto {
   /**
@@ -48,7 +49,7 @@ export class ChatMessageDto {
    * @example "clan"
    */
   @Expose()
-  type: string;
+  type: ChatType;
 
   /**
    * Feeling of the chat message

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -121,7 +121,7 @@ export abstract class BaseChatService {
     }
 
     const messageEnvelope: ChatEnvelopeDto = {
-      chat: ChatType.CLAN,
+      chat: updatedMessage.type,
       event: MessageEventType.NEW_REACTION,
       message: updatedMessage,
     };


### PR DESCRIPTION
### Brief description

This PR fixes the hard coded clan chat type to all chat message reactions. The chat type is now set dynamically from the db document.

### Change list

- Updated the `type` property in `ChatMessageDto` to use the `ChatType` enum instead of a string, enforcing stricter typing for chat message types.
- Modified `baseChat.service.ts` so that the `chat` field in the `ChatEnvelopeDto` is set to `updatedMessage.type` (which is now a `ChatType`), rather than being hardcoded to `ChatType.CLAN`, ensuring the correct chat type is used dynamically.
- Fix related test