### PR TITLE
741 custom character stat storing

### DIFF
--- a/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/createOne.test.ts
@@ -7,6 +7,7 @@ import { ObjectId } from 'mongodb';
 import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
 import CustomCharacterModule from '../../modules/customCharacter.module';
 import PlayerBuilderFactory from '../../data/playerBuilderFactory';
+import { NewCharacterBase } from '../../../../player/customCharacter/const/NewCharacterBase';
 
 describe('CustomCharacterService.createOne() test suite', () => {
   let characterService: CustomCharacterService;
@@ -34,7 +35,7 @@ describe('CustomCharacterService.createOne() test suite', () => {
     });
     const clearedCharacter = clearDBRespDefaultFields(createdCharacter);
 
-    const expectedSpecs = CharacterBaseStats[characterId];
+    const expectedSpecs = NewCharacterBase;
 
     expect(clearedCharacter).toHaveLength(1);
     expect(clearedCharacter[0]).toEqual({

--- a/src/__tests__/player/customCharacter/CustomCharacterService/readMany.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/readMany.test.ts
@@ -57,12 +57,22 @@ describe('CustomCharacterService.readMany() test suite', () => {
 
     const clearedCharacters = clearDBRespDefaultFields(characters);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(clearedCharacters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character1 }),
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -72,12 +82,22 @@ describe('CustomCharacterService.readMany() test suite', () => {
       filter: undefined,
     });
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character1 }),
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -87,12 +107,22 @@ describe('CustomCharacterService.readMany() test suite', () => {
       filter: {},
     });
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character1 }),
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -100,12 +130,22 @@ describe('CustomCharacterService.readMany() test suite', () => {
   it('Should return all characters in DB if options are undefined', async () => {
     const [characters, errors] = await characterService.readMany(undefined);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character1 }),
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -113,12 +153,22 @@ describe('CustomCharacterService.readMany() test suite', () => {
   it('Should return all characters in DB if options are null', async () => {
     const [characters, errors] = await characterService.readMany(null);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character1 }),
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -161,12 +211,19 @@ describe('CustomCharacterService.readMany() test suite', () => {
       sort,
     });
 
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters).toHaveLength(2);
     expect(characters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...character2 }),
-        expect.objectContaining({ ...character3 }),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -179,11 +236,21 @@ describe('CustomCharacterService.readMany() test suite', () => {
       sort,
     });
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(character3),
+    );
+
     expect(errors).toBeNull();
     expect(characters.map((characters) => characters.speed)).toEqual([
-      character1.speed,
-      character2.speed,
-      character3.speed,
+      expected1.speed,
+      expected2.speed,
+      expected3.speed,
     ]);
   });
 

--- a/src/__tests__/player/customCharacter/CustomCharacterService/readOne.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/readOne.test.ts
@@ -6,6 +6,7 @@ import { ModelName } from '../../../../common/enum/modelName.enum';
 import LoggedUser from '../../../test_utils/const/loggedUser';
 import CustomCharacterModule from '../../modules/customCharacter.module';
 import PlayerBuilderFactory from '../../data/playerBuilderFactory';
