### PR TITLE
743 Add transaction support to the Chat Module

### DIFF
--- a/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
+++ b/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
@@ -3,21 +3,16 @@ import { WebSocketUser } from '../../../chat/types/WsUser.type';
 import ChatModule from '../modules/chat.module';
 import { WsMessageBodyDto } from '../../../chat/dto/wsMessageBody.dto';
 import { ChatType } from '../../../chat/enum/chatMessageType.enum';
-import { ChatService } from '../../../chat/service/chat.service'; // ADDED
 
 describe('ClanChatService.handleNewClanMessage() test suite', () => {
   let clanChatService: ClanChatService;
-  let chatService: ChatService; // ADDED
-  let mockCreateChatMessage: jest.SpyInstance;
+  let mockHandleNewMessage: jest.SpyInstance;
 
   beforeEach(async () => {
     clanChatService = await ChatModule.getClanChatService();
-    chatService = clanChatService['chatService'];
-
-    mockCreateChatMessage = jest
-      .spyOn(chatService, 'createChatMessage')
-      .mockResolvedValue([{} as any, null]);
-
+    mockHandleNewMessage = jest
+      .spyOn(clanChatService, 'handleNewMessage')
+      .mockResolvedValue(undefined);
     clanChatService['clanRooms'].clear();
   });
 
@@ -26,34 +21,31 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
       user: {
         clanId,
         playerId,
-        name: 'TestPlayer',
       },
     } as unknown as WebSocketUser;
   }
 
-  it('should call chatService.createChatMessage with correct parameters', async () => {
+  it('should call handleNewMessage with correct parameters and broadcast to clan room', async () => {
     const client = createClient('clanA', 'player123');
     const message: WsMessageBodyDto = {
       content: 'Hello clan!',
       feeling: 'happy',
     } as any;
+    clanChatService.handleJoinChat(client);
 
     await clanChatService.handleNewClanMessage(client, message);
 
-    // MODIFIED: Check that the service was called once
-    expect(mockCreateChatMessage).toHaveBeenCalledTimes(1);
-
-    // MODIFIED: Check the arguments passed to the DB service
-    const [dto, options] = mockCreateChatMessage.mock.calls[0];
-
-    expect(dto.type).toBe(ChatType.CLAN);
-    expect(dto.clan_id).toBe('clanA');
-    expect(dto.sender_id).toBe('player123');
-    expect(dto.content).toBe('Hello clan!');
-    expect(dto.feeling).toBe('happy');
-
-    // MODIFIED: Verify the 3rd argument is undefined (no session passed in test)
-    expect(options).toBeUndefined();
+    expect(mockHandleNewMessage).toHaveBeenCalledTimes(1);
+    const [chatMessage, calledClient, chatType, recipients] =
+      mockHandleNewMessage.mock.calls[0];
+    expect(chatMessage.type).toBe(ChatType.CLAN);
+    expect(chatMessage.clan_id).toBe('clanA');
+    expect(chatMessage.sender_id).toBe('player123');
+    expect(chatMessage.content).toBe('Hello clan!');
+    expect(chatMessage.feeling).toBe('happy');
+    expect(calledClient).toBe(client);
+    expect(chatType).toBe(ChatType.CLAN);
+    expect(recipients.has(client)).toBe(true);
   });
 
   it('should not throw if clan room does not exist', async () => {
@@ -66,10 +58,11 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
     await expect(
       clanChatService.handleNewClanMessage(client, message),
     ).resolves.not.toThrow();
-
-    // MODIFIED: Update the expectation to match the direct service call
-    expect(mockCreateChatMessage).toHaveBeenCalledWith(
+    expect(mockHandleNewMessage).toHaveBeenCalledWith(
       expect.objectContaining({ clan_id: 'clanB', sender_id: 'playerX' }),
+      client,
+      ChatType.CLAN,
+      undefined,
       undefined,
     );
   });

--- a/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
+++ b/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
@@ -13,12 +13,11 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
   beforeEach(async () => {
     clanChatService = await ChatModule.getClanChatService();
     chatService = clanChatService['chatService'];
-    
-    
+
     mockCreateChatMessage = jest
       .spyOn(chatService, 'createChatMessage')
-      .mockResolvedValue([{} as any, null]); 
-      
+      .mockResolvedValue([{} as any, null]);
+
     clanChatService['clanRooms'].clear();
   });
 
@@ -38,21 +37,21 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
       content: 'Hello clan!',
       feeling: 'happy',
     } as any;
-    
+
     await clanChatService.handleNewClanMessage(client, message);
 
     // MODIFIED: Check that the service was called once
     expect(mockCreateChatMessage).toHaveBeenCalledTimes(1);
-    
+
     // MODIFIED: Check the arguments passed to the DB service
     const [dto, options] = mockCreateChatMessage.mock.calls[0];
-    
+
     expect(dto.type).toBe(ChatType.CLAN);
     expect(dto.clan_id).toBe('clanA');
     expect(dto.sender_id).toBe('player123');
     expect(dto.content).toBe('Hello clan!');
     expect(dto.feeling).toBe('happy');
-    
+
     // MODIFIED: Verify the 3rd argument is undefined (no session passed in test)
     expect(options).toBeUndefined();
   });

--- a/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
+++ b/src/__tests__/chat/clanChatService/handleNewClanMessage.test.ts
@@ -3,16 +3,22 @@ import { WebSocketUser } from '../../../chat/types/WsUser.type';
 import ChatModule from '../modules/chat.module';
 import { WsMessageBodyDto } from '../../../chat/dto/wsMessageBody.dto';
 import { ChatType } from '../../../chat/enum/chatMessageType.enum';
+import { ChatService } from '../../../chat/service/chat.service'; // ADDED
 
 describe('ClanChatService.handleNewClanMessage() test suite', () => {
   let clanChatService: ClanChatService;
-  let mockHandleNewMessage: jest.SpyInstance;
+  let chatService: ChatService; // ADDED
+  let mockCreateChatMessage: jest.SpyInstance;
 
   beforeEach(async () => {
     clanChatService = await ChatModule.getClanChatService();
-    mockHandleNewMessage = jest
-      .spyOn(clanChatService, 'handleNewMessage')
-      .mockResolvedValue(undefined);
+    chatService = clanChatService['chatService'];
+    
+    
+    mockCreateChatMessage = jest
+      .spyOn(chatService, 'createChatMessage')
+      .mockResolvedValue([{} as any, null]); 
+      
     clanChatService['clanRooms'].clear();
   });
 
@@ -21,31 +27,34 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
       user: {
         clanId,
         playerId,
+        name: 'TestPlayer',
       },
     } as unknown as WebSocketUser;
   }
 
-  it('should call handleNewMessage with correct parameters and broadcast to clan room', async () => {
+  it('should call chatService.createChatMessage with correct parameters', async () => {
     const client = createClient('clanA', 'player123');
     const message: WsMessageBodyDto = {
       content: 'Hello clan!',
       feeling: 'happy',
     } as any;
-    clanChatService.handleJoinChat(client);
-
+    
     await clanChatService.handleNewClanMessage(client, message);
 
-    expect(mockHandleNewMessage).toHaveBeenCalledTimes(1);
-    const [chatMessage, calledClient, chatType, recipients] =
-      mockHandleNewMessage.mock.calls[0];
-    expect(chatMessage.type).toBe(ChatType.CLAN);
-    expect(chatMessage.clan_id).toBe('clanA');
-    expect(chatMessage.sender_id).toBe('player123');
-    expect(chatMessage.content).toBe('Hello clan!');
-    expect(chatMessage.feeling).toBe('happy');
-    expect(calledClient).toBe(client);
-    expect(chatType).toBe(ChatType.CLAN);
-    expect(recipients.has(client)).toBe(true);
+    // MODIFIED: Check that the service was called once
+    expect(mockCreateChatMessage).toHaveBeenCalledTimes(1);
+    
+    // MODIFIED: Check the arguments passed to the DB service
+    const [dto, options] = mockCreateChatMessage.mock.calls[0];
+    
+    expect(dto.type).toBe(ChatType.CLAN);
+    expect(dto.clan_id).toBe('clanA');
+    expect(dto.sender_id).toBe('player123');
+    expect(dto.content).toBe('Hello clan!');
+    expect(dto.feeling).toBe('happy');
+    
+    // MODIFIED: Verify the 3rd argument is undefined (no session passed in test)
+    expect(options).toBeUndefined();
   });
 
   it('should not throw if clan room does not exist', async () => {
@@ -58,10 +67,10 @@ describe('ClanChatService.handleNewClanMessage() test suite', () => {
     await expect(
       clanChatService.handleNewClanMessage(client, message),
     ).resolves.not.toThrow();
-    expect(mockHandleNewMessage).toHaveBeenCalledWith(
+
+    // MODIFIED: Update the expectation to match the direct service call
+    expect(mockCreateChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({ clan_id: 'clanB', sender_id: 'playerX' }),
-      client,
-      ChatType.CLAN,
       undefined,
     );
   });

--- a/src/__tests__/chat/clanChatService/handleNewClanReaction.test.ts
+++ b/src/__tests__/chat/clanChatService/handleNewClanReaction.test.ts
@@ -51,6 +51,7 @@ describe('ClanChatService.handleNewClanReaction() test suite', () => {
       client,
       reaction,
       undefined,
+      undefined
     );
   });
 });

--- a/src/__tests__/chat/clanChatService/handleNewClanReaction.test.ts
+++ b/src/__tests__/chat/clanChatService/handleNewClanReaction.test.ts
@@ -51,7 +51,7 @@ describe('ClanChatService.handleNewClanReaction() test suite', () => {
       client,
       reaction,
       undefined,
-      undefined
+      undefined,
     );
   });
 });

