### PR TITLE
Feature/add-tests-friendship-module-#739

### DIFF
--- a/src/__tests__/friendship/data/builder/FriendRequestDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendRequestDtoBuilder.ts
@@ -1,0 +1,32 @@
+import { ObjectId } from "mongodb";
+import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
+import { FriendRequestDto } from "src/friendship/dto/FriendRequest.dto";
+
+export default class FriendRequestDtoBuilder
+    implements IDataBuilder<FriendRequestDto>
+{
+    private readonly base: FriendRequestDto = {
+        friendship_id: new ObjectId().toString(),
+        direction: 'incoming', // 'outgoing'
+        friend: undefined,
+    }
+
+    build(): FriendRequestDto {
+        return {...this.base} as FriendRequestDto;
+    }
+
+    setFriendship_id(friendship_id: string): this {
+        this.base.friendship_id = friendship_id;
+        return this
+    }
+
+    setDirection(direction: string | undefined): this {
+        this.base.direction = direction;
+        return this;
+    }
+
+    setFriend(friend: any): this {
+        this.base.friend = friend;
+        return this;
+    }
+}

--- a/src/__tests__/friendship/data/builder/FriendRequestDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendRequestDtoBuilder.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from "mongodb";
-import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
-import { FriendRequestDto } from "src/friendship/dto/FriendRequest.dto";
+import IDataBuilder from "../../../test_utils/interface/IDataBuilder";
+import { FriendRequestDto } from "../../../../friendship/dto/FriendRequest.dto";
 
 export default class FriendRequestDtoBuilder
     implements IDataBuilder<FriendRequestDto>

--- a/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
@@ -1,6 +1,6 @@
 import { ObjectId } from "mongodb";
-import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
-import { FriendlistDto } from "src/friendship/dto/friend-list.dto";
+import IDataBuilder from "../../../test_utils/interface/IDataBuilder";
+import { FriendlistDto } from "../../../../friendship/dto/friend-list.dto";
 
 export default class FriendlistDtoBuilder 
     implements IDataBuilder<FriendlistDto>

--- a/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
@@ -1,0 +1,44 @@
+import { ObjectId } from "mongodb";
+import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
+import { FriendlistDto } from "src/friendship/dto/friend-list.dto";
+
+export default class FriendlistDtoBuilder 
+    implements IDataBuilder<FriendlistDto>
+{
+    private readonly base: FriendlistDto = {
+        _id: new ObjectId().toString(),
+        name: "defaultName",
+        avatar: undefined,
+        clanName: undefined,
+        clan_id: undefined,
+    }
+
+    build(): FriendlistDto {
+        return {...this.base} as FriendlistDto;
+    }
+
+    setId(Id: string): this {
+        this.base._id = Id;
+        return this;
+    }
+
+    setName(name: string): this {
+        this.base.name = name;
+        return this;
+    }
+
+    setAvatar(avatar: any | undefined): this {
+        this.base.avatar = avatar;
+        return this;
+    }
+
+    setClanName(clanName: string | undefined): this {
+        this.base.clanName = clanName;
+        return this;
+    }
+
+    setClanId(clanId: string | undefined): this {
+        this.base.clan_id = clanId;
+        return this;
+    }
+}

--- a/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
@@ -1,4 +1,3 @@
-import { Types } from 'mongoose';
 import IDataBuilder from '../../../test_utils/interface/IDataBuilder';
 import { FriendshipStatus } from '../../../../friendship/enum/friendship-status.enum';
 import { Friendship } from '../../../../friendship/friendship.schema';

--- a/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
@@ -1,0 +1,40 @@
+import { ObjectId } from "mongoose";
+import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
+import { FriendshipStatus } from "src/friendship/enum/friendship-status.enum";
+import { Friendship } from "src/friendship/friendship.schema";
+
+export default class FriendshipBuilder
+    implements IDataBuilder<Friendship>
+{
+    private readonly base: Friendship = {
+        playerA: undefined,
+        playerB: undefined,
+        status: FriendshipStatus.PENDING,
+        requester: undefined,
+        pairKey: undefined,
+    }
+
+    build(): Friendship {
+        return {...this.base} as Friendship;
+    }
+
+    setPlayerA(playerA: ObjectId | undefined): this {
+        this.base.playerA = playerA;
+        return this;
+    }
+
+    setPlayerB(playerB: ObjectId | undefined): this {
+        this.base.playerB = playerB;
+        return this;
+    }
+
+    setStatus(status: FriendshipStatus): this {
+        this.base.status = status;
+        return this;
+    }
+
+    setRequester(requester: ObjectId | undefined): this {
+        this.base.requester = requester;
+        return this;
+    }
+}

--- a/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
@@ -1,40 +1,47 @@
-import { Types } from "mongoose";
-import IDataBuilder from "../../../test_utils/interface/IDataBuilder";
-import { FriendshipStatus } from "../../../../friendship/enum/friendship-status.enum";
-import { Friendship } from "../../../../friendship/friendship.schema";
+import { Types } from 'mongoose';
+import IDataBuilder from '../../../test_utils/interface/IDataBuilder';
+import { FriendshipStatus } from '../../../../friendship/enum/friendship-status.enum';
+import { Friendship } from '../../../../friendship/friendship.schema';
 