+import { CharacterBaseStats } from '../../../../player/customCharacter/const/CharacterBaseStats';
 
 describe('CustomCharacterService.readOne() test suite', () => {
   let characterService: CustomCharacterService;
@@ -30,10 +31,12 @@ describe('CustomCharacterService.readOne() test suite', () => {
   it('Should find and return a character based on the provided filter', async () => {
     const [foundCharacter, errors] = await characterService.readOne({ filter });
 
-    expect(errors).toBeNull();
-    expect(foundCharacter).toEqual(
-      expect.objectContaining({ ...existingCharacter }),
+    const expected = clearDBRespDefaultFields(
+      characterService.addValues(existingCharacter),
     );
+
+    expect(errors).toBeNull();
+    expect(foundCharacter).toEqual(expect.objectContaining(expected));
   });
 
   it('Should return SE NOT_FOUND if no characters matches the provided filter', async () => {

--- a/src/__tests__/player/customCharacter/CustomCharacterService/readOneById.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/readOneById.test.ts
@@ -33,8 +33,12 @@ describe('CustomCharacter.readOneById() test suite', () => {
 
     const clearedItem = clearDBRespDefaultFields(character);
 
+    const expected = clearDBRespDefaultFields(
+      characterService.addValues(existingCharacter),
+    );
+
     expect(errors).toBeNull();
-    expect(clearedItem).toEqual(expect.objectContaining(existingCharacter));
+    expect(clearedItem).toEqual(expect.objectContaining(expected));
   });
 
   it('Should return fields only requested in "select"', async () => {

--- a/src/__tests__/player/customCharacter/CustomCharacterService/readPlayerBattleCharacters.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/readPlayerBattleCharacters.test.ts
@@ -5,6 +5,7 @@ import CustomCharacterModule from '../../modules/customCharacter.module';
 import PlayerBuilderFactory from '../../data/playerBuilderFactory';
 import PlayerModule from '../../modules/player.module';
 import { getNonExisting_id } from '../../../test_utils/util/getNonExisting_id';
+import { CharacterBaseStats } from '../../../../player/customCharacter/const/CharacterBaseStats';
 
 describe('CustomCharacterService.readPlayerBattleCharacters() test suite', () => {
   let characterService: CustomCharacterService;
@@ -82,13 +83,23 @@ describe('CustomCharacterService.readPlayerBattleCharacters() test suite', () =>
 
     const clearedCharacters = clearDBRespDefaultFields(characters);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(player1Character1),
+    );
+    const expected2 = clearDBRespDefaultFields(
+      characterService.addValues(player1Character2),
+    );
+    const expected3 = clearDBRespDefaultFields(
+      characterService.addValues(player1Character3),
+    );
+
     expect(errors).toBeNull();
     expect(clearedCharacters).toHaveLength(3);
     expect(clearedCharacters).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ ...player1Character1 }),
-        expect.objectContaining({ ...player1Character2 }),
-        expect.objectContaining({ ...player1Character3 }),
+        expect.objectContaining(expected1),
+        expect.objectContaining(expected2),
+        expect.objectContaining(expected3),
       ]),
     );
   });
@@ -104,12 +115,14 @@ describe('CustomCharacterService.readPlayerBattleCharacters() test suite', () =>
       await characterService.readPlayerBattleCharacters(player1._id);
     const clearedCharacters = clearDBRespDefaultFields(characters);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(player1Character1),
+    );
+
     expect(errors).toBeNull();
     expect(clearedCharacters).toHaveLength(1);
     expect(clearedCharacters).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ ...player1Character1 }),
-      ]),
+      expect.arrayContaining([expect.objectContaining(expected1)]),
     );
   });
 
@@ -124,12 +137,14 @@ describe('CustomCharacterService.readPlayerBattleCharacters() test suite', () =>
       await characterService.readPlayerBattleCharacters(player1._id);
     const clearedCharacters = clearDBRespDefaultFields(characters);
 
+    const expected1 = clearDBRespDefaultFields(
+      characterService.addValues(player1Character1),
+    );
+
     expect(errors).toBeNull();
     expect(clearedCharacters).toHaveLength(1);
     expect(clearedCharacters).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ ...player1Character1 }),
-      ]),
+      expect.arrayContaining([expect.objectContaining(expected1)]),
     );
   });
 

