### PR TITLE
Fix(WebDav): add dynamic import helper to support ESM in CJS context …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "mongoose": "8.19.4",
         "mqtt": "5.14.1",
         "rxjs": "7.8.2",
-        "webdav": "5.8.0",
+        "webdav": "^4.11.2",
         "ws": "8.18.3"
       },
       "devDependencies": {
@@ -735,15 +735,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/@buttercup/fetch": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.2.1.tgz",
-      "integrity": "sha512-sCgECOx8wiqY8NN1xN22BqqKzXYIG2AicNLlakOAI4f0WgyLVUbAigMf8CZhBtJxdudTcB1gD5lciqi44jwJvg==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "node-fetch": "^3.3.0"
       }
     },
     "node_modules/@casl/ability": {
@@ -4206,6 +4197,20 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
     "node_modules/b4a": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
@@ -4344,8 +4349,7 @@
     "node_modules/base-64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
-      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
-      "license": "MIT"
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4637,8 +4641,7 @@
     "node_modules/byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
-      "integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q==",
-      "license": "MIT"
+      "integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4757,7 +4760,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
       }
@@ -4992,6 +4994,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -5248,18 +5261,8 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -5322,6 +5325,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denque": {
@@ -5470,18 +5481,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -5524,6 +5523,20 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6049,21 +6062,18 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^1.0.4"
       },
       "bin": {
-        "fxparser": "src/cli/cli.js"
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -6084,29 +6094,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/fflate": {
@@ -6262,7 +6249,6 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6324,16 +6310,38 @@
         "webpack": "^5.11.0"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "dependencies": {
-        "fetch-blob": "^3.1.2"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -6662,6 +6670,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -6674,6 +6696,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
@@ -6681,10 +6711,9 @@
       "license": "MIT"
     },
     "node_modules/hot-patcher": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
-      "integrity": "sha512-ECg1JFG0YzehicQaogenlcs2qg6WsXQsxtnbr1i696u5tLUjtJdQAh0u2g0Q5YV45f263Ta1GnUJsc8WIfJf4Q==",
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-1.0.0.tgz",
+      "integrity": "sha512-3H8VH0PreeNsKMZw16nTHbUp4YoHCnPlawpsPXGJUR4qENDynl79b6Xk9CIFvLcH1qungBsCuzKcWyzoPPalTw=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -6941,8 +6970,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -8106,10 +8134,9 @@
       }
     },
     "node_modules/layerr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
-      "integrity": "sha512-tv754Ki2dXpPVApOrjTyRo4/QegVb9eVFq4mjqp4+NM5NaX7syQvN5BBNfV/ZpAHCEHV24XdUVrBAoka4jt3pA==",
-      "license": "MIT"
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/layerr/-/layerr-0.1.2.tgz",
+      "integrity": "sha512-ob5kTd9H3S4GOG2nVXyQhOu9O8nBgP555XxWPkJI0tR0JeRilfyTp8WtPdIJHLXBmHMSdEq5+KMxiYABeScsIQ=="
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -8359,7 +8386,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -8888,8 +8914,7 @@
     "node_modules/nested-property": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