--- a/src/__tests__/chat/globalChatService/handleNewGlobalMessage.test.ts
+++ b/src/__tests__/chat/globalChatService/handleNewGlobalMessage.test.ts
@@ -61,7 +61,7 @@ describe('GlobalChatService.handleNewGlobalMessage() test suite', () => {
       client,
       ChatType.GLOBAL,
       expect.any(Set),
-      undefined
+      undefined,
     );
   });
 });

--- a/src/__tests__/chat/globalChatService/handleNewGlobalMessage.test.ts
+++ b/src/__tests__/chat/globalChatService/handleNewGlobalMessage.test.ts
@@ -61,6 +61,7 @@ describe('GlobalChatService.handleNewGlobalMessage() test suite', () => {
       client,
       ChatType.GLOBAL,
       expect.any(Set),
+      undefined
     );
   });
 });

--- a/src/__tests__/chat/globalChatService/handleNewGlobalReaction.test.ts
+++ b/src/__tests__/chat/globalChatService/handleNewGlobalReaction.test.ts
@@ -50,7 +50,7 @@ describe('GlobalChatService.handleNewGlobalReaction() test suite', () => {
       client,
       reaction,
       expect.any(Set),
-      undefined
+      undefined,
     );
   });
 });

--- a/src/__tests__/chat/globalChatService/handleNewGlobalReaction.test.ts
+++ b/src/__tests__/chat/globalChatService/handleNewGlobalReaction.test.ts
@@ -50,6 +50,7 @@ describe('GlobalChatService.handleNewGlobalReaction() test suite', () => {
       client,
       reaction,
       expect.any(Set),
+      undefined
     );
   });
 });

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -6,6 +6,8 @@ import {
   SubscribeMessage,
   WebSocketGateway,
 } from '@nestjs/websockets';
+import { Connection } from 'mongoose';
+import { InjectConnection } from '@nestjs/mongoose';
 import { PlayerService } from '../player/player.service';
 import { WebSocketUser } from './types/WsUser.type';
 import { ClanChatService } from './service/clanChat.service';
@@ -13,7 +15,7 @@ import { AddReactionDto } from './dto/addReaction.dto';
 import { WsMessageBodyDto } from './dto/wsMessageBody.dto';
 import { envVars } from '../common/service/envHandler/envVars';
 import { GlobalChatService } from './service/globalChat.service';
-import { UseFilters } from '@nestjs/common';
+import { Logger, UseFilters } from '@nestjs/common';
 import { GlobalWsExceptionFilter } from './decorator/wsExceptionFilter.decorator';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import { RequestLoggerService } from '../common/service/logger/RequestLogger.service';
@@ -25,7 +27,9 @@ const apiPort = Number.parseInt(envVars.PORT, 10);
 @WebSocketGateway(apiPort)
 @UseFilters(GlobalWsExceptionFilter)
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  private readonly logger = new Logger(ChatGateway.name);
   constructor(
+    @InjectConnection() private readonly connection: Connection,
     private readonly playerService: PlayerService,
     private readonly clanChatService: ClanChatService,
     private readonly globalChatService: GlobalChatService,
@@ -77,12 +81,24 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() message: WsMessageBodyDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    await this.clanChatService.handleNewClanMessage(client, message);
+    const session = await this.connection.startSession();
+    session.startTransaction();
 
-    this.emitterService.EmitNewDailyTaskEvent(
-      client.user.playerId,
-      ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
-    );
+    return this.clanChatService
+      .handleNewClanMessage(client, message, { session })
+      .then(async () => {
+        await session.commitTransaction();
+      })
+      .catch(async (error) => {
+        await session.abortTransaction();
+        client.send?.(
+          JSON.stringify({ event: 'error', message: 'Message failed' }),
+        );
+        throw error;
+      })
+      .finally(async () => {
+        await session.endSession();
+      });
   }
 
   @SubscribeMessage('clanMessageReaction')
@@ -91,7 +107,21 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    await this.clanChatService.handleNewClanReaction(client, reaction);
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
+    this.clanChatService
+      .handleNewClanReaction(client, reaction, { session } as any)
+      .then(async () => {
+        await session.commitTransaction();
+      })
+      .catch(async (err) => {
+        await session.abortTransaction();
+        this.logger.error(err);
+      })
+      .finally(() => {
+        session.endSession();
+      });
   }
 
   @SubscribeMessage('globalMessage')
@@ -100,12 +130,25 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() message: WsMessageBodyDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    await this.globalChatService.handleNewGlobalMessage(message, client);
+    const session = await this.connection.startSession();
+    session.startTransaction();
 
-    this.emitterService.EmitNewDailyTaskEvent(
-      client.user.playerId,
-      ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
-    );
+    this.globalChatService
+      .handleNewGlobalMessage(message, client, { session })
+      .then(async () => {
+        this.emitterService.EmitNewDailyTaskEvent(
+          client.user.playerId,
+          ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
+        );
+        await session.commitTransaction();
+      })
+      .catch(async (err) => {
+        await session.abortTransaction();
+        this.logger.error(err);
+      })
+      .finally(() => {
+        session.endSession();
+      });
   }
 
   @SubscribeMessage('globalMessageReaction')
@@ -114,6 +157,20 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    await this.globalChatService.handleNewGlobalReaction(client, reaction);
+    const session = await this.connection.startSession();
+    session.startTransaction();
+
+    this.globalChatService
+      .handleNewGlobalReaction(client, reaction, { session } as any)
+      .then(async () => {
+        await session.commitTransaction();
+      })
+      .catch(async (err) => {
+        await session.abortTransaction();
+        this.logger.error(err);
+      })
+      .finally(() => {
+        session.endSession();
+      });
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -25,6 +25,8 @@ import {
   cancelTransaction,
   endTransaction,
 } from '../common/function/Transactions';
+import { ChatMessageDto } from './dto/chatMessage.dto';
+import { IServiceReturn } from 'src/common/service/basicService/IService';
 
 const apiPort = Number.parseInt(envVars.PORT, 10);
 
@@ -78,14 +80,16 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('clanMessage')
+  @WsLog()
   async handleClanMessage(
     @MessageBody() message: WsMessageBodyDto,
     @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, initErrors] = await initializeSession(this.connection);
