### PR TITLE
add redis prefix to env vars and connection

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -53,6 +53,7 @@ const mongoString = `mongodb://${mongoUser}:${mongoPassword}@${mongoHost}:${mong
 // Set up redis connection
 const redisHost = envVars.REDIS_HOST;
 const redisPort = parseInt(envVars.REDIS_PORT);
+const redisEnvPrefix = envVars.REDIS_ENV_PREFIX;
 const testEnvironmentName = 'TESTING_SESSION';
 
 const authGuardClassToUse = isTestingSession() ? BoxAuthGuard : AuthGuard;
@@ -77,6 +78,7 @@ const authGuardClassToUse = isTestingSession() ? BoxAuthGuard : AuthGuard;
         host: redisHost,
         port: redisPort,
       },
+      prefix: `bullmq:${redisEnvPrefix}`,
     }),
     GameDataModule,
     ChatModule,

--- a/src/common/service/envHandler/envVars.ts
+++ b/src/common/service/envHandler/envVars.ts
@@ -78,6 +78,9 @@ interface EnvVars {
   /** The Redis server port. */
   REDIS_PORT: string;
 
+  /** Redis environment prefix dev | main | prod */
+  REDIS_ENV_PREFIX: string;
+
   /** The Mosquitto broker host. */
   MOSQUITTO_HOST: string;
 
@@ -143,6 +146,7 @@ export const envVars: EnvVars = {
   REDIS_PASSWORD: process.env.REDIS_PASSWORD ?? 'mySecretPassword',
   REDIS_HOST: process.env.REDIS_HOST ?? 'localhost',
   REDIS_PORT: process.env.REDIS_PORT ?? '6379',
+  REDIS_ENV_PREFIX: process.env.REDIS_ENV_PREFIX ?? 'dev',
 
   MOSQUITTO_HOST: process.env.MOSQUITTO_HOST,
   MOSQUITTO_PORT: process.env.MOSQUITTO_PORT,


### PR DESCRIPTION
### Brief description

This PR adds redis environment prefix environment variable to help distinguish Redis keys by environment, ensuring that the delayed tasks get consumed by the correct api instance. This should fix the issue in VPS that delayed tasks don't always trigger. Since the redis instance is shared among dev, main and prod versions of the API. 

### Change list

- Added `REDIS_ENV_PREFIX` to the `EnvVars` interface and to the `envVars` object, defaulting to `'dev'` if not provided. [[1]](diffhunk://#diff-690310c514d287ecc3e96c6e1343ab4c31344f9d7df213b37518245e78d6f2eeR81-R83) [[2]](diffhunk://#diff-690310c514d287ecc3e96c6e1343ab4c31344f9d7df213b37518245e78d6f2eeR149)

- Passed the new `REDIS_ENV_PREFIX` value to the Redis client configuration in `src/app.module.ts`, setting the Redis key prefix to `bullmq:${redisEnvPrefix}` for environment-specific key separation. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R56) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R81)