-      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA==",
-      "license": "MIT"
+      "integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
     },
     "node_modules/new-find-package-json": {
       "version": "2.0.0",
@@ -8919,26 +8944,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
     "node_modules/node-emoji": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
@@ -8947,24 +8952,6 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-gyp-build": {
@@ -9462,8 +9449,7 @@
     "node_modules/path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
-      "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA==",
-      "license": "ISC"
+      "integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA=="
     },
     "node_modules/path-scurry": {
       "version": "2.0.0",
@@ -9761,8 +9747,7 @@
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT"
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -9916,8 +9901,7 @@
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT"
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -10660,8 +10644,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/strtok3": {
       "version": "10.3.4",
@@ -11437,19 +11420,14 @@
       }
     },
     "node_modules/url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "license": "MIT",
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -11544,62 +11522,46 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webdav": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webdav/-/webdav-5.8.0.tgz",
-      "integrity": "sha512-iuFG7NamJ41Oshg4930iQgfIpRrUiatPWIekeznYgEf2EOraTRcDPTjy7gIOMtkdpKTaqPk1E68NO5PAGtJahA==",
-      "license": "MIT",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/webdav/-/webdav-4.11.2.tgz",
+      "integrity": "sha512-Ht9TPD5EB7gYW0YmhRcE5NW0/dn/HQfyLSPQY1Rw1coQ5MQTUooAQ9Bpqt4EU7QLw0b95tX4cU59R+SIojs9KQ==",
       "dependencies": {
-        "@buttercup/fetch": "^0.2.1",
+        "axios": "^0.27.2",
         "base-64": "^1.0.0",
         "byte-length": "^1.0.2",
-        "entities": "^6.0.0",
-        "fast-xml-parser": "^4.5.1",
-        "hot-patcher": "^2.0.1",
-        "layerr": "^3.0.0",
+        "fast-xml-parser": "^3.19.0",
+        "he": "^1.2.0",
+        "hot-patcher": "^1.0.0",
+        "layerr": "^0.1.2",
         "md5": "^2.3.0",
-        "minimatch": "^9.0.5",
+        "minimatch": "^5.1.0",
         "nested-property": "^4.0.0",
-        "node-fetch": "^3.3.2",
         "path-posix": "^1.0.0",
-        "url-join": "^5.0.0",
+        "url-join": "^4.0.1",
         "url-parse": "^1.5.10"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       }
     },
     "node_modules/webdav/node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/webdav/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mongoose": "8.19.4",
     "mqtt": "5.14.1",
     "rxjs": "7.8.2",
