### PR TITLE
Validate message content no longer than 64 characters

### DIFF
--- a/src/chat/dto/createMessage.dto.ts
+++ b/src/chat/dto/createMessage.dto.ts
@@ -32,14 +32,14 @@ export class CreateChatMessageDto {
   sender_id: string | ObjectId;
 
   /**
-   * Text content of the message
-   * content must not exceed 64 characters
+   * Text content of the message.
+   * Content must not exceed 64 characters
    * 
    * @example "Let’s meet at Soul Arena!"
    */
   @IsString()
   @IsNotEmpty()
-  @MaxLength(64, { message: "content must not exceed 64 characters" })
+  @MaxLength(64)
   content: string;
 
   /**

--- a/src/chat/dto/createMessage.dto.ts
+++ b/src/chat/dto/createMessage.dto.ts
@@ -4,6 +4,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  MaxLength,
   ValidateIf,
 } from 'class-validator';
 import { ChatType } from '../enum/chatMessageType.enum';
@@ -32,11 +33,13 @@ export class CreateChatMessageDto {
 
   /**
    * Text content of the message
-   *
+   * content must not exceed 64 characters
+   * 
    * @example "Let’s meet at Soul Arena!"
    */
   @IsString()
   @IsNotEmpty()
+  @MaxLength(64, { message: "content must not exceed 64 characters" })
   content: string;
 
   /**


### PR DESCRIPTION
### Brief description

This PR validated message content's length in chatModule, the message content must not exceed 64 characters (Using prewritten messages to select).

### Change list

- update `createMessage.dto.ts` to add decorator `@MaxLength` to validate the length.