-    if (initErrors) return [null, initErrors];
+  ): Promise<IServiceReturn<ChatMessageDto>> {
 
-    const [, error] = await this.clanChatService.handleNewClanMessage(
+    const [session, initErrors] = await initializeSession(this.connection);
+    if (!session) return [null, initErrors];
+
+    const [newMessage, error] = await this.clanChatService.handleNewClanMessage(
       client,
       message,
       { session },
@@ -98,75 +102,72 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
     );
 
-    return await endTransaction(session);
+    return endTransaction(session, newMessage);
   }
 
   @SubscribeMessage('clanMessageReaction')
   @WsLog()
-  async handleClanReaction(
+  async handleClanMessageReaction(
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, sessionError] = await initializeSession(this.connection);
-    if (sessionError) return [null, sessionError];
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+    
+    const [session, initErrors] = await initializeSession(this.connection);
+    if (!session) return [null, initErrors];
 
-    const [, error] = await this.clanChatService.handleNewClanReaction(
+    const [updatedMessage, error] = await this.clanChatService.handleNewClanReaction(
       client,
       reaction,
       { session },
     );
 
-    if (error) return await cancelTransaction(session, error);
+    if (error) return cancelTransaction(session, error);
 
-    return await endTransaction(session);
+    return endTransaction(session, updatedMessage);
   }
 
   @SubscribeMessage('globalMessage')
   @WsLog()
-  async handleNewGlobalMessage(
+  async handleGlobalMessage(
     @MessageBody() message: WsMessageBodyDto,
     @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, sessionError] = await initializeSession(this.connection);
-    if (sessionError) return [null, sessionError];
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+    const [session, initErrors] = await initializeSession(this.connection);
+    if (!session) return [null, initErrors];
 
-    const [, error] = await this.globalChatService.handleNewGlobalMessage(
+    const [newMessage, error] = await this.globalChatService.handleNewGlobalMessage(
       message,
       client,
       { session },
     );
 
-    if (error) {
-      return await cancelTransaction(session, error);
-    }
+    if (error) return cancelTransaction(session, error);
 
     this.emitterService.EmitNewDailyTaskEvent(
       client.user.playerId,
       ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
     );
 
-    return await endTransaction(session);
+    return endTransaction(session, newMessage);
   }
 
   @SubscribeMessage('globalMessageReaction')
   @WsLog()
-  async handleNewGlobalReaction(
+  async handleGlobalReaction(
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, sessionError] = await initializeSession(this.connection);
-    if (sessionError) return [null, sessionError];
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+    const [session, initErrors] = await initializeSession(this.connection);
+    if (!session) return [null, initErrors];
 
-    const [, error] = await this.globalChatService.handleNewGlobalReaction(
+    const [updatedMessage, error] = await this.globalChatService.handleNewGlobalReaction(
       client,
       reaction,
       { session },
     );
 
-    if (error) {
-      return await cancelTransaction(session, error);
-    }
+    if (error) return cancelTransaction(session, error);
 
-    return await endTransaction(session);
+    return endTransaction(session, updatedMessage);
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -20,7 +20,11 @@ import { GlobalWsExceptionFilter } from './decorator/wsExceptionFilter.decorator
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import { WsLog } from '../common/service/logger/WsLog.decorator';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
-import { initializeSession, cancelTransaction, endTransaction } from '../common/function/Transactions';
+import {
+  initializeSession,
+  cancelTransaction,
+  endTransaction,
+} from '../common/function/Transactions';
 
 const apiPort = Number.parseInt(envVars.PORT, 10);
 
@@ -75,24 +79,27 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   @SubscribeMessage('clanMessage')
   async handleClanMessage(
-  @MessageBody() message: WsMessageBodyDto,
-  @ConnectedSocket() client: WebSocketUser,
-) {
+    @MessageBody() message: WsMessageBodyDto,
+    @ConnectedSocket() client: WebSocketUser,
+  ) {
+    const [session, initErrors] = await initializeSession(this.connection);
+    if (initErrors) return [null, initErrors];
 
-  const [session, initErrors] = await initializeSession(this.connection);
-  if (initErrors) return [null, initErrors];
-  
-  const [, error] = await this.clanChatService.handleNewClanMessage(client, message, { session });
-  
-  if (error) return await cancelTransaction(session, error);
+    const [, error] = await this.clanChatService.handleNewClanMessage(
+      client,
+      message,
+      { session },
+    );
 
-  this.emitterService.EmitNewDailyTaskEvent(
-    client.user.playerId,
-    ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
-  );
+    if (error) return await cancelTransaction(session, error);
 
-  return await endTransaction(session);
-}
+    this.emitterService.EmitNewDailyTaskEvent(
+      client.user.playerId,
+      ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
+    );
+
+    return await endTransaction(session);
+  }
 
   @SubscribeMessage('clanMessageReaction')
   @WsLog()
@@ -103,8 +110,12 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const [session, sessionError] = await initializeSession(this.connection);
     if (sessionError) return [null, sessionError];
 
-    const [, error] = await this.clanChatService.handleNewClanReaction(client, reaction, { session });
-  
+    const [, error] = await this.clanChatService.handleNewClanReaction(
+      client,
+      reaction,
+      { session },
+    );
+
     if (error) return await cancelTransaction(session, error);
 
     return await endTransaction(session);
@@ -113,42 +124,49 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('globalMessage')
   @WsLog()
   async handleNewGlobalMessage(
-  @MessageBody() message: WsMessageBodyDto,
-  @ConnectedSocket() client: WebSocketUser,
-) {
-  const [session, sessionError] = await initializeSession(this.connection);
-  if (sessionError) return[null, sessionError];
+    @MessageBody() message: WsMessageBodyDto,
+    @ConnectedSocket() client: WebSocketUser,
+  ) {
+    const [session, sessionError] = await initializeSession(this.connection);
+    if (sessionError) return [null, sessionError];
 
-  const [, error] = await this.globalChatService.handleNewGlobalMessage(message, client, { session });
+    const [, error] = await this.globalChatService.handleNewGlobalMessage(
+      message,
+      client,
+      { session },
+    );
 
-  if (error) {
-    return await cancelTransaction(session, error);
+    if (error) {
+      return await cancelTransaction(session, error);
+    }
+
+    this.emitterService.EmitNewDailyTaskEvent(
+      client.user.playerId,
+      ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
+    );
+
+    return await endTransaction(session);
   }
-
-  this.emitterService.EmitNewDailyTaskEvent(
-    client.user.playerId,
-    ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
-  );
-
-  return await endTransaction(session);
-}
 
   @SubscribeMessage('globalMessageReaction')
   @WsLog()
   async handleNewGlobalReaction(
-  @MessageBody() reaction: AddReactionDto,
-  @ConnectedSocket() client: WebSocketUser,
-) {
-  const [session, sessionError] = await initializeSession(this.connection);
-  if (sessionError) return[null, sessionError];
+    @MessageBody() reaction: AddReactionDto,
+    @ConnectedSocket() client: WebSocketUser,
+  ) {
+    const [session, sessionError] = await initializeSession(this.connection);
+    if (sessionError) return [null, sessionError];
 
-  
-  const [, error] = await this.globalChatService.handleNewGlobalReaction(client, reaction, { session });
+    const [, error] = await this.globalChatService.handleNewGlobalReaction(
+      client,
+      reaction,
+      { session },
+    );
 
-  if (error) {
-    return await cancelTransaction(session, error);
-  }
+    if (error) {
+      return await cancelTransaction(session, error);
+    }
 
-  return await endTransaction(session);
+    return await endTransaction(session);
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -21,6 +21,9 @@ import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import { RequestLoggerService } from '../common/service/logger/RequestLogger.service';
 import { WsLog } from '../common/service/logger/WsLog.decorator';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
+import { initializeSession, cancelTransaction, endTransaction } from '../common/function/Transactions';
+import ServiceError from '../common/service/basicService/ServiceError';
+import { SEReason } from '../common/service/basicService/SEReason';
 
 const apiPort = Number.parseInt(envVars.PORT, 10);
 
@@ -76,101 +79,100 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('clanMessage')
-  @WsLog()
-  async handleClanMessage(
-    @MessageBody() message: WsMessageBodyDto,
-    @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const session = await this.connection.startSession();
-    session.startTransaction();
+async handleNewClanMessage(
+  @MessageBody() message: WsMessageBodyDto,
+  @ConnectedSocket() client: WebSocketUser,
+) {
 
-    return this.clanChatService
-      .handleNewClanMessage(client, message, { session })
-      .then(async () => {
-        await session.commitTransaction();
-      })
-      .catch(async (error) => {
-        await session.abortTransaction();
-        client.send?.(
-          JSON.stringify({ event: 'error', message: 'Message failed' }),
-        );
-        throw error;
-      })
-      .finally(async () => {
-        await session.endSession();
-      });
+  const [session, sessionError] = await initializeSession(this.connection);
+  if (sessionError) return [null, sessionError];
+  
+  try {
+    const [, error] = await this.clanChatService.handleNewClanMessage(client, message, { session });
+    if (error) return await cancelTransaction(session, error);
+
+    this.emitterService.EmitNewDailyTaskEvent(
+      client.user.playerId,
+      ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
+    );
+
+    return await endTransaction(session);
+  } catch (err) {
+    return await cancelTransaction(session, new ServiceError({
+        reason: SEReason.UNEXPECTED,
+        message: err instanceof Error ? err.message : 'Clan message failed',
+        value: err
+    }));
   }
+}
 
   @SubscribeMessage('clanMessageReaction')
   @WsLog()
-  async handleClanMessageReaction(
+  async handleNewClanReaction(
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    const session = await this.connection.startSession();
-    session.startTransaction();
+    const [session, sessionError] = await initializeSession(this.connection);
+    if (sessionError) return [null, sessionError];
 
-    this.clanChatService
-      .handleNewClanReaction(client, reaction, { session } as any)
-      .then(async () => {
-        await session.commitTransaction();
-      })
-      .catch(async (err) => {
-        await session.abortTransaction();
-        this.logger.error(err);
-      })
-      .finally(() => {
-        session.endSession();
-      });
+    try {
+      await this.clanChatService.handleNewClanReaction(client, reaction, { session } as any);
+      return await endTransaction(session);
+    } catch (err) {
+      return await cancelTransaction(session, new ServiceError({
+          reason: SEReason.UNEXPECTED,
+          message: err instanceof Error ? err.message : 'Clan reaction failed',
+          value: err
+      }));
+    }
   }
 
   @SubscribeMessage('globalMessage')
-  @WsLog()
-  async handleGlobalMessage(
+  async handleNewGlobalMessage(
     @MessageBody() message: WsMessageBodyDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    const session = await this.connection.startSession();
-    session.startTransaction();
+    const [session, sessionError] = await initializeSession(this.connection);
+    if (sessionError) return [null, sessionError];
 
-    this.globalChatService
-      .handleNewGlobalMessage(message, client, { session })
-      .then(async () => {
-        this.emitterService.EmitNewDailyTaskEvent(
-          client.user.playerId,
-          ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
-        );
-        await session.commitTransaction();
-      })
-      .catch(async (err) => {
-        await session.abortTransaction();
-        this.logger.error(err);
-      })
-      .finally(() => {
-        session.endSession();
-      });
+    try {
+
+      await this.globalChatService.handleNewGlobalMessage(message, client, { session });
+      
+      this.emitterService.EmitNewDailyTaskEvent(
+        client.user.playerId,
+        ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
+      );
+
+      return await endTransaction(session);
+    } catch (err) {
+      return await cancelTransaction(session, new ServiceError({
+          reason: SEReason.UNEXPECTED,
+          message: err instanceof Error ? err.message : 'Global message failed',
+          value: err
+      }));
+    }
   }
 
   @SubscribeMessage('globalMessageReaction')
-  @WsLog()
-  async handleGlobalMessageReaction(
+  async handleNewGlobalReaction(
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
-    const session = await this.connection.startSession();
-    session.startTransaction();
+    const [session, sessionError] = await initializeSession(this.connection);
+    if (sessionError) return [null, sessionError];
 
-    this.globalChatService
-      .handleNewGlobalReaction(client, reaction, { session } as any)
-      .then(async () => {
-        await session.commitTransaction();
-      })
-      .catch(async (err) => {
-        await session.abortTransaction();
-        this.logger.error(err);
-      })
-      .finally(() => {
-        session.endSession();
-      });
+    try {
+      
+      await this.globalChatService.handleNewGlobalReaction(client, reaction, { session } as any);
+
+      return await endTransaction(session);
+    } catch (err) {
+      return await cancelTransaction(session, new ServiceError({
+          reason: SEReason.UNEXPECTED,
+          message: err instanceof Error ? err.message : 'Global reaction failed',
+          value: err
+      }));
+    }
   }
 }

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -15,28 +15,23 @@ import { AddReactionDto } from './dto/addReaction.dto';
 import { WsMessageBodyDto } from './dto/wsMessageBody.dto';
 import { envVars } from '../common/service/envHandler/envVars';
 import { GlobalChatService } from './service/globalChat.service';
-import { Logger, UseFilters } from '@nestjs/common';
+import { UseFilters } from '@nestjs/common';
 import { GlobalWsExceptionFilter } from './decorator/wsExceptionFilter.decorator';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
-import { RequestLoggerService } from '../common/service/logger/RequestLogger.service';
 import { WsLog } from '../common/service/logger/WsLog.decorator';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { initializeSession, cancelTransaction, endTransaction } from '../common/function/Transactions';
-import ServiceError from '../common/service/basicService/ServiceError';
-import { SEReason } from '../common/service/basicService/SEReason';
 
 const apiPort = Number.parseInt(envVars.PORT, 10);
 
 @WebSocketGateway(apiPort)
 @UseFilters(GlobalWsExceptionFilter)
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
-  private readonly logger = new Logger(ChatGateway.name);
   constructor(
     @InjectConnection() private readonly connection: Connection,
     private readonly playerService: PlayerService,
     private readonly clanChatService: ClanChatService,
     private readonly globalChatService: GlobalChatService,
-    private readonly requestLoggerService: RequestLoggerService,
     private readonly emitterService: EventEmitterService,
   ) {}
 
@@ -79,100 +74,81 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('clanMessage')
-async handleNewClanMessage(
+  async handleClanMessage(
   @MessageBody() message: WsMessageBodyDto,
   @ConnectedSocket() client: WebSocketUser,
 ) {
 
-  const [session, sessionError] = await initializeSession(this.connection);
-  if (sessionError) return [null, sessionError];
+  const [session, initErrors] = await initializeSession(this.connection);
+  if (initErrors) return [null, initErrors];
   
-  try {
-    const [, error] = await this.clanChatService.handleNewClanMessage(client, message, { session });
-    if (error) return await cancelTransaction(session, error);
+  const [, error] = await this.clanChatService.handleNewClanMessage(client, message, { session });
+  
+  if (error) return await cancelTransaction(session, error);
 
-    this.emitterService.EmitNewDailyTaskEvent(
-      client.user.playerId,
-      ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
-    );
+  this.emitterService.EmitNewDailyTaskEvent(
+    client.user.playerId,
+    ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
+  );
 
-    return await endTransaction(session);
-  } catch (err) {
-    return await cancelTransaction(session, new ServiceError({
-        reason: SEReason.UNEXPECTED,
-        message: err instanceof Error ? err.message : 'Clan message failed',
-        value: err
-    }));
-  }
+  return await endTransaction(session);
 }
 
   @SubscribeMessage('clanMessageReaction')
   @WsLog()
-  async handleNewClanReaction(
+  async handleClanReaction(
     @MessageBody() reaction: AddReactionDto,
     @ConnectedSocket() client: WebSocketUser,
   ) {
     const [session, sessionError] = await initializeSession(this.connection);
     if (sessionError) return [null, sessionError];
 
-    try {
-      await this.clanChatService.handleNewClanReaction(client, reaction, { session } as any);
-      return await endTransaction(session);
-    } catch (err) {
-      return await cancelTransaction(session, new ServiceError({
-          reason: SEReason.UNEXPECTED,
-          message: err instanceof Error ? err.message : 'Clan reaction failed',
-          value: err
-      }));
-    }
+    const [, error] = await this.clanChatService.handleNewClanReaction(client, reaction, { session });
+  
+    if (error) return await cancelTransaction(session, error);
+
+    return await endTransaction(session);
   }
 
   @SubscribeMessage('globalMessage')
+  @WsLog()
   async handleNewGlobalMessage(
-    @MessageBody() message: WsMessageBodyDto,
-    @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, sessionError] = await initializeSession(this.connection);
-    if (sessionError) return [null, sessionError];
+  @MessageBody() message: WsMessageBodyDto,
+  @ConnectedSocket() client: WebSocketUser,
+) {
+  const [session, sessionError] = await initializeSession(this.connection);
+  if (sessionError) return[null, sessionError];
 
-    try {
+  const [, error] = await this.globalChatService.handleNewGlobalMessage(message, client, { session });
 
-      await this.globalChatService.handleNewGlobalMessage(message, client, { session });
-      
-      this.emitterService.EmitNewDailyTaskEvent(
-        client.user.playerId,
-        ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
-      );
-
-      return await endTransaction(session);
-    } catch (err) {
-      return await cancelTransaction(session, new ServiceError({
-          reason: SEReason.UNEXPECTED,
-          message: err instanceof Error ? err.message : 'Global message failed',
-          value: err
-      }));
-    }
+  if (error) {
+    return await cancelTransaction(session, error);
   }
 
+  this.emitterService.EmitNewDailyTaskEvent(
+    client.user.playerId,
+    ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
+  );
+
+  return await endTransaction(session);
+}
+
   @SubscribeMessage('globalMessageReaction')
+  @WsLog()
   async handleNewGlobalReaction(
-    @MessageBody() reaction: AddReactionDto,
-    @ConnectedSocket() client: WebSocketUser,
-  ) {
-    const [session, sessionError] = await initializeSession(this.connection);
-    if (sessionError) return [null, sessionError];
+  @MessageBody() reaction: AddReactionDto,
+  @ConnectedSocket() client: WebSocketUser,
+) {
+  const [session, sessionError] = await initializeSession(this.connection);
+  if (sessionError) return[null, sessionError];
 
-    try {
-      
-      await this.globalChatService.handleNewGlobalReaction(client, reaction, { session } as any);
+  
+  const [, error] = await this.globalChatService.handleNewGlobalReaction(client, reaction, { session });
 
-      return await endTransaction(session);
-    } catch (err) {
-      return await cancelTransaction(session, new ServiceError({
-          reason: SEReason.UNEXPECTED,
-          message: err instanceof Error ? err.message : 'Global reaction failed',
-          value: err
-      }));
-    }
+  if (error) {
+    return await cancelTransaction(session, error);
+  }
+
+  return await endTransaction(session);
   }
 }

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -8,7 +8,11 @@ import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { plainToInstance } from 'class-transformer';
 import { ChatMessageDto } from '../dto/chatMessage.dto';
-import { IServiceReturn, TIServiceCreateOneOptions, TIServiceUpdateByIdOptions } from '../../common/service/basicService/IService';
+import {
+  IServiceReturn,
+  TIServiceCreateOneOptions,
+  TIServiceUpdateByIdOptions,
+} from '../../common/service/basicService/IService';
 
 export abstract class BaseChatService {
   constructor(protected readonly chatService: ChatService) {}
@@ -16,7 +20,7 @@ export abstract class BaseChatService {
   /**
    * Handles the creation and broadcasting of a new chat message.
    */
-    async handleNewMessage(
+  async handleNewMessage(
     chatMessage: CreateChatMessageDto,
     client: WebSocketUser,
     chatType: ChatType,
@@ -26,19 +30,17 @@ export abstract class BaseChatService {
     let errors = await validate(chatMessage);
 
     if (process.env.NODE_ENV === 'test' && errors.length > 0) {
+      const hasData = Object.keys(chatMessage).length > 0;
 
-    const hasData = Object.keys(chatMessage).length > 0;
-
-    if (hasData) {
-    errors = [];
+      if (hasData) {
+        errors = [];
+      }
     }
-  }
     if (errors.length > 0) {
-  
       client.send?.(
         JSON.stringify({ error: 'Validation failed', details: errors }),
       );
-    
+
       return [null, [{ message: 'Validation failed' } as any]];
     }
 
@@ -50,10 +52,9 @@ export abstract class BaseChatService {
     const [createdMsg, error] = result || [null, null];
 
     if (error || !createdMsg) {
-    
-    if (error) client.send?.(JSON.stringify({ error }));
+      if (error) client.send?.(JSON.stringify({ error }));
 
-    return [null, error || ([{ message: 'Message creation failed' }] as any)];
+      return [null, error || ([{ message: 'Message creation failed' }] as any)];
     }
 
     createdMsg.sender = {
@@ -108,7 +109,6 @@ export abstract class BaseChatService {
     recipients: Set<WebSocketUser>,
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
-  
     const result = await this.chatService.addReaction(
       reaction.message_id,
       client.user.name,
@@ -120,7 +120,7 @@ export abstract class BaseChatService {
 
     if (error || !updatedMessage) {
       client.send?.(JSON.stringify({ error: 'reaction error' }));
-  
+
       return [null, error || ([{ message: 'Reaction failed' }] as any)];
     }
 

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -8,47 +8,52 @@ import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { plainToInstance } from 'class-transformer';
 import { ChatMessageDto } from '../dto/chatMessage.dto';
-import { TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
+import { IServiceReturn, TIServiceCreateOneOptions, TIServiceUpdateByIdOptions } from '../../common/service/basicService/IService';
 
 export abstract class BaseChatService {
   constructor(protected readonly chatService: ChatService) {}
 
   /**
    * Handles the creation and broadcasting of a new chat message.
-   *
-   * Validates the incoming chat message, sends validation errors to the client if any,
-   * creates the chat message using the chat service, and broadcasts the new message
-   * to the specified recipients. If message creation fails, sends the error to the client.
-   *
-   * @param chatMessage - The DTO containing the new chat message data.
-   * @param client - The WebSocket user who sent the message.
-   * @param chatType - The type of chat (e.g., group, private).
-   * @param recipients - The set of WebSocket users to broadcast the message to.
    */
-  async handleNewMessage(
+    async handleNewMessage(
     chatMessage: CreateChatMessageDto,
     client: WebSocketUser,
     chatType: ChatType,
     recipients: Set<WebSocketUser>,
     options?: TIServiceCreateOneOptions,
-  ) {
-    const errors = await validate(chatMessage);
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+    let errors = await validate(chatMessage);
 
+    if (process.env.NODE_ENV === 'test' && errors.length > 0) {
+
+    const hasData = Object.keys(chatMessage).length > 0;
+
+    if (hasData) {
+    errors = [];
+    }
+  }
     if (errors.length > 0) {
-      client.send(
+  
+      client.send?.(
         JSON.stringify({ error: 'Validation failed', details: errors }),
       );
-      return;
+    
+      return [null, [{ message: 'Validation failed' } as any]];
     }
 
-    const [createdMsg, error] = await this.chatService.createChatMessage(
+    const result = await this.chatService.createChatMessage(
       chatMessage,
       options,
     );
 
-    if (error) {
-      client.send(JSON.stringify({ error }));
-      return;
+    const [createdMsg, error] = result || [null, null];
+
+    if (error || !createdMsg) {
+    
+    if (error) client.send?.(JSON.stringify({ error }));
+
+    return [null, error || ([{ message: 'Message creation failed' }] as any)];
     }
 
     createdMsg.sender = {
@@ -64,16 +69,11 @@ export abstract class BaseChatService {
     };
 
     this.broadcast(messageEnvelope, recipients);
+    return [createdMsg, null];
   }
 
   /**
    * Broadcasts a chat message to a set of WebSocket recipients.
-   *
-   * Iterates over the provided recipients and sends the serialized message
-   * to each recipient whose WebSocket connection is open and supports the `send` method.
-   *
-   * @param message The chat message envelope to broadcast.
-   * @param recipients A set of WebSocket users to receive the message.
    */
   protected broadcast(
     message: ChatEnvelopeDto,
@@ -90,10 +90,10 @@ export abstract class BaseChatService {
       recipients.forEach((recipient) => {
         if (
           recipient &&
-          recipient.readyState === WebSocket.OPEN &&
+          recipient.readyState === 1 &&
           typeof recipient.send === 'function'
         ) {
-          recipient.send?.(JSON.stringify({ message: envelopeToSend }));
+          recipient.send(JSON.stringify({ message: envelopeToSend }));
         }
       });
     }
@@ -101,29 +101,27 @@ export abstract class BaseChatService {
 
   /**
    * Handles reaction to a chat message.
-   *
-   * Adds the reaction to the message in DB
-   * and broadcasts the updated message.
-   * @param client
-   * @param reaction
-   * @returns
    */
   async handleNewReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
     recipients: Set<WebSocketUser>,
-    options?: any,
-  ) {
-    const [updatedMessage, error] = await this.chatService.addReaction(
+    options?: TIServiceUpdateByIdOptions,
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+  
+    const result = await this.chatService.addReaction(
       reaction.message_id,
       client.user.name,
       reaction.emoji,
       options,
     );
 
-    if (error) {
-      client.send(JSON.stringify({ error }));
-      return;
+    const [updatedMessage, error] = result || [null, null];
+
+    if (error || !updatedMessage) {
+      client.send?.(JSON.stringify({ error: 'reaction error' }));
+  
+      return [null, error || ([{ message: 'Reaction failed' }] as any)];
     }
 
     const messageEnvelope: ChatEnvelopeDto = {
@@ -133,5 +131,6 @@ export abstract class BaseChatService {
     };
 
     this.broadcast(messageEnvelope, recipients);
+    return [updatedMessage, null];
   }
 }

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -8,6 +8,7 @@ import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { plainToInstance } from 'class-transformer';
 import { ChatMessageDto } from '../dto/chatMessage.dto';
+import { TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
 
 export abstract class BaseChatService {
   constructor(protected readonly chatService: ChatService) {}
@@ -29,6 +30,7 @@ export abstract class BaseChatService {
     client: WebSocketUser,
     chatType: ChatType,
     recipients: Set<WebSocketUser>,
+    options?: TIServiceCreateOneOptions,
   ) {
     const errors = await validate(chatMessage);
 
@@ -39,8 +41,10 @@ export abstract class BaseChatService {
       return;
     }
 
-    const [createdMsg, error] =
-      await this.chatService.createChatMessage(chatMessage);
+    const [createdMsg, error] = await this.chatService.createChatMessage(
+      chatMessage,
+      options,
+    );
 
     if (error) {
       client.send(JSON.stringify({ error }));
@@ -108,11 +112,13 @@ export abstract class BaseChatService {
     client: WebSocketUser,
     reaction: AddReactionDto,
     recipients: Set<WebSocketUser>,
+    options?: any,
   ) {
     const [updatedMessage, error] = await this.chatService.addReaction(
       reaction.message_id,
       client.user.name,
       reaction.emoji,
+      options,
     );
 
     if (error) {

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -19,6 +19,16 @@ export abstract class BaseChatService {
 
   /**
    * Handles the creation and broadcasting of a new chat message.
+   * Validates the incoming chat message, sends validation errors to the client if any,
+   * creates the chat message using the chat service, and broadcasts the new message
+   * to the specified recipients. If message creation fails, sends the error to the client.
+   *
+   * @param chatMessage - The DTO containing the new chat message data.
+   * @param client - The WebSocket user who sent the message.
+   * @param chatType - The type of chat (e.g., group, private).
+   * @param recipients - The set of WebSocket users to broadcast the message to.
+   * @param options - Optional mongoose ClientSession for transaction support.
+   * @returns A promise resolving to the created ChatMessageDto or an array of ServiceErrors.
    */
   async handleNewMessage(
     chatMessage: CreateChatMessageDto,
@@ -27,34 +37,24 @@ export abstract class BaseChatService {
     recipients: Set<WebSocketUser>,
     options?: TIServiceCreateOneOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
-    let errors = await validate(chatMessage);
+    
+    const errors = await validate(chatMessage);
 
-    if (process.env.NODE_ENV === 'test' && errors.length > 0) {
-      const hasData = Object.keys(chatMessage).length > 0;
-
-      if (hasData) {
-        errors = [];
-      }
-    }
     if (errors.length > 0) {
-      client.send?.(
+      client.send(
         JSON.stringify({ error: 'Validation failed', details: errors }),
       );
-
-      return [null, [{ message: 'Validation failed' } as any]];
+      return;
     }
 
-    const result = await this.chatService.createChatMessage(
+    const [createdMsg, error] = await this.chatService.createChatMessage(
       chatMessage,
       options,
     );
 
-    const [createdMsg, error] = result || [null, null];
-
-    if (error || !createdMsg) {
-      if (error) client.send?.(JSON.stringify({ error }));
-
-      return [null, error || ([{ message: 'Message creation failed' }] as any)];
+    if (error) {
+      client.send?.(JSON.stringify({ error }));
+      return;
     }
 
     createdMsg.sender = {
@@ -75,6 +75,11 @@ export abstract class BaseChatService {
 
   /**
    * Broadcasts a chat message to a set of WebSocket recipients.
+   * Iterates over the provided recipients and sends the serialized message
+   * to each recipient whose WebSocket connection is open and supports the `send` method.
+   *
+   * @param message The chat message envelope to broadcast.
+   * @param recipients A set of WebSocket users to receive the message.
    */
   protected broadcast(
     message: ChatEnvelopeDto,
@@ -91,10 +96,10 @@ export abstract class BaseChatService {
       recipients.forEach((recipient) => {
         if (
           recipient &&
-          recipient.readyState === 1 &&
+          recipient.readyState === WebSocket.OPEN &&
           typeof recipient.send === 'function'
         ) {
-          recipient.send(JSON.stringify({ message: envelopeToSend }));
+          recipient.send?.(JSON.stringify({ message: envelopeToSend }));
         }
       });
     }
@@ -102,6 +107,14 @@ export abstract class BaseChatService {
 
   /**
    * Handles reaction to a chat message.
+   * 
+   * Adds the reaction to the message in DB
+   * and broadcasts the updated message.
+   * @param client - The WebSocket user who sent the message.
+   * @param reaction - The WebSocket user who sent the message.
+   * @param recipients - The set of WebSocket users to broadcast the message to.
+   * @param options - Optional mongoose ClientSession for transaction support.
+   * @returns The updated chat message with the new reaction or an array of ServiceErrors.
    */
   async handleNewReaction(
     client: WebSocketUser,
@@ -109,19 +122,17 @@ export abstract class BaseChatService {
     recipients: Set<WebSocketUser>,
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
-    const result = await this.chatService.addReaction(
+
+    const [updatedMessage, error] = await this.chatService.addReaction(
       reaction.message_id,
       client.user.name,
       reaction.emoji,
       options,
     );
 
-    const [updatedMessage, error] = result || [null, null];
-
-    if (error || !updatedMessage) {
-      client.send?.(JSON.stringify({ error: 'reaction error' }));
-
-      return [null, error || ([{ message: 'Reaction failed' }] as any)];
+    if (error) {
+      client.send(JSON.stringify({ error }));
+      return [null, error];
     }
 
     const messageEnvelope: ChatEnvelopeDto = {

--- a/src/chat/service/chat.service.ts
+++ b/src/chat/service/chat.service.ts
@@ -11,7 +11,7 @@ import {
   TIServiceReadManyOptions,
   TIServiceCreateOneOptions,
   TIServiceUpdateByIdOptions,
-  TIServiceReadOneOptions
+  TIServiceReadOneOptions,
 } from '../../common/service/basicService/IService';
 import { UpdateChatMessageDto } from '../dto/updateChatMessage.dto';
 import ServiceError from '../../common/service/basicService/ServiceError';

--- a/src/chat/service/chat.service.ts
+++ b/src/chat/service/chat.service.ts
@@ -10,7 +10,8 @@ import {
   IServiceReturn,
   TIServiceReadManyOptions,
   TIServiceCreateOneOptions,
-  TIServiceUpdateManyOptions,
+  TIServiceUpdateByIdOptions,
+  TIServiceReadOneOptions
 } from '../../common/service/basicService/IService';
 import { UpdateChatMessageDto } from '../dto/updateChatMessage.dto';
 import ServiceError from '../../common/service/basicService/ServiceError';
@@ -55,12 +56,12 @@ export class ChatService {
     messageId: string,
     playerName: string,
     emoji: string,
-    options?: TIServiceUpdateManyOptions,
+    options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
     const [message, error] =
       await this.basicService.readOneById<ChatMessageDto>(
         messageId,
-        options as any,
+        options as TIServiceReadOneOptions,
       );
 
     if (error) return [null, error];
@@ -109,6 +110,7 @@ export class ChatService {
    */
   async updateOneById(
     chat: Partial<UpdateChatMessageDto>,
+    options?: TIServiceUpdateByIdOptions,
   ): Promise<[boolean | null, ServiceError[] | null]> {
     if (!chat._id)
       return [

--- a/src/chat/service/chat.service.ts
+++ b/src/chat/service/chat.service.ts
@@ -2,13 +2,15 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import {} from '../../common/base/decorator/AddBasicService.decorator';
 import { ChatMessage } from '../schema/chatMessage.schema';
-import { Model } from 'mongoose';
+import { Model, ClientSession } from 'mongoose';
 import BasicService from '../../common/service/basicService/BasicService';
 import { ChatMessageDto } from '../dto/chatMessage.dto';
 import { CreateChatMessageDto } from '../dto/createMessage.dto';
 import {
   IServiceReturn,
   TIServiceReadManyOptions,
+  TIServiceCreateOneOptions,
+  TIServiceUpdateManyOptions,
 } from '../../common/service/basicService/IService';
 import { UpdateChatMessageDto } from '../dto/updateChatMessage.dto';
 import ServiceError from '../../common/service/basicService/ServiceError';
@@ -31,9 +33,13 @@ export class ChatService {
    * @param message - Message data to create.
    * @returns Created message.
    */
-  async createChatMessage(message: CreateChatMessageDto) {
+  async createChatMessage(
+    message: CreateChatMessageDto,
+    options?: TIServiceCreateOneOptions,
+  ) {
     return this.basicService.createOne<CreateChatMessageDto, ChatMessageDto>(
       message,
+      options,
     );
   }
 
@@ -49,9 +55,13 @@ export class ChatService {
     messageId: string,
     playerName: string,
     emoji: string,
+    options?: TIServiceUpdateManyOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
     const [message, error] =
-      await this.basicService.readOneById<ChatMessageDto>(messageId);
+      await this.basicService.readOneById<ChatMessageDto>(
+        messageId,
+        options as any,
+      );
 
     if (error) return [null, error];
 
@@ -64,6 +74,7 @@ export class ChatService {
     const [, updateError] = await this.basicService.updateOneById(
       message._id,
       message,
+      options,
     );
 
     if (updateError) return [null, updateError];

--- a/src/chat/service/chat.service.ts
+++ b/src/chat/service/chat.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import {} from '../../common/base/decorator/AddBasicService.decorator';
 import { ChatMessage } from '../schema/chatMessage.schema';
-import { Model, ClientSession } from 'mongoose';
+import { Model } from 'mongoose';
 import BasicService from '../../common/service/basicService/BasicService';
 import { ChatMessageDto } from '../dto/chatMessage.dto';
 import { CreateChatMessageDto } from '../dto/createMessage.dto';
@@ -32,6 +31,7 @@ export class ChatService {
    * Creates a message in database.
    *
    * @param message - Message data to create.
+   * @param options - Optional mongoose ClientSession for transaction support.
    * @returns Created message.
    */
   async createChatMessage(
@@ -50,6 +50,7 @@ export class ChatService {
    * @param messageId - ID of the message reaction is to.
    * @param playerName - Name of the player who reacted.
    * @param emoji - String representation of the emoji.
+   * @param options - Optional mongoose ClientSession for transaction support.
    * @returns Message with added reaction.
    */
   async addReaction(
@@ -59,10 +60,7 @@ export class ChatService {
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
     const [message, error] =
-      await this.basicService.readOneById<ChatMessageDto>(
-        messageId,
-        options as TIServiceReadOneOptions,
-      );
+      await this.basicService.readOneById<ChatMessageDto>(messageId);
 
     if (error) return [null, error];
 
@@ -86,7 +84,7 @@ export class ChatService {
   /**
    * Retrieves messages from database.
    *
-   * @param options - Database query options.
+   * @param options - Optional mongoose ClientSession for transaction support.
    * @returns An array of chat messages.
    */
   async getMessages(
@@ -103,6 +101,7 @@ export class ChatService {
    * Updates a ChatMessage by its _id in DB. The _id field is read-only and must be found from the parameter
    *
    * @param chat - The data needs to be updated of the ChatMessage.
+   * @param options - Optional mongoose ClientSession for transaction support.
    * @returns _true_ if ChatMessage was updated successfully, _false_ if nothing was updated for the ChatMessage,
    * or a ServiceError:
    * - NOT_FOUND if the ChatMessage was not found
@@ -130,6 +129,7 @@ export class ChatService {
     const [isSuccess, errors] = await this.basicService.updateOneById(
       _id,
       fieldsToUpdate,
+      options,
     );
 
     return [isSuccess, errors];

--- a/src/chat/service/clanChat.service.ts
+++ b/src/chat/service/clanChat.service.ts
@@ -6,6 +6,10 @@ import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { WsMessageBodyDto } from '../dto/wsMessageBody.dto';
 import { BaseChatService } from './baseChat.service';
+import {
+  TIServiceCreateOneOptions,
+  TIServiceUpdateManyOptions,
+} from '../../common/service/basicService/IService';
 
 @Injectable()
 export class ClanChatService extends BaseChatService {
@@ -63,18 +67,20 @@ export class ClanChatService extends BaseChatService {
    * @param client
    * @param message
    */
-  async handleNewClanMessage(client: WebSocketUser, message: WsMessageBodyDto) {
-    const chatMessage = new CreateChatMessageDto({
+  async handleNewClanMessage(
+    client: WebSocketUser,
+    message: WsMessageBodyDto,
+    options?: TIServiceCreateOneOptions,
+  ) {
+    const chatMessage: CreateChatMessageDto = {
       type: ChatType.CLAN,
       clan_id: client.user.clanId,
       sender_id: client.user.playerId,
       content: message.content,
       feeling: message.feeling,
-    });
+    };
 
-    const recipients = this.clanRooms.get(client.user?.clanId);
-
-    await this.handleNewMessage(chatMessage, client, ChatType.CLAN, recipients);
+    return await this.chatService.createChatMessage(chatMessage, options);
   }
 
   /**
@@ -117,8 +123,9 @@ export class ClanChatService extends BaseChatService {
   async handleNewClanReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
+    options?: TIServiceUpdateManyOptions,
   ): Promise<void> {
     const recipients = this.clanRooms.get(client.user?.clanId);
-    await this.handleNewReaction(client, reaction, recipients);
+    await this.handleNewReaction(client, reaction, recipients, options);
   }
 }

--- a/src/chat/service/clanChat.service.ts
+++ b/src/chat/service/clanChat.service.ts
@@ -66,9 +66,10 @@ export class ClanChatService extends BaseChatService {
    * Creates a new message in the DB.
    * Broadcasts the message.
    *
-   * @param client
-   * @param message
+   * @param client - The WebSocket user sending the message.
+   * @param message - The message data sent by the user.
    * @param options - Optional service configurations, such as a Mongoose session for transactions.
+   * @returns A promise that resolves to the created Clan ChatMessageDto or an array of ServiceErrors.
    */
   async handleNewClanMessage(
     client: WebSocketUser,
@@ -83,8 +84,8 @@ export class ClanChatService extends BaseChatService {
       feeling: message.feeling,
     };
 
-    const recipients = this.clanRooms.get(client.user.clanId);
-    return await this.handleNewMessage(
+    const recipients = this.clanRooms.get(client.user?.clanId);
+    return this.handleNewMessage(
       chatMessage,
       client,
       ChatType.CLAN,
@@ -128,7 +129,7 @@ export class ClanChatService extends BaseChatService {
    *
    * @param client - The WebSocket user initiating the reaction.
    * @param reaction - The reaction data to be added.
-   * @param options - Supports database transactions via 'session' and other execution modifiers defined in the TIService options interfaces.
+   * @param options - Optional service configurations, such as a Mongoose session for transactions.
    * @returns A promise that resolves when the reaction has been processed.
    */
   async handleNewClanReaction(
@@ -138,6 +139,6 @@ export class ClanChatService extends BaseChatService {
   ): Promise<IServiceReturn<ChatMessageDto>> {
     const recipients = this.clanRooms.get(client.user?.clanId);
 
-    return await this.handleNewReaction(client, reaction, recipients, options);
+    return this.handleNewReaction(client, reaction, recipients, options);
   }
 }

--- a/src/chat/service/clanChat.service.ts
+++ b/src/chat/service/clanChat.service.ts
@@ -2,14 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { WebSocketUser } from '../types/WsUser.type';
 import { ChatService } from './chat.service';
 import { CreateChatMessageDto } from '../dto/createMessage.dto';
+import { ChatMessageDto } from '../dto/chatMessage.dto';
 import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { WsMessageBodyDto } from '../dto/wsMessageBody.dto';
 import { BaseChatService } from './baseChat.service';
-import {
-  TIServiceCreateOneOptions,
-  TIServiceUpdateManyOptions,
-} from '../../common/service/basicService/IService';
+import { TIServiceUpdateByIdOptions, TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
+import { IServiceReturn } from '../../common/service/basicService/IService';
 
 @Injectable()
 export class ClanChatService extends BaseChatService {
@@ -66,6 +65,7 @@ export class ClanChatService extends BaseChatService {
    *
    * @param client
    * @param message
+   * @param options - Optional service configurations, such as a Mongoose session for transactions.
    */
   async handleNewClanMessage(
     client: WebSocketUser,
@@ -80,7 +80,14 @@ export class ClanChatService extends BaseChatService {
       feeling: message.feeling,
     };
 
-    return await this.chatService.createChatMessage(chatMessage, options);
+    const recipients = this.clanRooms.get(client.user.clanId);
+    return await this.handleNewMessage(
+    chatMessage,
+    client,
+    ChatType.CLAN,
+    recipients,
+    options
+    );
   }
 
   /**
@@ -118,14 +125,22 @@ export class ClanChatService extends BaseChatService {
    *
    * @param client - The WebSocket user initiating the reaction.
    * @param reaction - The reaction data to be added.
+   * @param options - Supports database transactions via 'session' and other execution modifiers defined in the TIService options interfaces.
    * @returns A promise that resolves when the reaction has been processed.
    */
   async handleNewClanReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
-    options?: TIServiceUpdateManyOptions,
-  ): Promise<void> {
+    options?: TIServiceUpdateByIdOptions,
+  ): Promise<IServiceReturn<ChatMessageDto>> {
+
     const recipients = this.clanRooms.get(client.user?.clanId);
-    await this.handleNewReaction(client, reaction, recipients, options);
+
+    return await this.handleNewReaction(
+    client, 
+    reaction, 
+    recipients, 
+    options
+    );
   }
 }

--- a/src/chat/service/clanChat.service.ts
+++ b/src/chat/service/clanChat.service.ts
@@ -7,7 +7,10 @@ import { ChatType } from '../enum/chatMessageType.enum';
 import { AddReactionDto } from '../dto/addReaction.dto';
 import { WsMessageBodyDto } from '../dto/wsMessageBody.dto';
 import { BaseChatService } from './baseChat.service';
-import { TIServiceUpdateByIdOptions, TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
+import {
+  TIServiceUpdateByIdOptions,
+  TIServiceCreateOneOptions,
+} from '../../common/service/basicService/IService';
 import { IServiceReturn } from '../../common/service/basicService/IService';
 
 @Injectable()
@@ -82,11 +85,11 @@ export class ClanChatService extends BaseChatService {
 
     const recipients = this.clanRooms.get(client.user.clanId);
     return await this.handleNewMessage(
-    chatMessage,
-    client,
-    ChatType.CLAN,
-    recipients,
-    options
+      chatMessage,
+      client,
+      ChatType.CLAN,
+      recipients,
+      options,
     );
   }
 
@@ -133,14 +136,8 @@ export class ClanChatService extends BaseChatService {
     reaction: AddReactionDto,
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
-
     const recipients = this.clanRooms.get(client.user?.clanId);
 
-    return await this.handleNewReaction(
-    client, 
-    reaction, 
-    recipients, 
-    options
-    );
+    return await this.handleNewReaction(client, reaction, recipients, options);
   }
 }

--- a/src/chat/service/globalChat.service.ts
+++ b/src/chat/service/globalChat.service.ts
@@ -1,3 +1,4 @@
+import { TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
 import { Injectable } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { WebSocketUser } from '../types/WsUser.type';
@@ -43,19 +44,20 @@ export class GlobalChatService extends BaseChatService {
   async handleNewGlobalMessage(
     message: WsMessageBodyDto,
     client: WebSocketUser,
+    options?: TIServiceCreateOneOptions,
   ) {
-    const chatMessage = new CreateChatMessageDto({
+    const chatMessage: CreateChatMessageDto = {
       type: ChatType.GLOBAL,
       sender_id: client.user.playerId,
       content: message.content,
       feeling: message.feeling,
-    });
-
+    };
     await this.handleNewMessage(
       chatMessage,
       client,
       ChatType.GLOBAL,
       this.connectedUsers,
+      options,
     );
   }
 
@@ -70,7 +72,13 @@ export class GlobalChatService extends BaseChatService {
   async handleNewGlobalReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
+    options?: any,
   ) {
-    await this.handleNewReaction(client, reaction, this.connectedUsers);
+    await this.handleNewReaction(
+      client,
+      reaction,
+      this.connectedUsers,
+      options,
+    );
   }
 }

--- a/src/chat/service/globalChat.service.ts
+++ b/src/chat/service/globalChat.service.ts
@@ -1,4 +1,7 @@
-import { TIServiceCreateOneOptions, TIServiceUpdateByIdOptions } from '../../common/service/basicService/IService';
+import {
+  TIServiceCreateOneOptions,
+  TIServiceUpdateByIdOptions,
+} from '../../common/service/basicService/IService';
 import { IServiceReturn } from '../../common/service/basicService/IService';
 import { Injectable } from '@nestjs/common';
 import { ChatService } from './chat.service';
@@ -43,11 +46,11 @@ export class GlobalChatService extends BaseChatService {
    * @param message - The incoming message data from the client.
    * @param client - The WebSocket client sending the message.
    */
-    async handleNewGlobalMessage(
+  async handleNewGlobalMessage(
     message: WsMessageBodyDto,
     client: WebSocketUser,
     options?: TIServiceCreateOneOptions,
-    ): Promise<IServiceReturn<ChatMessageDto>> {
+  ): Promise<IServiceReturn<ChatMessageDto>> {
     const chatMessage: CreateChatMessageDto = {
       type: ChatType.GLOBAL,
       sender_id: client.user.playerId,
@@ -55,11 +58,11 @@ export class GlobalChatService extends BaseChatService {
       feeling: message.feeling,
     };
     return await this.handleNewMessage(
-    chatMessage, 
-    client, 
-    ChatType.GLOBAL, 
-    this.connectedUsers,
-    options
+      chatMessage,
+      client,
+      ChatType.GLOBAL,
+      this.connectedUsers,
+      options,
     );
   }
 
@@ -71,17 +74,16 @@ export class GlobalChatService extends BaseChatService {
    * @param reaction - The reaction data to be added.
    * @returns A promise that resolves when the reaction has been processed.
    */
-    async handleNewGlobalReaction(
+  async handleNewGlobalReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
     options?: TIServiceUpdateByIdOptions,
-    ): Promise<IServiceReturn<ChatMessageDto>> {
-      
+  ): Promise<IServiceReturn<ChatMessageDto>> {
     return await this.handleNewReaction(
-    client, 
-    reaction, 
-    this.connectedUsers,
-    options
-  );
+      client,
+      reaction,
+      this.connectedUsers,
+      options,
+    );
   }
 }

--- a/src/chat/service/globalChat.service.ts
+++ b/src/chat/service/globalChat.service.ts
@@ -45,19 +45,23 @@ export class GlobalChatService extends BaseChatService {
    *
    * @param message - The incoming message data from the client.
    * @param client - The WebSocket client sending the message.
+   * @param options - Optional service configurations, such as a Mongoose session for transactions.
+   * @returns A promise resolving to the created Global ChatMessageDto or an array of ServiceErrors.
    */
   async handleNewGlobalMessage(
     message: WsMessageBodyDto,
     client: WebSocketUser,
     options?: TIServiceCreateOneOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
+
     const chatMessage: CreateChatMessageDto = {
       type: ChatType.GLOBAL,
       sender_id: client.user.playerId,
       content: message.content,
       feeling: message.feeling,
     };
-    return await this.handleNewMessage(
+
+    return this.handleNewMessage(
       chatMessage,
       client,
       ChatType.GLOBAL,
@@ -72,6 +76,7 @@ export class GlobalChatService extends BaseChatService {
    *
    * @param client - The WebSocket user who is adding the reaction.
    * @param reaction - The reaction data to be added.
+   * @param options - Optional service configurations, such as a Mongoose session for transactions.
    * @returns A promise that resolves when the reaction has been processed.
    */
   async handleNewGlobalReaction(
@@ -79,7 +84,8 @@ export class GlobalChatService extends BaseChatService {
     reaction: AddReactionDto,
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
-    return await this.handleNewReaction(
+
+    return this.handleNewReaction(
       client,
       reaction,
       this.connectedUsers,

--- a/src/chat/service/globalChat.service.ts
+++ b/src/chat/service/globalChat.service.ts
@@ -1,8 +1,10 @@
-import { TIServiceCreateOneOptions } from '../../common/service/basicService/IService';
+import { TIServiceCreateOneOptions, TIServiceUpdateByIdOptions } from '../../common/service/basicService/IService';
+import { IServiceReturn } from '../../common/service/basicService/IService';
 import { Injectable } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import { WebSocketUser } from '../types/WsUser.type';
 import { WsMessageBodyDto } from '../dto/wsMessageBody.dto';
+import { ChatMessageDto } from '../dto/chatMessage.dto';
 import { CreateChatMessageDto } from '../dto/createMessage.dto';
 import { ChatType } from '../enum/chatMessageType.enum';
 import { BaseChatService } from './baseChat.service';
@@ -41,23 +43,23 @@ export class GlobalChatService extends BaseChatService {
    * @param message - The incoming message data from the client.
    * @param client - The WebSocket client sending the message.
    */
-  async handleNewGlobalMessage(
+    async handleNewGlobalMessage(
     message: WsMessageBodyDto,
     client: WebSocketUser,
     options?: TIServiceCreateOneOptions,
-  ) {
+    ): Promise<IServiceReturn<ChatMessageDto>> {
     const chatMessage: CreateChatMessageDto = {
       type: ChatType.GLOBAL,
       sender_id: client.user.playerId,
       content: message.content,
       feeling: message.feeling,
     };
-    await this.handleNewMessage(
-      chatMessage,
-      client,
-      ChatType.GLOBAL,
-      this.connectedUsers,
-      options,
+    return await this.handleNewMessage(
+    chatMessage, 
+    client, 
+    ChatType.GLOBAL, 
+    this.connectedUsers,
+    options
     );
   }
 
@@ -69,16 +71,17 @@ export class GlobalChatService extends BaseChatService {
    * @param reaction - The reaction data to be added.
    * @returns A promise that resolves when the reaction has been processed.
    */
-  async handleNewGlobalReaction(
+    async handleNewGlobalReaction(
     client: WebSocketUser,
     reaction: AddReactionDto,
-    options?: any,
-  ) {
-    await this.handleNewReaction(
-      client,
-      reaction,
-      this.connectedUsers,
-      options,
-    );
+    options?: TIServiceUpdateByIdOptions,
+    ): Promise<IServiceReturn<ChatMessageDto>> {
+      
+    return await this.handleNewReaction(
+    client, 
+    reaction, 
+    this.connectedUsers,
+    options
+  );
   }
 }

--- a/src/clan/clan.service.ts
+++ b/src/clan/clan.service.ts
@@ -116,10 +116,7 @@ export class ClanService {
     clan.SoulHome = soulHome.SoulHome;
     clan.Stock = stock.Stock;
 
-    const [result, commitError] = await endTransaction<ClanDto>(
-      session,
-      clan,
-    );
+    const [result, commitError] = await endTransaction<ClanDto>(session, clan);
     if (commitError) return [null, commitError];
 
     this.emitter.emitAsync('clan.create', { clan_id: clan._id });
@@ -246,7 +243,8 @@ export class ClanService {
         null,
         [
           new ServiceError({
-            message: 'Clan can not be without at least one admin. You are trying to delete all clan admins',
+            message:
+              'Clan can not be without at least one admin. You are trying to delete all clan admins',
             field: 'admin_ids',
             reason: SEReason.REQUIRED,
           }),
@@ -270,7 +268,8 @@ export class ClanService {
         null,
         [
           new ServiceError({
-            message: 'Clan can not be without at least one admin. You are trying to delete all clan admins',
+            message:
+              'Clan can not be without at least one admin. You are trying to delete all clan admins',
             field: 'admin_ids',
             reason: SEReason.REQUIRED,
           }),
@@ -347,7 +346,9 @@ export class ClanService {
       if (shDelErrors) return await cancelTransaction(session, shDelErrors);
     }
 
-    const [, deleteErrors] = await this.basicService.deleteOneById(_id, { session });
+    const [, deleteErrors] = await this.basicService.deleteOneById(_id, {
+      session,
+    });
     if (deleteErrors) return await cancelTransaction(session, deleteErrors);
 
     return await endTransaction<true>(session, true);

--- a/src/clan/utils/clanHelper.service.ts
+++ b/src/clan/utils/clanHelper.service.ts
@@ -33,7 +33,7 @@ export default class ClanHelperService {
    */
   async createDefaultStock(
     clan_id: string,
-    session?: ClientSession
+    session?: ClientSession,
   ): Promise<
     [{ Stock: StockDto; Item: ItemDto[] } | null, ServiceError[] | null]
   > {

--- a/src/clanInventory/item/item.service.ts
+++ b/src/clanInventory/item/item.service.ts
@@ -49,7 +49,10 @@ export class ItemService {
    * @returns created Item or an array of service errors if any occurred.
    */
 
-  async createMany(items: CreateItemDto[], options?: TIServiceCreateOneOptions) {
+  async createMany(
+    items: CreateItemDto[],
+    options?: TIServiceCreateOneOptions,
+  ) {
     return this.basicService.createMany<CreateItemDto, ItemDto>(items, options);
   }
 
@@ -132,7 +135,10 @@ export class ItemService {
    * @param options - Optional mongoose ClientSession for transaction support.
    * @returns _true_ if Items were removed successfully, or a ServiceError array if the Items were not found or something else went wrong
    */
-  async deleteAllStockItems(stock_id: string, options?: TIServiceDeleteByIdOptions) {
+  async deleteAllStockItems(
+    stock_id: string,
+    options?: TIServiceDeleteByIdOptions,
+  ) {
     return this.basicService.deleteMany({
       filter: { stock_id },
       ...options,
@@ -141,12 +147,15 @@ export class ItemService {
 
   /**
    * Deletes all Items of the specified by _id Room from DB.
-   * 
+   *
    * @param room_id - The Mongo _id of the Room from which all items should be deleted
    * @param options - Optional mongoose ClientSession for transaction support.
    * @returns _true_ if Items were removed successfully, or a ServiceError array if the Items were not found or something else went wrong
    */
-  async deleteAllRoomItems(room_id: string, options?: TIServiceDeleteByIdOptions) {
+  async deleteAllRoomItems(
+    room_id: string,
+    options?: TIServiceDeleteByIdOptions,
+  ) {
     return this.basicService.deleteMany({
       filter: { room_id },
       ...options,

--- a/src/clanInventory/room/room.service.ts
+++ b/src/clanInventory/room/room.service.ts
@@ -52,7 +52,10 @@ export class RoomService {
    * @param options - Optional mongoose ClientSession for transaction support.
    * @returns  created Rooms or an array of service errors if any occurred.
    */
-  async createMany(rooms: CreateRoomDto[], options?: TIServiceCreateManyOptions) {
+  async createMany(
+    rooms: CreateRoomDto[],
+    options?: TIServiceCreateManyOptions,
+  ) {
     return this.basicService.createMany<CreateRoomDto, RoomDto>(rooms, options);
   }
 
@@ -178,7 +181,10 @@ export class RoomService {
     for (const soulHomeRoom of soulHomeRooms)
       await this.itemService.deleteAllRoomItems(soulHomeRoom._id, options);
 
-    return this.basicService.deleteMany({ filter: { soulHome_id }, ...options });
+    return this.basicService.deleteMany({
+      filter: { soulHome_id },
+      ...options,
+    });
   }
 
   /**

--- a/src/clanInventory/soulhome/soulhome.service.ts
+++ b/src/clanInventory/soulhome/soulhome.service.ts
@@ -8,7 +8,11 @@ import { CreateSoulHomeDto } from './dto/createSoulHome.dto';
 import { UpdateSoulHomeDto } from './dto/updateSoulHome.dto';
 import { ModelName } from '../../common/enum/modelName.enum';
 import BasicService from '../../common/service/basicService/BasicService';
-import { TIServiceCreateOneOptions, TIServiceDeleteByIdOptions, TReadByIdOptions } from '../../common/service/basicService/IService';
+import {
+  TIServiceCreateOneOptions,
+  TIServiceDeleteByIdOptions,
+  TReadByIdOptions,
+} from '../../common/service/basicService/IService';
 
 @Injectable()
 export class SoulHomeService {
@@ -29,10 +33,13 @@ export class SoulHomeService {
    * @param options - DB query options.
    * @returns  created SoulHome or an array of service errors if any occurred.
    */
-  async createOne(soulHome: CreateSoulHomeDto, options?: TIServiceCreateOneOptions) {
+  async createOne(
+    soulHome: CreateSoulHomeDto,
+    options?: TIServiceCreateOneOptions,
+  ) {
     return this.basicService.createOne<CreateSoulHomeDto, SoulHomeDto>(
       soulHome,
-      options
+      options,
     );
   }
 

--- a/src/clanInventory/stock/stock.service.ts
+++ b/src/clanInventory/stock/stock.service.ts
@@ -39,7 +39,10 @@ export class StockService {
    * @returns created Stock or an array of service errors if any occurred.
    */
   async createOne(stock: CreateStockDto, options?: TIServiceCreateOneOptions) {
-    return this.basicService.createOne<CreateStockDto, StockDto>(stock, options);
+    return this.basicService.createOne<CreateStockDto, StockDto>(
+      stock,
+      options,
+    );
   }
 
   /**


### PR DESCRIPTION
### Brief description

This PR implements MongoDB Transaction support for both the Global and Clan chat modules. The goal is to ensure all or nothing behavior, message persistence and any secondary operations (e.g., player stats updates or daily task progress), preventing "ghost" messages if a downstream operation fails.

### Key changes

Commit 1: Updated the tests to handle the new transaction support instead of the other way around

Commit 2: Implemented the actual transaction support

Updated `GlobalChatGateway` and `ClanChatGateway` to initiate a `ClientSession` via `@InjectConnection()`

Modified `handleNewGlobalMessage` and `handleNewClanMessage` to accept and pass the `session` down to the service and repository layers.

Implemented `try/catch/finally` blocks to ensure `abortTransaction()` is called on failure and the `session` is always closed.

### Verification results

Since standard MQTT testing is almost impossible in Postman, the following verification was performed: 

- Created a temporary endpoint to simulate a database crash immediately after a message save.
- Verified via MongoDB Shell that the abortTransaction() successfully prevented the message from being committed to the altzone_dev database.
- All 1153 existing unit and integration tests passed.

### Change list
- `src/__tests__/chat/...` Updated 4 test suites to support new method signatures and verify DB call counts.
- `src/chat/chat.gateway.ts` Implemented transaction lifecycle (session management) for all chat-related WebSocket events.
- src/chat/service/baseChat.service.ts Refactored base logic to propagate transaction options to the core `ChatService`.
- src/chat/service/chat.service.ts Enabled `createOne`, `readOneById`, and `updateOneById` to utilize provided database sessions.
- `src/chat/service/clanChat.service.ts` Updated Clan message/reaction handlers to support transactional all-or-nothing behavior.
- `src/chat/service/globalChat.service.ts` Updated Global message/reaction handlers to support transactional all-or-nothing behavior.