-    "webdav": "5.8.0",
+    "webdav": "^4.11.2",
     "ws": "8.18.3"
   },
   "devDependencies": {

--- a/src/common/utils/createWebDavClient.ts
+++ b/src/common/utils/createWebDavClient.ts
@@ -1,0 +1,14 @@
+// ESM-only workaround: webdav is ESM-only, so we use dynamic import to avoid CommonJS issues
+import { createClient, WebDAVClient } from 'webdav';
+import { envVars } from '../service/envHandler/envVars';
+
+export function createWebDavClient(): WebDAVClient {
+  return createClient(
+    `http://${envVars.OWNCLOUD_HOST}:${envVars.OWNCLOUD_PORT}/remote.php/webdav/`,
+    {
+      username: envVars.OWNCLOUD_USER,
+      password: envVars.OWNCLOUD_PASSWORD,
+      maxBodyLength: 52428800,
+    },
+  );
+}

--- a/src/gameAnalytics/logFile.service.ts
+++ b/src/gameAnalytics/logFile.service.ts
@@ -1,29 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { createClient, WebDAVClient } from 'webdav';
+import { Readable } from 'stream';
 import ServiceError from '../common/service/basicService/ServiceError';
 import { SEReason } from '../common/service/basicService/SEReason';
-import { createClient, WebDAVClient } from 'webdav';
 import { envVars } from '../common/service/envHandler/envVars';
-import { Readable } from 'stream';
 
 @Injectable()
-export class LogFileService {
-  constructor() {
-    this.initializeWebDavClient();
-  }
-  private client: WebDAVClient;
-
+export class LogFileService implements OnModuleInit {
+  private client!: WebDAVClient;
   private readonly logFilesRootFolder = envVars.OWNCLOUD_LOG_FILES_ROOT;
 
-  /**
-   * Saves the provided file to the own cloud via WebDAV in the designated folder.
-   *
-   * @param fileToSave - The file to save.
-   * @param player_id - The player's unique identifier to be included in the file name.
-   * @param battleId - The battle id to which battle belongs to
-   * @returns A tuple with first element set to _true_ if file was saved
-   *
-   *          or _array of ServiceErrors_ as a second element
-   */
+  onModuleInit() {
+    this.client = createClient(
+      `http://${envVars.OWNCLOUD_HOST}:${envVars.OWNCLOUD_PORT}/remote.php/webdav/`,
+      {
+        username: envVars.OWNCLOUD_USER,
+        password: envVars.OWNCLOUD_PASSWORD,
+        maxBodyLength: 52428800,
+      },
+    );
+  }
+
   async saveFile(
     fileToSave: Express.Multer.File,
     player_id: string,
@@ -36,7 +33,6 @@ export class LogFileService {
     try {
       const isFileFolderExist = await this.client.exists(folderPath);
       if (!isFileFolderExist)
-        //Notice that the "logFilesRootFolder" folder must be already created manually in own cloud
         await this.client.createDirectory(folderPath, { recursive: true });
     } catch (error) {
       return [
@@ -44,7 +40,7 @@ export class LogFileService {
         [
           new ServiceError({
             reason: SEReason.UNEXPECTED,
-            message: 'Unexpected error happen during folder creation',
+            message: 'Unexpected error during folder creation',
             additional: this.getWebDavErrorData(error),
           }),
         ],
@@ -53,13 +49,9 @@ export class LogFileService {
 
     try {
       const fileStream = this.bufferToStream(fileToSave.buffer);
-      const isSuccess = await this.client.putFileContents(
-        filePath,
-        fileStream,
-        {
-          overwrite: true,
-        },
-      );
+      const isSuccess = await this.client.putFileContents(filePath, fileStream, {
+        overwrite: true,
+      });
 
       if (!isSuccess)
         return [
@@ -79,7 +71,7 @@ export class LogFileService {
         [
           new ServiceError({
             reason: SEReason.UNEXPECTED,
-            message: 'Unexpected error happen during file saving',
+            message: 'Unexpected error during file saving',
             additional: this.getWebDavErrorData(error),
           }),
         ],
@@ -87,11 +79,6 @@ export class LogFileService {
     }
   }
 
-  /**
-   * Converts provided buffer of a file to reading stream
-   * @param buffer buffer to convert
-   * @returns stream
-   */
   private bufferToStream(buffer: Buffer) {
     const readable = new Readable();
     readable._read = () => {};
@@ -100,89 +87,37 @@ export class LogFileService {
     return readable;
   }
 
-  /**
-   * Initializes the WebDAV client using credentials from the environment variables.
-   */
-  private initializeWebDavClient() {
-    this.client = createClient(
-      `http://${envVars.OWNCLOUD_HOST}:${envVars.OWNCLOUD_PORT}/remote.php/webdav/`,
-      {
-        username: envVars.OWNCLOUD_USER,
-        password: envVars.OWNCLOUD_PASSWORD,
-        maxBodyLength: 52428800,
-      },
-    );
-  }
-
-  /**
-   * Extracts the error data from the WebDAV error response.
-   *
-   * @param error - The error object to extract information from.
-   * @returns The response data from the WebDAV error, or null if not available.
-   */
   private getWebDavErrorData(error: any) {
     return error?.response?.data ?? null;
   }
 
-  /**
-   * Constructs the full path to the folder where log files will be stored.
-   *
-   * @param battleId - The id of the battle where file belongs to
-   * @returns The full folder path as a string.
-   */
   private getFolderPath(battleId: string) {
     const folderDataName = this.getDateFolderName();
     return `${this.logFilesRootFolder}/${folderDataName}/${battleId}`;
   }
-  /**
-   * Constructs the full path to the file, including the folder and the file name.
-   *
-   * @param battleId - The id of the battle where file belongs to
-   * @param player_id - The player's unique identifier to be included in the file name.
-   * @returns The full file path.
-   */
+
   private getFilePath(battleId: string, player_id: string) {
     const folderPath = this.getFolderPath(battleId);
     const fileName = this.getFileName(player_id);
     return `${folderPath}/${fileName}`;
   }
 
-  /**
-   * Generates a folder name based on the current date.
-   *
-   * @returns A string representing the folder name, formatted as DD-MM-YYYY.
-   */
   private getDateFolderName() {
     return this.getDateString();
   }
-  /**
-   * Generates a file name based on the current date, time, player _id, and a random string.
-   *
-   * @param player_id - The player's unique identifier to be included in the file name.
-   * @returns The file name as a string, formatted as DD-MM-YYYY_HH-MM-SS_playerID_random.log.
-   */
+
   private getFileName(player_id: string) {
     const dateString = this.getDateString();
     const timeString = this.getTimeString();
     const randomString = Math.floor(Math.random() * 1000000);
-
     return `${dateString}_${timeString}_${player_id}_${randomString}.log`;
   }
 
-  /**
-   * Gets the current date as a string formatted as DD-MM-YYYY.
-   *
-   * @returns A string representing the current date.
-   */
   private getDateString() {
     const now = new Date();
     return `${now.getDate()}-${now.getMonth() + 1}-${now.getFullYear()}`;
   }
-  /**
-   * Gets the current time as a string formatted as HH-MM-SS.
-   *
-   * @returns A string representing the current time.
-   */
+
   private getTimeString() {
     const now = new Date();
     return `${now.getHours()}-${now.getMinutes()}-${now.getSeconds()}`;

--- a/src/profile/dto/playerProfile.dto.ts
+++ b/src/profile/dto/playerProfile.dto.ts
@@ -13,5 +13,6 @@ export class PlayerProfileDto extends CreatePlayerDto {
   @IsProfileExists()
   @IsMongoId()
   @IsOptional()
-  override profile_id: string;
+  override profile_id = '';
+
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,12 +4,15 @@
     "types": ["node", "multer"],
     "noEmitOnError": true,
     "declaration": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "exclude": [
     "node_modules",
     "**/*.test.ts",
     "**/*.spec.ts",
     "**/__tests__/**"
-  ]
+  ],
+  "include": ["src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,39 @@
 {
   "compilerOptions": {
     /* Language and Environment */
-    "target": "ES2021",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "experimentalDecorators": true,                      /* Enable experimental support for TC39 stage 2 draft decorators. */
-    "emitDecoratorMetadata": true,                       /* Emit design-type metadata for decorated declarations in source files. */
+    "target": "ES2021",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
 
     /* Modules */
-    "module": "CommonJS",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
-    "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
-    "resolveJsonModule": true,                           /* Enable importing .json files. */
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "moduleDetection": "force",
+    "rootDir": "./src",
+    "baseUrl": "./",
+    "resolveJsonModule": true,
 
     /* Emit */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    "sourceMap": true,                                   /* Create source map files for emitted JavaScript files. */
-    "outDir": "./dist",                                  /* Specify an output folder for all emitted files. */
-    "removeComments": true,                              /* Disable emitting comments. */
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "removeComments": true,
 
     /* Interop Constraints */
-    "allowSyntheticDefaultImports": true,                /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": false,            /* Ensure that casing is correct in imports. */
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
 
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "noImplicitAny": false,                               /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": false,                            /* When type checking, take into account 'null' and 'undefined'. */
-    "strictBindCallApply": false,                         /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    "noFallthroughCasesInSwitch": false,               /* Enable error reporting for fallthrough cases in switch statements. */
+    "strict": true,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
+    "strictBindCallApply": false,
+    "noFallthroughCasesInSwitch": false,
 
     /* Completeness */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Brief description

When running `npm run start:dev` I ran into this issue:

```
`[8:35:17 PM] Starting compilation in watch mode...

[8:35:26 PM] Found 0 errors. Watching for file changes.

[dotenv@17.2.2] injecting env (0) from .env -- tip: ⚙️  specify custom .env file path with { path: '/custom/path/.env' }
C:\Users\Matias.DESKTOP-2SBTD6B\Desktop\Altzone-Server\dist\gameAnalytics\logFile.service.js:19
const webdav_1 = require("webdav");
                 ^

Error [ERR_REQUIRE_ESM]: require() of ES Module C:\Users\Matias.DESKTOP-2SBTD6B\Desktop\Altzone-Server\node_modules\webdav\dist\node\index.js from C:\Users\Matias.DESKTOP-2SBTD6B\Desktop\Altzone-Server\dist\gameAnalytics\logFile.service.js not supported.
Instead change the require of index.js in C:\Users\Matias.DESKTOP-2SBTD6B\Desktop\Altzone-Server\dist\gameAnalytics\logFile.service.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (C:\Users\Matias.DESKTOP-2SBTD6B\Desktop\Altzone-Server\dist\gameAnalytics\logFile.service.js:19:18) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.11.0
```


Turns out the project doesn't work out of the gate and required extensive tweaking to the source code to bypass this ESM vs CommonJS mismatch. This fixes said compatibility issue so that the issue doesn't repeat for anybody else. Otherwise this is a critical blocker for anyone just cloning the repo and following the README instructions.



Change list
- Added a helper utility to dynamically import ESM modules (createWebDavClient.ts)
- Updated logFile.service.ts to use the new helper
- TSConfig was adjusted (module: es2020) to allow import.meta.url usage safely



## Why this matters
Without this fix, the app throws ERR_REQUIRE_ESM when importing `webdav` using `require()` in compiled output as we can see in the output.

- Closes https://github.com/Alt-Org/Altzone-Server/issues/751