-export default class FriendshipBuilder
-    implements IDataBuilder<Friendship>
-{
-    private readonly base: Friendship = {
-        playerA: undefined,
-        playerB: undefined,
-        status: FriendshipStatus.ACCEPTED,
-        requester: undefined,
-        pairKey: undefined,
+export default class FriendshipBuilder implements IDataBuilder<Friendship> {
+  private playerA: Types.ObjectId;
+  private playerB: Types.ObjectId;
+  private status: FriendshipStatus;
+  private requester?: Types.ObjectId;
+  private pairKey?: string;
+
+  build(): Friendship {
+    const friendship: any = {
+      playerA: this.playerA,
+      playerB: this.playerB,
+      status: this.status,
+      pairKey: this.pairKey,
+    };
+
+    if (this.requester !== undefined) {
+      friendship.requester = this.requester;
     }
 
-    build(): Friendship {
-        return {...this.base} as Friendship;
-    }
+    return friendship as Friendship;
+  }
 
-    setPlayerA(playerA: Types.ObjectId): this {
-        this.base.playerA = playerA;
-        return this;
-    }
+  setPlayerA(playerA: Types.ObjectId): this {
+    this.playerA = playerA;
+    return this;
+  }
 
-    setPlayerB(playerB: Types.ObjectId): this {
-        this.base.playerB = playerB;
-        return this;
-    }
+  setPlayerB(playerB: Types.ObjectId): this {
+    this.playerB = playerB;
+    return this;
+  }
 
-    setStatus(status: FriendshipStatus): this {
-        this.base.status = status;
-        return this;
-    }
+  setStatus(status: FriendshipStatus): this {
+    this.status = status;
+    return this;
+  }
 
-    setRequester(requester: Types.ObjectId): this {
-        this.base.requester = requester;
-        return this;
-    }
+  setRequester(requester: Types.ObjectId): this {
+    this.requester = requester;
+    return this;
+  }
 }

--- a/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
@@ -2,12 +2,13 @@ import { Types } from 'mongoose';
 import IDataBuilder from '../../../test_utils/interface/IDataBuilder';
 import { FriendshipStatus } from '../../../../friendship/enum/friendship-status.enum';
 import { Friendship } from '../../../../friendship/friendship.schema';
+import { ObjectId } from 'mongodb';
 
 export default class FriendshipBuilder implements IDataBuilder<Friendship> {
-  private playerA: Types.ObjectId;
-  private playerB: Types.ObjectId;
+  private playerA: string | ObjectId;
+  private playerB: string | ObjectId;
   private status: FriendshipStatus;
-  private requester?: Types.ObjectId;
+  private requester?: string | ObjectId;
   private pairKey?: string;
 
   build(): Friendship {
@@ -25,12 +26,12 @@ export default class FriendshipBuilder implements IDataBuilder<Friendship> {
     return friendship as Friendship;
   }
 
-  setPlayerA(playerA: Types.ObjectId): this {
+  setPlayerA(playerA: string | ObjectId): this {
     this.playerA = playerA;
     return this;
   }
 
-  setPlayerB(playerB: Types.ObjectId): this {
+  setPlayerB(playerB: string | ObjectId): this {
     this.playerB = playerB;
     return this;
   }
@@ -40,7 +41,7 @@ export default class FriendshipBuilder implements IDataBuilder<Friendship> {
     return this;
   }
 
-  setRequester(requester: Types.ObjectId): this {
+  setRequester(requester: string | ObjectId): this {
     this.requester = requester;
     return this;
   }

--- a/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendshipBuilder.ts
@@ -1,7 +1,7 @@
-import { ObjectId } from "mongoose";
-import IDataBuilder from "src/__tests__/test_utils/interface/IDataBuilder";
-import { FriendshipStatus } from "src/friendship/enum/friendship-status.enum";
-import { Friendship } from "src/friendship/friendship.schema";
+import { Types } from "mongoose";
+import IDataBuilder from "../../../test_utils/interface/IDataBuilder";
+import { FriendshipStatus } from "../../../../friendship/enum/friendship-status.enum";
+import { Friendship } from "../../../../friendship/friendship.schema";
 
 export default class FriendshipBuilder
     implements IDataBuilder<Friendship>
@@ -9,7 +9,7 @@ export default class FriendshipBuilder
     private readonly base: Friendship = {
         playerA: undefined,
         playerB: undefined,
-        status: FriendshipStatus.PENDING,
+        status: FriendshipStatus.ACCEPTED,
         requester: undefined,
         pairKey: undefined,
     }
@@ -18,12 +18,12 @@ export default class FriendshipBuilder
         return {...this.base} as Friendship;
     }
 
-    setPlayerA(playerA: ObjectId | undefined): this {
+    setPlayerA(playerA: Types.ObjectId): this {
         this.base.playerA = playerA;
         return this;
     }
 
-    setPlayerB(playerB: ObjectId | undefined): this {
+    setPlayerB(playerB: Types.ObjectId): this {
         this.base.playerB = playerB;
         return this;
     }
@@ -33,7 +33,7 @@ export default class FriendshipBuilder
         return this;
     }
 
-    setRequester(requester: ObjectId | undefined): this {
+    setRequester(requester: Types.ObjectId): this {
         this.base.requester = requester;
         return this;
     }

--- a/src/__tests__/friendship/data/friendshipBuilderFactory.ts
+++ b/src/__tests__/friendship/data/friendshipBuilderFactory.ts
@@ -1,0 +1,32 @@
+import FriendlistDtoBuilder from "./builder/FriendlistDtoBuilder";
+import FriendRequestDtoBuilder from "./builder/FriendRequestDtoBuilder";
+import FriendshipBuilder from "./builder/FriendshipBuilder";
+
+type BuilderName =
+    | 'FriendlistDto'
+    | 'FriendRequestDto'
+    | 'Friendship';
+
+type BuilderMap = {
+    FriendlistDto: FriendlistDtoBuilder;
+    FriendRequestDto: FriendRequestDtoBuilder;
+    Friendship: FriendshipBuilder;
+};
+
+export default class FriendshipBuilderFactory {
+    static getBuilder<T extends BuilderName>(builderName: T): BuilderMap[T] {
+        switch (builderName) {
+            case 'FriendlistDto':
+                return new FriendlistDtoBuilder() as BuilderMap[T];
+
+            case 'FriendRequestDto':
+                return new FriendRequestDtoBuilder() as BuilderMap[T];
+
+            case 'Friendship':
+                return new FriendshipBuilder() as BuilderMap[T];
+
+            default:
+                throw new Error(`Unknown builder name: ${builderName}`);
+        }
+    }
+}

--- a/src/__tests__/friendship/data/mockData/createData.mock.ts
+++ b/src/__tests__/friendship/data/mockData/createData.mock.ts
@@ -3,12 +3,29 @@ import FriendshipModule from '../../modules/friendship.module';
 import PlayerBuilder from '../../../player/data/player/playerBuilder';
 import { Clan } from '../../../../clan/clan.schema';
 import ClanBuilder from '../../../clan/data/clan/ClanBuilder';
+import { Friendship } from 'src/friendship/friendship.schema';
+import FriendshipBuilderFactory from '../friendshipBuilderFactory';
+
+export async function createMockFriendships(
+  overides: Partial<Friendship>[]
+): Promise<void> {
+  const model = FriendshipModule.getFriendshipModel();
+
+  for (const overide of overides) {
+    const builder = FriendshipBuilderFactory.getBuilder('Friendship')
+      .setPlayerA(overide.playerA)
+      .setPlayerB(overide.playerB)
+      .setStatus(overide.status);
+
+    if (overide.requester) builder.setRequester(overide.requester);
+    await model.create(builder.build());
+  }
+}
 
 export async function createMockPlayers(
-  overides: Partial<Player>[],
-): Promise<Player[]> {
+  overides: Partial<Player>[]
+): Promise<void> {
   const model = FriendshipModule.getPlayerModel();
-  const players: Player[] = [];
 
   for (const overide of overides) {
     const builder = new PlayerBuilder()
@@ -18,18 +35,14 @@ export async function createMockPlayers(
       .setClanId(overide.clan_id)
       .build();
 
-    const savedPlayer = await model.create(builder);
-    players.push(savedPlayer);
+    await model.create(builder);
   }
-
-  return players;
 }
 
 export async function createMockClans(
-  overides: Partial<Clan>[],
-): Promise<Clan[]> {
+  overides: Partial<Clan>[]
+): Promise<void> {
   const model = FriendshipModule.getClanModel();
-  const clans: Clan[] = [];
 
   for (const overide of overides) {
     const builder = new ClanBuilder()
@@ -37,9 +50,6 @@ export async function createMockClans(
       .setName(overide.name)
       .build();
 
-    const savedClans = await model.create(builder);
-    clans.push(savedClans);
+    await model.create(builder);
   }
-
-  return clans;
 }

--- a/src/__tests__/friendship/data/mockData/createData.mock.ts
+++ b/src/__tests__/friendship/data/mockData/createData.mock.ts
@@ -1,0 +1,45 @@
+import { Player } from '../../../../player/schemas/player.schema';
+import FriendshipModule from '../../modules/friendship.module';
+import PlayerBuilder from '../../../player/data/player/playerBuilder';
+import { Clan } from '../../../../clan/clan.schema';
+import ClanBuilder from '../../../clan/data/clan/ClanBuilder';
+
+export async function createMockPlayers(
+  overides: Partial<Player>[],
+): Promise<Player[]> {
+  const model = FriendshipModule.getPlayerModel();
+  const players: Player[] = [];
+
+  for (const overide of overides) {
+    const builder = new PlayerBuilder()
+      .setId(overide._id)
+      .setName(overide.name)
+      .setUniqueIdentifier(overide.uniqueIdentifier)
+      .setClanId(overide.clan_id)
+      .build();
+
+    const savedPlayer = await model.create(builder);
+    players.push(savedPlayer);
+  }
+
+  return players;
+}
+
+export async function createMockClans(
+  overides: Partial<Clan>[],
+): Promise<Clan[]> {
+  const model = FriendshipModule.getClanModel();
+  const clans: Clan[] = [];
+
+  for (const overide of overides) {
+    const builder = new ClanBuilder()
+      .setId(overide._id)
+      .setName(overide.name)
+      .build();
+
+    const savedClans = await model.create(builder);
+    clans.push(savedClans);
+  }
+
+  return clans;
+}

--- a/src/__tests__/friendship/friendshipService/addFriend.test.ts
+++ b/src/__tests__/friendship/friendshipService/addFriend.test.ts
@@ -1,20 +1,16 @@
 import { ObjectId } from 'mongodb';
 import { FriendshipService } from '../../../friendship/friendship.service';
 import FriendshipModule from '../modules/friendship.module';
-import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
 import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
-import { Friendship } from '../../../friendship/friendship.schema';
 import {
     createMockClans,
+    createMockFriendships,
     createMockPlayers,
 } from '../data/mockData/createData.mock';
+import { Friendship } from 'src/friendship/friendship.schema';
 
 describe('FriendshipService.sendNewFriendRequestNotification()', () => {
     let friendshipService: FriendshipService;
-    const clanModel = FriendshipModule.getClanModel();
-    const playerModel = FriendshipModule.getPlayerModel();
-    const friendshipModel = FriendshipModule.getFriendshipModel();
-    const createdFriendships: Friendship[] = [];
 
     const player1_id = new ObjectId().toString();
     const player2_id = new ObjectId().toString();
@@ -22,40 +18,22 @@ describe('FriendshipService.sendNewFriendRequestNotification()', () => {
 
     const clan_id = new ObjectId().toString();
 
-    beforeAll(async () => {
-        const friendshipConfigs = [
-            {
-                playerA: player1_id,
-                playerB: player2_id,
-                status: FriendshipStatus.PENDING,
-                requester: player1_id,
-            },
-            {
-                playerA: player1_id,
-                playerB: player3_id,
-                status: FriendshipStatus.ACCEPTED,
-            },
-        ];
-
-        for (const config of friendshipConfigs) {
-            const builder = FriendshipBuilderFactory.getBuilder('Friendship');
-            builder
-                .setPlayerA(config.playerA)
-                .setPlayerB(config.playerB)
-                .setStatus(config.status);
-
-            if (config.requester) {
-                builder.setRequester(config.requester);
-            }
-            createdFriendships.push(builder.build());
-        }
-    });
+    const friendshipConfigs: Partial<Friendship>[] = [
+        {
+            playerA: player1_id,
+            playerB: player2_id,
+            status: FriendshipStatus.PENDING,
+            requester: player1_id,
+        },
+        {
+            playerA: player1_id,
+            playerB: player3_id,
+            status: FriendshipStatus.ACCEPTED,
+        },
+    ];
 
     beforeEach(async () => {
         friendshipService = await FriendshipModule.getFriendshipService();
-        await friendshipModel.deleteMany({});
-        await clanModel.deleteMany({});
-        await playerModel.deleteMany({});
 
         await createMockClans([{ _id: clan_id, name: 'TestClan' }]);
         await createMockPlayers([
@@ -78,7 +56,7 @@ describe('FriendshipService.sendNewFriendRequestNotification()', () => {
                 uniqueIdentifier: 'unique-3',
             },
         ]);
-        await friendshipModel.create(createdFriendships);
+        await createMockFriendships(friendshipConfigs);
     });
 
     it('Should return undefined if addFriend is successful', async () => {

--- a/src/__tests__/friendship/friendshipService/addFriend.test.ts
+++ b/src/__tests__/friendship/friendshipService/addFriend.test.ts
@@ -1,0 +1,116 @@
+import { ObjectId } from 'mongodb';
+import { FriendshipService } from '../../../friendship/friendship.service';
+import FriendshipModule from '../modules/friendship.module';
+import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
+import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+import { Friendship } from '../../../friendship/friendship.schema';
+import {
+    createMockClans,
+    createMockPlayers,
+} from '../data/mockData/createData.mock';
+
+describe('FriendshipService.sendNewFriendRequestNotification()', () => {
+    let friendshipService: FriendshipService;
+    const clanModel = FriendshipModule.getClanModel();
+    const playerModel = FriendshipModule.getPlayerModel();
+    const friendshipModel = FriendshipModule.getFriendshipModel();
+    const createdFriendships: Friendship[] = [];
+
+    const player1_id = new ObjectId().toString();
+    const player2_id = new ObjectId().toString();
+    const player3_id = new ObjectId().toString();
+
+    const clan_id = new ObjectId().toString();
+
+    beforeAll(async () => {
+        const friendshipConfigs = [
+            {
+                playerA: player1_id,
+                playerB: player2_id,
+                status: FriendshipStatus.PENDING,
+                requester: player1_id,
+            },
+            {
+                playerA: player1_id,
+                playerB: player3_id,
+                status: FriendshipStatus.ACCEPTED,
+            },
+        ];
+
+        for (const config of friendshipConfigs) {
+            const builder = FriendshipBuilderFactory.getBuilder('Friendship');
+            builder
+                .setPlayerA(config.playerA)
+                .setPlayerB(config.playerB)
+                .setStatus(config.status);
+
+            if (config.requester) {
+                builder.setRequester(config.requester);
+            }
+            createdFriendships.push(builder.build());
+        }
+    });
+
+    beforeEach(async () => {
+        friendshipService = await FriendshipModule.getFriendshipService();
+        await friendshipModel.deleteMany({});
+        await clanModel.deleteMany({});
+        await playerModel.deleteMany({});
+
+        await createMockClans([{ _id: clan_id, name: 'TestClan' }]);
+        await createMockPlayers([
+            {
+                _id: player1_id,
+                name: 'Player1',
+                clan_id,
+                uniqueIdentifier: 'unique-1',
+            },
+            {
+                _id: player2_id,
+                name: 'Player2',
+                clan_id,
+                uniqueIdentifier: 'unique-2',
+            },
+            {
+                _id: player3_id,
+                name: 'Player3',
+                clan_id,
+                uniqueIdentifier: 'unique-3',
+            },
+        ]);
+        await friendshipModel.create(createdFriendships);
+    });
+
+    it('Should return undefined if addFriend is successful', async () => {
+        // void function if success
+        await expect(friendshipService.addFriend(player2_id, player3_id))
+            .resolves
+            .toBeUndefined();
+    });
+
+    it(
+        'Should return NOT_UNIQUE from pairkey if 2 players have friendship with status PENDING',
+        async () => {
+            const [friendship, err] = await friendshipService.addFriend(
+                player1_id,
+                player2_id
+            );
+
+            expect(err).toContainSE_NOT_UNIQUE();
+            expect(friendship).toBeNull();
+        }
+    );
+
+    it(
+        'Should return NOT_UNIQUE from pairkey if 2 players have friendship with status ACCEPTED',
+        async () => {
+            const [friendship, err] = await friendshipService.addFriend(
+                player1_id,
+                player3_id
+            );
+
+            expect(err).toContainSE_NOT_UNIQUE();
+            expect(friendship).toBeNull();
+        }
+    );
+});

--- a/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
+++ b/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
@@ -93,7 +93,7 @@ describe('Friendship.getFriendRequests() test suites', () => {
     expect(friendships).toBeNull();
   });
 
-  it('...', async () => {
+  it('Should avoid status ACCEPTED and return one friendship request', async () => {
     const [friendships, err] = await friendshipService.getFriendRequests(
       player3_id.toString(),
     );

--- a/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
+++ b/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
@@ -1,0 +1,129 @@
+import { Types } from 'mongoose';
+import { FriendshipService } from '../../../friendship/friendship.service';
+import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
+import FriendshipModule from '../modules/friendship.module';
+import { Friendship } from '../../../friendship/friendship.schema';
+import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+
+describe('Friendship.getFriendRequests() test suites', () => {
+  let friendshipService: FriendshipService;
+  const friendshipModel = FriendshipModule.getFriendshipModel();
+
+  const player1_id = new Types.ObjectId();
+  const player2_id = new Types.ObjectId();
+  const player3_id = new Types.ObjectId();
+  const player4_id = new Types.ObjectId();
+
+  const createdFriendships: Friendship[] = [];
+
+  beforeAll(() => {
+    const friendshipConfigs = [
+      {
+        playerA: player1_id,
+        playerB: player2_id,
+        status: FriendshipStatus.PENDING,
+        requester: player1_id,
+      },
+      {
+        playerA: player1_id,
+        playerB: player3_id,
+        status: FriendshipStatus.PENDING,
+        requester: player1_id,
+      },
+      {
+        playerA: player2_id,
+        playerB: player3_id,
+        status: FriendshipStatus.ACCEPTED,
+      },
+      {
+        playerA: player1_id,
+        playerB: player4_id,
+        status: FriendshipStatus.BLOCKED,
+      },
+    ];
+
+    for (const config of friendshipConfigs) {
+      const friendshipBuilder =
+        FriendshipBuilderFactory.getBuilder('Friendship');
+
+      friendshipBuilder
+        .setPlayerA(config.playerA)
+        .setPlayerB(config.playerB)
+        .setStatus(config.status);
+
+      if (config.requester) {
+        friendshipBuilder.setRequester(config.requester);
+      }
+
+      createdFriendships.push(friendshipBuilder.build());
+    }
+  });
+
+  beforeEach(async () => {
+    await friendshipModel.deleteMany({});
+    friendshipService = await FriendshipModule.getFriendshipService();
+
+    await friendshipModel.create(createdFriendships);
+  });
+
+  it('Should get two friendship requests for player1', async () => {
+    const [friendships, err] = await friendshipService.getFriendRequests(
+      player1_id.toString(),
+    );
+
+    expect(err).toBeNull();
+    expect(friendships).toHaveLength(2);
+  });
+
+  it('Should get one friendship request for player2', async () => {
+    const [friendships, err] = await friendshipService.getFriendRequests(
+      player2_id.toString(),
+    );
+
+    expect(err).toBeNull();
+    expect(friendships).toHaveLength(1);
+  });
+
+  it('should return NOT_FOUND for player4', async () => {
+    const [friendships, err] = await friendshipService.getFriendRequests(
+      player4_id.toString(),
+    );
+
+    expect(err).toContainSE_NOT_FOUND();
+    expect(friendships).toBeNull();
+  });
+
+  it('...', async () => {
+    const [friendships, err] = await friendshipService.getFriendRequests(
+      player3_id.toString(),
+    );
+
+    expect(err).toBeNull();
+    expect(friendships).toHaveLength(1);
+  });
+
+  it('Direct create should fail without requester', async () => {
+    const invalidFriendship = {
+      playerA: player1_id,
+      playerB: player2_id,
+      status: FriendshipStatus.PENDING,
+    };
+
+    await expect(friendshipModel.create(invalidFriendship)).rejects.toThrow(
+      /requester is required when status is PENDING/,
+    );
+  });
+
+  it('Direct create should fail with wrong requester', async () => {
+    const invalidFriendship = {
+      playerA: player1_id,
+      playerB: player2_id,
+      status: FriendshipStatus.PENDING,
+      requester: player3_id,
+    };
+
+    await expect(friendshipModel.create(invalidFriendship)).rejects.toThrow(
+      /requester must be either playerA or playerB/,
+    );
+  });
+});

--- a/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
+++ b/src/__tests__/friendship/friendshipService/getFriendRequests.test.ts
@@ -1,74 +1,53 @@
-import { Types } from 'mongoose';
 import { FriendshipService } from '../../../friendship/friendship.service';
-import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
 import FriendshipModule from '../modules/friendship.module';
-import { Friendship } from '../../../friendship/friendship.schema';
 import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+import { ObjectId } from 'mongodb';
+import { createMockFriendships } from '../data/mockData/createData.mock';
+import { Friendship } from 'src/friendship/friendship.schema';
 
 describe('Friendship.getFriendRequests() test suites', () => {
   let friendshipService: FriendshipService;
   const friendshipModel = FriendshipModule.getFriendshipModel();
 
-  const player1_id = new Types.ObjectId();
-  const player2_id = new Types.ObjectId();
-  const player3_id = new Types.ObjectId();
-  const player4_id = new Types.ObjectId();
+  const player1_id = new ObjectId().toString();
+  const player2_id = new ObjectId().toString();
+  const player3_id = new ObjectId().toString();
+  const player4_id = new ObjectId().toString();
 
-  const createdFriendships: Friendship[] = [];
-
-  beforeAll(() => {
-    const friendshipConfigs = [
-      {
-        playerA: player1_id,
-        playerB: player2_id,
-        status: FriendshipStatus.PENDING,
-        requester: player1_id,
-      },
-      {
-        playerA: player1_id,
-        playerB: player3_id,
-        status: FriendshipStatus.PENDING,
-        requester: player1_id,
-      },
-      {
-        playerA: player2_id,
-        playerB: player3_id,
-        status: FriendshipStatus.ACCEPTED,
-      },
-      {
-        playerA: player1_id,
-        playerB: player4_id,
-        status: FriendshipStatus.BLOCKED,
-      },
-    ];
-
-    for (const config of friendshipConfigs) {
-      const friendshipBuilder =
-        FriendshipBuilderFactory.getBuilder('Friendship');
-
-      friendshipBuilder
-        .setPlayerA(config.playerA)
-        .setPlayerB(config.playerB)
-        .setStatus(config.status);
-
-      if (config.requester) {
-        friendshipBuilder.setRequester(config.requester);
-      }
-
-      createdFriendships.push(friendshipBuilder.build());
-    }
-  });
+  const friendshipConfigs: Partial<Friendship>[] = [
+    {
+      playerA: player1_id,
+      playerB: player2_id,
+      status: FriendshipStatus.PENDING,
+      requester: player1_id,
+    },
+    {
+      playerA: player1_id,
+      playerB: player3_id,
+      status: FriendshipStatus.PENDING,
+      requester: player1_id,
+    },
+    {
+      playerA: player2_id,
+      playerB: player3_id,
+      status: FriendshipStatus.ACCEPTED,
+    },
+    {
+      playerA: player1_id,
+      playerB: player4_id,
+      status: FriendshipStatus.BLOCKED,
+    },
+  ];
 
   beforeEach(async () => {
-    await friendshipModel.deleteMany({});
     friendshipService = await FriendshipModule.getFriendshipService();
 
-    await friendshipModel.create(createdFriendships);
+    await createMockFriendships(friendshipConfigs)
   });
 
   it('Should get two friendship requests for player1', async () => {
     const [friendships, err] = await friendshipService.getFriendRequests(
-      player1_id.toString(),
+      player1_id,
     );
 
     expect(err).toBeNull();
@@ -77,7 +56,7 @@ describe('Friendship.getFriendRequests() test suites', () => {
 
   it('Should get one friendship request for player2', async () => {
     const [friendships, err] = await friendshipService.getFriendRequests(
-      player2_id.toString(),
+      player2_id,
     );
 
     expect(err).toBeNull();
@@ -86,7 +65,7 @@ describe('Friendship.getFriendRequests() test suites', () => {
 
   it('should return NOT_FOUND for player4', async () => {
     const [friendships, err] = await friendshipService.getFriendRequests(
-      player4_id.toString(),
+      player4_id,
     );
 
     expect(err).toContainSE_NOT_FOUND();
@@ -95,7 +74,7 @@ describe('Friendship.getFriendRequests() test suites', () => {
 
   it('Should avoid status ACCEPTED and return one friendship request', async () => {
     const [friendships, err] = await friendshipService.getFriendRequests(
-      player3_id.toString(),
+      player3_id,
     );
 
     expect(err).toBeNull();

--- a/src/__tests__/friendship/friendshipService/getFriendshipsWithStatus.test.ts
+++ b/src/__tests__/friendship/friendshipService/getFriendshipsWithStatus.test.ts
@@ -1,76 +1,58 @@
 import { ObjectId } from "mongodb";
 import { FriendshipService } from "../../../friendship/friendship.service"
 import FriendshipModule from "../modules/friendship.module";
-import { Friendship } from "../../../friendship/friendship.schema";
 import { FriendshipStatus } from "../../../friendship/enum/friendship-status.enum";
-import FriendshipBuilderFactory from "../data/friendshipBuilderFactory";
+import { createMockFriendships } from "../data/mockData/createData.mock";
+import { Friendship } from "src/friendship/friendship.schema";
 
 describe('FriendshipService.getFriendshipsWithStatus() test suites', () => {
     let friendshipService: FriendshipService;
-    const friendshipModel = FriendshipModule.getFriendshipModel();
-    const createdFriendships: Friendship[] = [];
 
     const player1_id = new ObjectId().toString();
     const player2_id = new ObjectId().toString();
     const player3_id = new ObjectId().toString();
     const player4_id = new ObjectId().toString();
 
-    beforeAll(() => {
-        const friendshipConfigs = [
-            {
-                playerA: player1_id,
-                playerB: player2_id,
-                status: FriendshipStatus.PENDING,
-                requester: player1_id,
-            },
-            {
-                playerA: player1_id,
-                playerB: player3_id,
-                status: FriendshipStatus.PENDING,
-                requester: player1_id,
-            },
-            {
-                playerA: player1_id,
-                playerB: player4_id,
-                status: FriendshipStatus.PENDING,
-                requester: player1_id,
-            },
-            {
-                playerA: player2_id,
-                playerB: player3_id,
-                status: FriendshipStatus.ACCEPTED,
-            },
-            {
-                playerA: player2_id,
-                playerB: player4_id,
-                status: FriendshipStatus.ACCEPTED,
-            },
-            {
-                playerA: player3_id,
-                playerB: player4_id,
-                status: FriendshipStatus.BLOCKED,
-            },
-        ];
-
-        for (const config of friendshipConfigs) {
-            const builder = FriendshipBuilderFactory.getBuilder('Friendship');
-            builder
-                .setPlayerA(config.playerA)
-                .setPlayerB(config.playerB)
-                .setStatus(config.status);
-
-            if (config.requester) {
-                builder.setRequester(config.requester);
-            }
-            createdFriendships.push(builder.build());
-        }
-    });
+    const friendshipConfigs: Partial<Friendship>[] = [
+        {
+            playerA: player1_id,
+            playerB: player2_id,
+            status: FriendshipStatus.PENDING,
+            requester: player1_id,
+        },
+        {
+            playerA: player1_id,
+            playerB: player3_id,
+            status: FriendshipStatus.PENDING,
+            requester: player1_id,
+        },
+        {
+            playerA: player1_id,
+            playerB: player4_id,
+            status: FriendshipStatus.PENDING,
+            requester: player1_id,
+        },
+        {
+            playerA: player2_id,
+            playerB: player3_id,
+            status: FriendshipStatus.ACCEPTED,
+        },
+        {
+            playerA: player2_id,
+            playerB: player4_id,
+            status: FriendshipStatus.ACCEPTED,
+        },
+        {
+            playerA: player3_id,
+            playerB: player4_id,
+            status: FriendshipStatus.BLOCKED,
+        },
+    ];
 
     beforeEach(async () => {
-        await friendshipModel.deleteMany({});
         friendshipService = await FriendshipModule.getFriendshipService();
 
-        await friendshipModel.create(createdFriendships);
+        await createMockFriendships(friendshipConfigs);
     });
 
     it('Should get all friendship with status PENDING', async () => {

--- a/src/__tests__/friendship/friendshipService/getFriendshipsWithStatus.test.ts
+++ b/src/__tests__/friendship/friendshipService/getFriendshipsWithStatus.test.ts
@@ -1,0 +1,126 @@
+import { ObjectId } from "mongodb";
+import { FriendshipService } from "../../../friendship/friendship.service"
+import FriendshipModule from "../modules/friendship.module";
+import { Friendship } from "../../../friendship/friendship.schema";
+import { FriendshipStatus } from "../../../friendship/enum/friendship-status.enum";
+import FriendshipBuilderFactory from "../data/friendshipBuilderFactory";
+
+describe('FriendshipService.getFriendshipsWithStatus() test suites', () => {
+    let friendshipService: FriendshipService;
+    const friendshipModel = FriendshipModule.getFriendshipModel();
+    const createdFriendships: Friendship[] = [];
+
+    const player1_id = new ObjectId().toString();
+    const player2_id = new ObjectId().toString();
+    const player3_id = new ObjectId().toString();
+    const player4_id = new ObjectId().toString();
+
+    beforeAll(() => {
+        const friendshipConfigs = [
+            {
+                playerA: player1_id,
+                playerB: player2_id,
+                status: FriendshipStatus.PENDING,
+                requester: player1_id,
+            },
+            {
+                playerA: player1_id,
+                playerB: player3_id,
+                status: FriendshipStatus.PENDING,
+                requester: player1_id,
+            },
+            {
+                playerA: player1_id,
+                playerB: player4_id,
+                status: FriendshipStatus.PENDING,
+                requester: player1_id,
+            },
+            {
+                playerA: player2_id,
+                playerB: player3_id,
+                status: FriendshipStatus.ACCEPTED,
+            },
+            {
+                playerA: player2_id,
+                playerB: player4_id,
+                status: FriendshipStatus.ACCEPTED,
+            },
+            {
+                playerA: player3_id,
+                playerB: player4_id,
+                status: FriendshipStatus.BLOCKED,
+            },
+        ];
+
+        for (const config of friendshipConfigs) {
+            const builder = FriendshipBuilderFactory.getBuilder('Friendship');
+            builder
+                .setPlayerA(config.playerA)
+                .setPlayerB(config.playerB)
+                .setStatus(config.status);
+
+            if (config.requester) {
+                builder.setRequester(config.requester);
+            }
+            createdFriendships.push(builder.build());
+        }
+    });
+
+    beforeEach(async () => {
+        await friendshipModel.deleteMany({});
+        friendshipService = await FriendshipModule.getFriendshipService();
+
+        await friendshipModel.create(createdFriendships);
+    });
+
+    it('Should get all friendship with status PENDING', async () => {
+        const [friendships, err] = await friendshipService.getFriendshipsWithStatus(
+            player1_id,
+            FriendshipStatus.PENDING
+        );
+
+        expect(err).toBeNull();
+        expect(friendships).toHaveLength(3);
+    });
+
+    it('Should get all friendship with status ACCEPTED', async () => {
+        const [friendships, err] = await friendshipService.getFriendshipsWithStatus(
+            player2_id,
+            FriendshipStatus.ACCEPTED
+        );
+
+        expect(err).toBeNull();
+        expect(friendships).toHaveLength(2);
+    });
+
+    it('Should get all friendship with status BLOCKED', async () => {
+        const [friendships, err] = await friendshipService.getFriendshipsWithStatus(
+            player3_id,
+            FriendshipStatus.BLOCKED
+        );
+
+        expect(err).toBeNull();
+        expect(friendships).toHaveLength(1);
+    });
+
+    it('Should return NOT_FOUND if no match player_id', async () => {
+        const randomPlayer_id = new ObjectId().toString();
+        const [friendships, err] = await friendshipService.getFriendshipsWithStatus(
+            randomPlayer_id,
+            FriendshipStatus.ACCEPTED
+        );
+
+        expect(err).toContainSE_NOT_FOUND();
+        expect(friendships).toBeNull();
+    });
+
+    it('Should return NOT_FOUND if no match STATUS', async () => {
+        const [friendships, err] = await friendshipService.getFriendshipsWithStatus(
+            player1_id,
+            undefined
+        );
+
+        expect(err).toContainSE_NOT_FOUND();
+        expect(friendships).toBeNull();
+    });
+})

--- a/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
+++ b/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
@@ -2,17 +2,17 @@ import { FriendshipService } from '../../../friendship/friendship.service';
 import FriendshipModule from '../modules/friendship.module';
 import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
 import { Friendship } from '../../../friendship/friendship.schema';
-import { Types } from 'mongoose';
 import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+import { ObjectId } from 'mongodb';
 
 describe('Friendship.getPlayerFriendlist() test suite', () => {
   let friendshipService: FriendshipService;
   const friendshipModel = FriendshipModule.getFriendshipModel();
   const friendshipBuilder = FriendshipBuilderFactory.getBuilder('Friendship');
 
-  const player1_id = new Types.ObjectId();
-  const player2_id = new Types.ObjectId();
-  const player3_id = new Types.ObjectId();
+  const player1_id = new ObjectId();
+  const player2_id = new ObjectId();
+  const player3_id = new ObjectId();
 
   const createdFriendships: Friendship[] = [];
 
@@ -60,7 +60,7 @@ describe('Friendship.getPlayerFriendlist() test suite', () => {
   });
 
   it('Should return an empty array if no player_id match the filter', async () => {
-    const randomPlayer_id = new Types.ObjectId();
+    const randomPlayer_id = new ObjectId();
     const [friendships, err] = await friendshipService.getPlayerFriendlist(
       randomPlayer_id.toString(),
     );

--- a/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
+++ b/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
@@ -47,10 +47,10 @@ describe('Friendship.getPlayerFriendlist() test suite', () => {
     await friendshipModel.deleteMany({});
     friendshipService = await FriendshipModule.getFriendshipService();
 
-    await friendshipModel.create(...createdFriendships);
+    await friendshipModel.create(createdFriendships);
   });
 
-  it('Should get two friendships with status ACCEPTED', async () => {
+  it('Should get two friendships for player1', async () => {
     const [friendships, err] = await friendshipService.getPlayerFriendlist(
       player1_id.toString(),
     );
@@ -69,7 +69,7 @@ describe('Friendship.getPlayerFriendlist() test suite', () => {
     expect(friendships).toBeNull();
   });
 
-  it('Should return only one friendship for player2', async () => {
+  it('Should get only one friendship for player2', async () => {
     const [friendships, err] = await friendshipService.getPlayerFriendlist(
       player2_id.toString(),
     );

--- a/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
+++ b/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
@@ -1,53 +1,42 @@
 import { FriendshipService } from '../../../friendship/friendship.service';
 import FriendshipModule from '../modules/friendship.module';
-import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
-import { Friendship } from '../../../friendship/friendship.schema';
 import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
 import { ObjectId } from 'mongodb';
+import { createMockFriendships } from '../data/mockData/createData.mock';
+import { Friendship } from 'src/friendship/friendship.schema';
 
 describe('Friendship.getPlayerFriendlist() test suite', () => {
   let friendshipService: FriendshipService;
-  const friendshipModel = FriendshipModule.getFriendshipModel();
-  const friendshipBuilder = FriendshipBuilderFactory.getBuilder('Friendship');
 
-  const player1_id = new ObjectId();
-  const player2_id = new ObjectId();
-  const player3_id = new ObjectId();
+  const player1_id = new ObjectId().toString();
+  const player2_id = new ObjectId().toString();
+  const player3_id = new ObjectId().toString();
 
-  const createdFriendships: Friendship[] = [];
+  const friendshipConfigs: Partial<Friendship>[] = [
+    {
+      playerA: player1_id,
+      playerB: player2_id,
+      status: FriendshipStatus.ACCEPTED,
 
-  beforeAll(() => {
-    const friendshipToCreate1 = friendshipBuilder
-      .setPlayerA(player1_id)
-      .setPlayerB(player2_id)
-      .setStatus(FriendshipStatus.ACCEPTED)
-      .build();
+    },
+    {
+      playerA: player1_id,
+      playerB: player3_id,
+      status: FriendshipStatus.ACCEPTED,
 
-    createdFriendships.push(friendshipToCreate1);
-
-    const friendshipToCreate2 = friendshipBuilder
-      .setPlayerA(player1_id)
-      .setPlayerB(player3_id)
-      .setStatus(FriendshipStatus.ACCEPTED)
-      .build();
-
-    createdFriendships.push(friendshipToCreate2);
-
-    const friendshipToCreate3 = friendshipBuilder
-      .setPlayerA(player2_id)
-      .setPlayerB(player3_id)
-      .setStatus(FriendshipStatus.PENDING)
-      .setRequester(player2_id)
-      .build();
-
-    createdFriendships.push(friendshipToCreate3);
-  });
+    },
+    {
+      playerA: player2_id,
+      playerB: player3_id,
+      status: FriendshipStatus.PENDING,
+      requester: player2_id,
+    },
+  ];
 
   beforeEach(async () => {
-    await friendshipModel.deleteMany({});
     friendshipService = await FriendshipModule.getFriendshipService();
 
-    await friendshipModel.create(createdFriendships);
+    await createMockFriendships(friendshipConfigs);
   });
 
   it('Should get two friendships for player1', async () => {

--- a/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
+++ b/src/__tests__/friendship/friendshipService/getPlayerFriendlist.test.ts
@@ -1,0 +1,80 @@
+import { FriendshipService } from '../../../friendship/friendship.service';
+import FriendshipModule from '../modules/friendship.module';
+import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
+import { Friendship } from '../../../friendship/friendship.schema';
+import { Types } from 'mongoose';
+import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+
+describe('Friendship.getPlayerFriendlist() test suite', () => {
+  let friendshipService: FriendshipService;
+  const friendshipModel = FriendshipModule.getFriendshipModel();
+  const friendshipBuilder = FriendshipBuilderFactory.getBuilder('Friendship');
+
+  const player1_id = new Types.ObjectId();
+  const player2_id = new Types.ObjectId();
+  const player3_id = new Types.ObjectId();
+
+  const createdFriendships: Friendship[] = [];
+
+  beforeAll(() => {
+    const friendshipToCreate1 = friendshipBuilder
+      .setPlayerA(player1_id)
+      .setPlayerB(player2_id)
+      .setStatus(FriendshipStatus.ACCEPTED)
+      .build();
+
+    createdFriendships.push(friendshipToCreate1);
+
+    const friendshipToCreate2 = friendshipBuilder
+      .setPlayerA(player1_id)
+      .setPlayerB(player3_id)
+      .setStatus(FriendshipStatus.ACCEPTED)
+      .build();
+
+    createdFriendships.push(friendshipToCreate2);
+
+    const friendshipToCreate3 = friendshipBuilder
+      .setPlayerA(player2_id)
+      .setPlayerB(player3_id)
+      .setStatus(FriendshipStatus.PENDING)
+      .setRequester(player2_id)
+      .build();
+
+    createdFriendships.push(friendshipToCreate3);
+  });
+
+  beforeEach(async () => {
+    await friendshipModel.deleteMany({});
+    friendshipService = await FriendshipModule.getFriendshipService();
+
+    await friendshipModel.create(...createdFriendships);
+  });
+
+  it('Should get two friendships with status ACCEPTED', async () => {
+    const [friendships, err] = await friendshipService.getPlayerFriendlist(
+      player1_id.toString(),
+    );
+
+    expect(err).toBeNull();
+    expect(friendships).toHaveLength(2);
+  });
+
+  it('Should return an empty array if no player_id match the filter', async () => {
+    const randomPlayer_id = new Types.ObjectId();
+    const [friendships, err] = await friendshipService.getPlayerFriendlist(
+      randomPlayer_id.toString(),
+    );
+
+    expect(err).toContainSE_NOT_FOUND();
+    expect(friendships).toBeNull();
+  });
+
+  it('Should return only one friendship for player2', async () => {
+    const [friendships, err] = await friendshipService.getPlayerFriendlist(
+      player2_id.toString(),
+    );
+
+    expect(err).toBeNull();
+    expect(friendships).toHaveLength(1);
+  });
+});

--- a/src/__tests__/friendship/friendshipService/sendNewFriendRequestNotification.test.ts
+++ b/src/__tests__/friendship/friendshipService/sendNewFriendRequestNotification.test.ts
@@ -3,18 +3,16 @@ import { FriendshipService } from '../../../friendship/friendship.service';
 import FriendshipModule from '../modules/friendship.module';
 import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
 import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
-import { Friendship } from '../../../friendship/friendship.schema';
 import {
   createMockClans,
+  createMockFriendships,
   createMockPlayers,
 } from '../data/mockData/createData.mock';
+import { Friendship } from 'src/friendship/friendship.schema';
 
 describe('FriendshipService.sendNewFriendRequestNotification()', () => {
   let friendshipService: FriendshipService;
-  const clanModel = FriendshipModule.getClanModel();
-  const playerModel = FriendshipModule.getPlayerModel();
   const friendshipModel = FriendshipModule.getFriendshipModel();
-  const createdFriendships: Friendship[] = [];
 
   const player1_id = new ObjectId().toString();
   const player2_id = new ObjectId().toString();
@@ -22,47 +20,29 @@ describe('FriendshipService.sendNewFriendRequestNotification()', () => {
 
   const clan_id = new ObjectId().toString();
 
-  beforeAll(() => {
-    const friendshipConfigs = [
-      {
-        playerA: player1_id,
-        playerB: player2_id,
-        status: FriendshipStatus.PENDING,
-        requester: player1_id,
-      },
-      {
-        playerA: player1_id,
-        playerB: player3_id,
-        status: FriendshipStatus.PENDING,
-        requester: player1_id,
-      },
-      {
-        playerA: player2_id,
-        playerB: player3_id,
-        status: FriendshipStatus.PENDING,
-        requester: player2_id,
-      },
-    ];
-
-    for (const config of friendshipConfigs) {
-      const builder = FriendshipBuilderFactory.getBuilder('Friendship');
-      builder
-        .setPlayerA(config.playerA)
-        .setPlayerB(config.playerB)
-        .setStatus(config.status);
-
-      if (config.requester) {
-        builder.setRequester(config.requester);
-      }
-      createdFriendships.push(builder.build());
-    }
-  });
+  const friendshipConfigs: Partial<Friendship>[] = [
+    {
+      playerA: player1_id,
+      playerB: player2_id,
+      status: FriendshipStatus.PENDING,
+      requester: player1_id,
+    },
+    {
+      playerA: player1_id,
+      playerB: player3_id,
+      status: FriendshipStatus.PENDING,
+      requester: player1_id,
+    },
+    {
+      playerA: player2_id,
+      playerB: player3_id,
+      status: FriendshipStatus.PENDING,
+      requester: player2_id,
+    },
+  ];
 
   beforeEach(async () => {
     friendshipService = await FriendshipModule.getFriendshipService();
-    await friendshipModel.deleteMany({});
-    await clanModel.deleteMany({});
-    await playerModel.deleteMany({});
 
     await createMockClans([{ _id: clan_id, name: 'TestClan' }]);
     await createMockPlayers([
@@ -85,7 +65,7 @@ describe('FriendshipService.sendNewFriendRequestNotification()', () => {
         uniqueIdentifier: 'unique-3',
       },
     ]);
-    await friendshipModel.create(createdFriendships);
+    await createMockFriendships(friendshipConfigs);
   });
 
   it('Should send notifications for all pending friendship requests', async () => {

--- a/src/__tests__/friendship/friendshipService/sendNewFriendRequestNotification.test.ts
+++ b/src/__tests__/friendship/friendshipService/sendNewFriendRequestNotification.test.ts
@@ -1,0 +1,111 @@
+import { ObjectId } from 'mongodb';
+import { FriendshipService } from '../../../friendship/friendship.service';
+import FriendshipModule from '../modules/friendship.module';
+import FriendshipBuilderFactory from '../data/friendshipBuilderFactory';
+import { FriendshipStatus } from '../../../friendship/enum/friendship-status.enum';
+import { Friendship } from '../../../friendship/friendship.schema';
+import {
+  createMockClans,
+  createMockPlayers,
+} from '../data/mockData/createData.mock';
+
+describe('FriendshipService.sendNewFriendRequestNotification()', () => {
+  let friendshipService: FriendshipService;
+  const clanModel = FriendshipModule.getClanModel();
+  const playerModel = FriendshipModule.getPlayerModel();
+  const friendshipModel = FriendshipModule.getFriendshipModel();
+  const createdFriendships: Friendship[] = [];
+
+  const player1_id = new ObjectId().toString();
+  const player2_id = new ObjectId().toString();
+  const player3_id = new ObjectId().toString();
+
+  const clan_id = new ObjectId().toString();
+
+  beforeAll(() => {
+    const friendshipConfigs = [
+      {
+        playerA: player1_id,
+        playerB: player2_id,
+        status: FriendshipStatus.PENDING,
+        requester: player1_id,
+      },
+      {
+        playerA: player1_id,
+        playerB: player3_id,
+        status: FriendshipStatus.PENDING,
+        requester: player1_id,
+      },
+      {
+        playerA: player2_id,
+        playerB: player3_id,
+        status: FriendshipStatus.PENDING,
+        requester: player2_id,
+      },
+    ];
+
+    for (const config of friendshipConfigs) {
+      const builder = FriendshipBuilderFactory.getBuilder('Friendship');
+      builder
+        .setPlayerA(config.playerA)
+        .setPlayerB(config.playerB)
+        .setStatus(config.status);
+
+      if (config.requester) {
+        builder.setRequester(config.requester);
+      }
+      createdFriendships.push(builder.build());
+    }
+  });
+
+  beforeEach(async () => {
+    friendshipService = await FriendshipModule.getFriendshipService();
+    await friendshipModel.deleteMany({});
+    await clanModel.deleteMany({});
+    await playerModel.deleteMany({});
+
+    await createMockClans([{ _id: clan_id, name: 'TestClan' }]);
+    await createMockPlayers([
+      {
+        _id: player1_id,
+        name: 'Player1',
+        clan_id,
+        uniqueIdentifier: 'unique-1',
+      },
+      {
+        _id: player2_id,
+        name: 'Player2',
+        clan_id,
+        uniqueIdentifier: 'unique-2',
+      },
+      {
+        _id: player3_id,
+        name: 'Player3',
+        clan_id,
+        uniqueIdentifier: 'unique-3',
+      },
+    ]);
+    await friendshipModel.create(createdFriendships);
+  });
+
+  it('Should send notifications for all pending friendship requests', async () => {
+    const pendingFriendships = await friendshipModel.find({
+      status: FriendshipStatus.PENDING,
+    });
+
+    expect(pendingFriendships).toHaveLength(3);
+
+    const notifier = (friendshipService as any).notifier;
+    const spy = jest.spyOn(notifier, 'newFriendRequest');
+
+    for (const friendship of pendingFriendships) {
+      // void function
+      const result =
+        await friendshipService.sendNewFriendRequestNotification(friendship);
+      expect(result).toBeUndefined();
+    }
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    spy.mockRestore();
+  });
+});

--- a/src/__tests__/friendship/modules/friendship.module.ts
+++ b/src/__tests__/friendship/modules/friendship.module.ts
@@ -1,0 +1,24 @@
+import mongoose from "mongoose";
+import { FriendshipService } from "src/friendship/friendship.service";
+import FriendshipCommonModule from "./friendshipCommon";
+import FriendshipNotifier from "src/friendship/friendship.notifier";
+import { ModelName } from "src/common/enum/modelName.enum";
+import { FriendshipSchema } from "src/friendship/friendship.schema";
+
+export default class FriendshipModule {
+    private constructor() {}
+
+    static async getFriendshipService() {
+        const module = await FriendshipCommonModule.getModule();
+        return await module.resolve(FriendshipService);
+    }
+
+    static async getFriendshipNotifier() {
+        const module = await FriendshipCommonModule.getModule();
+        return await module.resolve(FriendshipNotifier);
+    }
+
+    static getFriendshipModel() {
+        return mongoose.model(ModelName.FRIENDSHIP, FriendshipSchema);
+    }
+}

--- a/src/__tests__/friendship/modules/friendship.module.ts
+++ b/src/__tests__/friendship/modules/friendship.module.ts
@@ -1,9 +1,9 @@
 import mongoose from "mongoose";
-import { FriendshipService } from "src/friendship/friendship.service";
+import { FriendshipService } from "../../../friendship/friendship.service";
 import FriendshipCommonModule from "./friendshipCommon";
-import FriendshipNotifier from "src/friendship/friendship.notifier";
-import { ModelName } from "src/common/enum/modelName.enum";
-import { FriendshipSchema } from "src/friendship/friendship.schema";
+import FriendshipNotifier from "../../../friendship/friendship.notifier";
+import { ModelName } from "../../../common/enum/modelName.enum";
+import { FriendshipSchema } from "../../../friendship/friendship.schema";
 
 export default class FriendshipModule {
     private constructor() {}

--- a/src/__tests__/friendship/modules/friendship.module.ts
+++ b/src/__tests__/friendship/modules/friendship.module.ts
@@ -4,6 +4,8 @@ import FriendshipCommonModule from "./friendshipCommon";
 import FriendshipNotifier from "../../../friendship/friendship.notifier";
 import { ModelName } from "../../../common/enum/modelName.enum";
 import { FriendshipSchema } from "../../../friendship/friendship.schema";
+import { ClanSchema } from "../../../clan/clan.schema";
+import { PlayerSchema } from "../../../player/schemas/player.schema";
 
 export default class FriendshipModule {
     private constructor() {}
@@ -11,14 +13,22 @@ export default class FriendshipModule {
     static async getFriendshipService() {
         const module = await FriendshipCommonModule.getModule();
         return await module.resolve(FriendshipService);
-    }
+    };
 
     static async getFriendshipNotifier() {
         const module = await FriendshipCommonModule.getModule();
         return await module.resolve(FriendshipNotifier);
-    }
+    };
 
     static getFriendshipModel() {
         return mongoose.model(ModelName.FRIENDSHIP, FriendshipSchema);
+    };
+
+    static getClanModel() {
+        return mongoose.model(ModelName.CLAN, ClanSchema);
+    };
+
+    static getPlayerModel() {
+        return mongoose.model(ModelName.PLAYER, PlayerSchema);
     }
 }

--- a/src/__tests__/friendship/modules/friendshipCommon.ts
+++ b/src/__tests__/friendship/modules/friendshipCommon.ts
@@ -1,0 +1,33 @@
+import { MongooseModule } from "@nestjs/mongoose";
+import { Test, TestingModule } from "@nestjs/testing";
+import { mongooseOptions, mongoString } from "src/__tests__/test_utils/const/db";
+import { ModelName } from "src/common/enum/modelName.enum";
+import FriendshipNotifier from "src/friendship/friendship.notifier";
+import { FriendshipSchema } from "src/friendship/friendship.schema";
+import { FriendshipService } from "src/friendship/friendship.service";
+import { PlayerModule } from "src/player/player.module";
+import { PlayerSchema } from "src/player/schemas/player.schema";
+
+export default class FriendshipCommonModule {
+    private constructor() {}
+
+    private static module: TestingModule;
+
+    static async getModule() {
+        if (!FriendshipCommonModule.module)
+            FriendshipCommonModule.module = await Test.createTestingModule({
+                imports: [
+                    MongooseModule.forRoot(mongoString, mongooseOptions),
+                    MongooseModule.forFeature([
+                        { name: ModelName.FRIENDSHIP, schema: FriendshipSchema },
+                        { name: ModelName.PLAYER, schema: PlayerSchema },
+                    ]),
+
+                    PlayerModule
+                ],
+                providers: [FriendshipService],
+            }).compile();
+            
+        return FriendshipCommonModule.module;
+    }
+}

--- a/src/__tests__/friendship/modules/friendshipCommon.ts
+++ b/src/__tests__/friendship/modules/friendshipCommon.ts
@@ -1,12 +1,12 @@
 import { MongooseModule } from "@nestjs/mongoose";
 import { Test, TestingModule } from "@nestjs/testing";
-import { mongooseOptions, mongoString } from "src/__tests__/test_utils/const/db";
-import { ModelName } from "src/common/enum/modelName.enum";
-import FriendshipNotifier from "src/friendship/friendship.notifier";
-import { FriendshipSchema } from "src/friendship/friendship.schema";
-import { FriendshipService } from "src/friendship/friendship.service";
-import { PlayerModule } from "src/player/player.module";
-import { PlayerSchema } from "src/player/schemas/player.schema";
+import { mongooseOptions, mongoString } from "../../test_utils/const/db";
+import { ModelName } from "../../../common/enum/modelName.enum";
+import FriendshipNotifier from "../../../friendship/friendship.notifier";
+import { FriendshipSchema } from "../../../friendship/friendship.schema";
+import { FriendshipService } from "../../../friendship/friendship.service";
+import { PlayerModule } from "../../../player/player.module";
+import { PlayerSchema } from "../../../player/schemas/player.schema";
 
 export default class FriendshipCommonModule {
     private constructor() {}
@@ -25,7 +25,7 @@ export default class FriendshipCommonModule {
 
                     PlayerModule
                 ],
-                providers: [FriendshipService],
+                providers: [FriendshipService, FriendshipNotifier],
             }).compile();
             
         return FriendshipCommonModule.module;

--- a/src/__tests__/friendship/modules/friendshipCommon.ts
+++ b/src/__tests__/friendship/modules/friendshipCommon.ts
@@ -7,6 +7,7 @@ import { FriendshipSchema } from "../../../friendship/friendship.schema";
 import { FriendshipService } from "../../../friendship/friendship.service";
 import { PlayerModule } from "../../../player/player.module";
 import { PlayerSchema } from "../../../player/schemas/player.schema";
+import { ClanSchema } from "../../../clan/clan.schema";
 
 export default class FriendshipCommonModule {
     private constructor() {}
@@ -21,6 +22,7 @@ export default class FriendshipCommonModule {
                     MongooseModule.forFeature([
                         { name: ModelName.FRIENDSHIP, schema: FriendshipSchema },
                         { name: ModelName.PLAYER, schema: PlayerSchema },
+                        { name: ModelName.CLAN, schema: ClanSchema },
                     ]),
 
                     PlayerModule

--- a/src/friendship/friendship.schema.ts
+++ b/src/friendship/friendship.schema.ts
@@ -56,9 +56,21 @@ FriendshipSchema.pre('validate', function (next) {
   const b = this.playerB.toString();
   if (a === b) return next(new Error('playerA and playerB cannot be the same'));
 
+  if (this.status === FriendshipStatus.PENDING) {
+    if (!this.requester) {
+      return next(new Error('requester is required when status is PENDING'));
+    }
+
+    const requesterStr = this.requester.toString();
+    if (requesterStr !== a && requesterStr !== b) {
+      return next(new Error('requester must be either playerA or playerB'));
+    }
+  }
+
   this.pairKey = [a, b].sort().join('_');
   next();
 });
+
 FriendshipSchema.pre('save', function (next) {
   if (this.isModified('status') && this.status === FriendshipStatus.ACCEPTED) {
     this.requester = undefined;

--- a/src/friendship/friendship.schema.ts
+++ b/src/friendship/friendship.schema.ts
@@ -2,6 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import {
   HydratedDocument,
   Schema as MongooseSchema,
+  Types,
   UpdateQuery,
 } from 'mongoose';
 import { ModelName } from '../common/enum/modelName.enum';
@@ -16,14 +17,14 @@ export class Friendship {
     ref: ModelName.PLAYER,
     required: true,
   })
-  playerA: MongooseSchema.Types.ObjectId;
+  playerA: Types.ObjectId;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: ModelName.PLAYER,
     required: true,
   })
-  playerB: MongooseSchema.Types.ObjectId;
+  playerB: Types.ObjectId;
 
   @Prop({
     type: String,
@@ -36,11 +37,11 @@ export class Friendship {
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: ModelName.PLAYER,
-    required: function () {
+    required: function (this: Friendship) {
       return this.status === FriendshipStatus.PENDING;
     },
   })
-  requester?: MongooseSchema.Types.ObjectId;
+  requester?: Types.ObjectId;
 
   @Prop({ type: String, required: true })
   pairKey: string;

--- a/src/friendship/friendship.schema.ts
+++ b/src/friendship/friendship.schema.ts
@@ -2,11 +2,11 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import {
   HydratedDocument,
   Schema as MongooseSchema,
-  Types,
   UpdateQuery,
 } from 'mongoose';
 import { ModelName } from '../common/enum/modelName.enum';
 import { FriendshipStatus } from './enum/friendship-status.enum';
+import { ObjectId } from 'mongodb';
 
 export type FriendshipDocument = HydratedDocument<Friendship>;
 
@@ -17,14 +17,14 @@ export class Friendship {
     ref: ModelName.PLAYER,
     required: true,
   })
-  playerA: Types.ObjectId;
+  playerA: string | ObjectId;
 
   @Prop({
     type: MongooseSchema.Types.ObjectId,
     ref: ModelName.PLAYER,
     required: true,
   })
-  playerB: Types.ObjectId;
+  playerB: string | ObjectId;
 
   @Prop({
     type: String,
@@ -41,7 +41,7 @@ export class Friendship {
       return this.status === FriendshipStatus.PENDING;
     },
   })
-  requester?: Types.ObjectId;
+  requester?: string | ObjectId;
 
   @Prop({ type: String, required: true })
   pairKey: string;

--- a/src/friendship/friendship.service.ts
+++ b/src/friendship/friendship.service.ts
@@ -43,7 +43,7 @@ export class FriendshipService {
         playerId,
         FriendshipStatus.ACCEPTED,
       );
-      if (error) throw error;
+      if (error) return [null, error];
 
       const filtered: FriendlistDto[] = friendships.map((doc) => {
         if (!doc.playerA || !doc.playerB) return null;

--- a/src/friendship/friendship.service.ts
+++ b/src/friendship/friendship.service.ts
@@ -14,6 +14,7 @@ import { FriendlistDto } from './dto/friend-list.dto';
 import { Player } from '../player/schemas/player.schema';
 import FriendshipNotifier from './friendship.notifier';
 import { InvalidIdsServiceError } from './error/duplicateId.error';
+import { FriendRequestDto } from './dto/FriendRequest.dto';
 
 @Injectable()
 export class FriendshipService {
@@ -37,7 +38,7 @@ export class FriendshipService {
    */
   async getPlayerFriendlist(
     playerId: string,
-  ): Promise<IServiceReturn<PopulatedFriendship[]>> {
+  ): Promise<IServiceReturn<FriendlistDto[]>> {
     try {
       const [friendships, error] = await this.getFriendshipsWithStatus(
         playerId,
@@ -57,10 +58,10 @@ export class FriendshipService {
           avatar: friend.avatar,
           clanName: friend.Clan?.name ?? null,
           clan_id: friend.clan_id.toString(),
-        };
+        } as FriendlistDto;
       });
 
-      return [filtered as any, null];
+      return [filtered, null];
     } catch (error) {
       const errors = convertMongooseToServiceErrors(error);
       return [null, errors];
@@ -75,15 +76,17 @@ export class FriendshipService {
    * @param - playerId of the player whose friendlist to return
    * @returns Friend request list
    */
-  async getFriendRequests(playerId: string) {
+  async getFriendRequests(
+    playerId: string
+  ): Promise<IServiceReturn<FriendRequestDto[]>> {
     try {
       const [requests, error] = await this.getFriendshipsWithStatus(
         playerId,
         FriendshipStatus.PENDING,
       );
-      if (error) throw error;
+      if (error) return [null, error];
 
-      const filtered = requests.map((doc) => {
+      const filtered: FriendRequestDto[] = requests.map((doc) => {
         if (!doc.playerA || !doc.playerB) return null;
         const friend =
           doc.playerA._id.toString() === playerId ? doc.playerB : doc.playerA;
@@ -100,7 +103,7 @@ export class FriendshipService {
             clan_id: friend.clan_id.toString(),
             clanName: friend.Clan?.name ?? null,
           },
-        };
+        } as FriendRequestDto;
       });
 
       return [filtered, null];


### PR DESCRIPTION
### Brief description
This PR implements all the tests for friendship module. Including module, DTO builders and unit tests for the friendship service and notifier to ensure the service work as expected. Also some changes of types, validation and handling error service in `friendship` schema, service. Following ticket #739 

### Change list

- Added `src/__test__/friendship/` folder including `modules`, `data` (builders) and `friendshipService`.
- `src/friendship/friendship.schema.ts`: Replace the type of `Mongoose.Types.ObjectId` to `string | ObjectId`. This change will make it being possible to create new runtime instance. Add validation for `requester` when status is `PENDING`.
- `src/friendship/friendship.service.ts`: Add return type for `getFriendRequests()` and return `[null, error]` when the `NotFoundServiceError` has been returned from `getFriendshipsWithStatus()` instead of throw the error.