--- a/src/__tests__/player/customCharacter/CustomCharacterService/updateOneByCondition.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/updateOneByCondition.test.ts
@@ -41,7 +41,10 @@ describe('CustomCharacterService.updateOneByCondition() test suite', () => {
       existingCharacter._id,
     );
     const clearedCharacter = clearDBRespDefaultFields(updatedCharacter);
-    expect(clearedCharacter).toEqual({ ...existingCharacter, size: newSize });
+    expect(clearedCharacter).toEqual({
+      ...existingCharacter,
+      size: existingCharacter.size + newSize,
+    });
   });
 
   it('Should return ServiceError NOT_FOUND if no characters match the provided filter', async () => {

--- a/src/__tests__/player/customCharacter/CustomCharacterService/updateOneByCondition.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/updateOneByCondition.test.ts
@@ -43,7 +43,7 @@ describe('CustomCharacterService.updateOneByCondition() test suite', () => {
     const clearedCharacter = clearDBRespDefaultFields(updatedCharacter);
     expect(clearedCharacter).toEqual({
       ...existingCharacter,
-      size: existingCharacter.size + newSize,
+      size: newSize,
     });
   });
 

--- a/src/__tests__/player/customCharacter/CustomCharacterService/updateOneById.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/updateOneById.test.ts
@@ -42,7 +42,7 @@ describe('CustomCharacter.updateOneById() test suite', () => {
     const clearedCharacter = clearDBRespDefaultFields(updatedCharacter);
     expect(clearedCharacter).toEqual({
       ...existingCharacter,
-      size: existingCharacter.size + updatedSize,
+      size: updatedSize,
     });
   });
 

--- a/src/__tests__/player/customCharacter/CustomCharacterService/updateOneById.test.ts
+++ b/src/__tests__/player/customCharacter/CustomCharacterService/updateOneById.test.ts
@@ -42,7 +42,7 @@ describe('CustomCharacter.updateOneById() test suite', () => {
     const clearedCharacter = clearDBRespDefaultFields(updatedCharacter);
     expect(clearedCharacter).toEqual({
       ...existingCharacter,
-      size: updatedSize,
+      size: existingCharacter.size + updatedSize,
     });
   });
 

--- a/src/player/customCharacter/const/NewCharacterBase.ts
+++ b/src/player/customCharacter/const/NewCharacterBase.ts
@@ -1,0 +1,21 @@
+/**
+ * Character stats
+ */
+type Stats = {
+  defence: number;
+  hp: number;
+  size: number;
+  attack: number;
+  speed: number;
+};
+
+/**
+ * Defines base stats for new created characters
+ */
+export const NewCharacterBase: Stats = {
+  defence: 0,
+  hp: 0,
+  size: 0,
+  attack: 0,
+  speed: 0,
+};

--- a/src/player/customCharacter/customCharacter.service.ts
+++ b/src/player/customCharacter/customCharacter.service.ts
@@ -390,13 +390,11 @@ export class CustomCharacterService {
   }
 
   /**
-   * Add key value pairs to correct key, $inc or $set.
-   *
-   * Inc increments existing values in DB, set replaces existing values.
+   * Reduce base stats to get deltas.
    *
    * @param customCharacterToUpdate - Data to updated in DB
    *
-   * @returns Object with $inc and $set used to update character data in DB
+   * @returns Object with $set used to update character data in DB
    */
   public getFieldsToUpdate(customCharacterToUpdate: Partial<CustomCharacter>) {
     const stats: string[] = ['defence', 'hp', 'size', 'attack', 'speed'];

--- a/src/player/customCharacter/customCharacter.service.ts
+++ b/src/player/customCharacter/customCharacter.service.ts
@@ -400,15 +400,17 @@ export class CustomCharacterService {
    */
   public getFieldsToUpdate(customCharacterToUpdate: Partial<CustomCharacter>) {
     const stats: string[] = ['defence', 'hp', 'size', 'attack', 'speed'];
-    const $inc: Record<string, number> = {};
     const $set: Record<string, any> = {};
+    const base = CharacterBaseStats[customCharacterToUpdate.characterId]
 
     for (const [key, value] of Object.entries(customCharacterToUpdate)) {
-      if (key === '_id' || value === undefined) continue;
-      if (stats.includes(key) && typeof value === 'number') $inc[key] = value;
+      if (key === '_id' || value === undefined) 
+        continue;
+      if (stats.includes(key) && typeof value === 'number')
+        $set[key] = value - (base?.[key] ?? 0)
       else $set[key] = value;
     }
-    return { $inc, $set };
+    return { $set };
   }
 
   /**

--- a/src/player/customCharacter/customCharacter.service.ts
+++ b/src/player/customCharacter/customCharacter.service.ts
@@ -20,6 +20,7 @@ import BasicService from '../../common/service/basicService/BasicService';
 import { CharacterBaseStats } from './const/CharacterBaseStats';
 import { UpdateCustomCharacterDto } from './dto/updateCustomCharacter.dto';
 import { ObjectId } from 'mongodb';
+import { NewCharacterBase } from './const/NewCharacterBase';
 
 @Injectable()
 export class CustomCharacterService {
@@ -41,6 +42,8 @@ export class CustomCharacterService {
   /**
    * Creates a new CustomCharacter in DB.
    *
+   * Base stats are added to deltas stored in DB before returning.
+   *
    * @param customCharacterToCreate  custom character data to create
    * @param owner_id player _id, which will own the character
    *
@@ -56,18 +59,22 @@ export class CustomCharacterService {
       return [null, characterValidationErrors];
     }
 
-    const expectedSpecs =
-      CharacterBaseStats[customCharacterToCreate.characterId];
-
     const newCharacter: CustomCharacter = {
-      ...expectedSpecs,
+      ...NewCharacterBase,
       ...customCharacterToCreate,
       player_id: owner_id as any,
     };
 
-    return this.basicService.createOne<CustomCharacter, CustomCharacter>(
-      newCharacter,
-    );
+    let doc: CustomCharacter | null;
+    let errors: ServiceError[] | null;
+
+    [doc, errors] = await this.basicService.createOne<
+      CustomCharacter,
+      CustomCharacter
+    >(newCharacter);
+
+    if (doc) doc = this.addValues((doc as any).toObject());
+    return [doc, errors];
   };
 
   /**
@@ -132,6 +139,8 @@ export class CustomCharacterService {
   /**
    * Reads a custom character by its _id in DB.
    *
+   * Base stats are added to deltas stored in DB before returning.
+   *
    * @param _id - The Mongo _id of the character to read.
    * @param options - Options for reading the character.
    *
@@ -159,11 +168,23 @@ export class CustomCharacterService {
       optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
         this.refsInModel.includes(ref),
       );
-    return this.basicService.readOneById<CustomCharacter>(_id, optionsToApply);
+
+    let doc: CustomCharacter | null;
+    let errors: ServiceError[] | null;
+
+    [doc, errors] = await this.basicService.readOneById<CustomCharacter>(
+      _id,
+      optionsToApply,
+    );
+
+    if (doc) doc = this.addValues((doc as any).toObject());
+    return [doc, errors];
   }
 
   /**
    * Reads a custom character by specified condition.
+   *
+   * Base stats are added to deltas stored in DB before returning.
    *
    * @param options - Options for reading the character.
    *
@@ -190,11 +211,21 @@ export class CustomCharacterService {
       optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
         this.refsInModel.includes(ref),
       );
-    return this.basicService.readOne<CustomCharacter>(optionsToApply);
+
+    let doc: CustomCharacter | null;
+    let errors: ServiceError[] | null;
+
+    [doc, errors] =
+      await this.basicService.readOne<CustomCharacter>(optionsToApply);
+
+    if (doc) doc = this.addValues((doc as any).toObject());
+    return [doc, errors];
   }
 
   /**
    * Reads custom characters from DB with specified configuration.
+   *
+   * Base stats are added to deltas stored in DB before returning.
    *
    * Notice that if the options is undefined or null, or filter option is undefined, null or empty object all custom characters will be returned.
    *
@@ -210,11 +241,21 @@ export class CustomCharacterService {
       optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
         this.refsInModel.includes(ref),
       );
-    return this.basicService.readMany<CustomCharacter>(optionsToApply);
+
+    let docs: CustomCharacter[] | null;
+    let errors: ServiceError[] | null;
+
+    [docs, errors] =
+      await this.basicService.readMany<CustomCharacter>(optionsToApply);
+
+    if (docs) docs = docs.map((doc) => this.addValues((doc as any).toObject()));
+    return [docs, errors];
   };
 
   /**
    * Reads custom characters that player has chosen as a battle characters
+   *
+   * Base stats are added to deltas stored in DB before returning.
    *
    * Notice that if some characters are not found, they will be ignored.
    *
@@ -255,13 +296,38 @@ export class CustomCharacterService {
         ],
       ];
 
-    return this.basicService.readMany({
+    let docs: CustomCharacter[] | null;
+    let errors: ServiceError[] | null;
+
+    [docs, errors] = await this.basicService.readMany({
       filter: {
         player_id: player._id,
         _id: { $in: player.battleCharacter_ids },
       },
     });
+
+    if (docs) docs = docs.map((doc) => this.addValues((doc as any).toObject()));
+    return [docs, errors];
   };
+
+  /**
+   * Sum character stat deltas stored in DB with matching characters base stats
+   *
+   * @param doc - Plain object to add to
+   *
+   * @returns Result with added values
+   */
+  public addValues(doc: CustomCharacter) {
+    const result = { ...doc };
+    const baseStats = CharacterBaseStats[doc.characterId];
+    if (!baseStats) return result;
+
+    for (const [key] of Object.entries(baseStats)) {
+      if (!doc.hasOwnProperty(key)) continue;
+      result[key] = (doc[key] ?? 0) + (baseStats[key] ?? 0);
+    }
+    return result;
+  }
 
   /**
    * Updates a custom character by its _id in DB. The _id field is read-only and is required
@@ -271,8 +337,10 @@ export class CustomCharacterService {
    * @returns _true_ if CustomCharacter was updated successfully, _false_ if nothing was updated for the CustomCharacter,
    * SE REQUIRED if _id is not provided or SE NOT_FOUND if no characters were found
    */
-  async updateOneById(customCharacterToUpdate: UpdateCustomCharacterDto) {
-    const { _id, ...fieldsToUpdate } = customCharacterToUpdate;
+  async updateOneById(
+    customCharacterToUpdate: UpdateCustomCharacterDto,
+  ): Promise<IServiceReturn<boolean>> {
+    const { _id } = customCharacterToUpdate;
 
     if (!_id)
       return [
@@ -286,6 +354,8 @@ export class CustomCharacterService {
           }),
         ],
       ];
+
+    const fieldsToUpdate = this.getFieldsToUpdate(customCharacterToUpdate);
 
     return this.basicService.updateOneById(_id, fieldsToUpdate);
   }
@@ -302,7 +372,7 @@ export class CustomCharacterService {
   async updateOneByCondition(
     customCharacterToUpdate: Partial<CustomCharacter>,
     condition: TIServiceUpdateOneOptions<CustomCharacter>,
-  ) {
+  ): Promise<IServiceReturn<boolean>> {
     if (!customCharacterToUpdate || !condition)
       return [
         null,
@@ -314,12 +384,31 @@ export class CustomCharacterService {
         ],
       ];
 
-    const { _id, ...fieldsToUpdate } = {
-      ...customCharacterToUpdate,
-      _id: null,
-    };
+    const fieldsToUpdate = this.getFieldsToUpdate(customCharacterToUpdate);
 
     return this.basicService.updateOne(fieldsToUpdate, condition);
+  }
+
+  /**
+   * Add key value pairs to correct key, $inc or $set.
+   *
+   * Inc increments existing values in DB, set replaces existing values.
+   *
+   * @param customCharacterToUpdate - Data to updated in DB
+   *
+   * @returns Object with $inc and $set used to update character data in DB
+   */
+  public getFieldsToUpdate(customCharacterToUpdate: Partial<CustomCharacter>) {
+    const stats: string[] = ['defence', 'hp', 'size', 'attack', 'speed'];
+    const $inc: Record<string, number> = {};
+    const $set: Record<string, any> = {};
+
+    for (const [key, value] of Object.entries(customCharacterToUpdate)) {
+      if (key === '_id' || value === undefined) continue;
+      if (stats.includes(key) && typeof value === 'number') $inc[key] = value;
+      else $set[key] = value;
+    }
+    return { $inc, $set };
   }
 
   /**


### PR DESCRIPTION
### Brief description
Updated customCharacter.service to meet required changes in #741 Custom character stat storing. Also changes to tests.


### Change list

- New function: addValues, gets document as POJO, adds matching base stats, returns result.
- New function: getFieldsToUpdate, adds key value pairs to correct key, $inc or $set.
- createOne creates a new character with stat deltas starting at 0, returns base + deltas.
- readOneById, readOne, readMany and readPlayerBattleCharacters use addValues, return base + deltas.
- updateOneById and updateOneByCondition use getFieldsToUpdate to increment deltas and set others.
- Changes to __tests__ custom character files to match new results.
