### PR TITLE
783 Error refactored

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,8 +2,6 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { useContainer, ValidationError } from 'class-validator';
-import { APIError } from './common/controller/APIError';
-import { validationToAPIErrors } from './common/exceptionFilter/ValidationExceptionFilter';
 import EnvHandler from './common/service/envHandler/envHandler';
 import cookieParser from 'cookie-parser';
 import SwaggerInitializer from './common/swagger/swaggerInitializer';
@@ -56,15 +54,34 @@ bootstrap();
  * @returns bad request exception
  */
 function errorFactory(validationErrors: ValidationError[]) {
-  const apiErrors: APIError[] = [];
-  for (let i = 0, l = validationErrors.length; i < l; i++) {
-    const errors = validationToAPIErrors(validationErrors[i]);
-    apiErrors.push(...errors);
-  }
+  const detailedErrors: any[] = [];
+
+  // Helper function for nested validation errors
+  const shoutAtErrors = (errors: ValidationError[], parentPath = '') => {
+    errors.forEach((error) => {
+
+      const path = parentPath ? `${parentPath}.${error.property}` : error.property;
+
+      if (error.constraints) {
+        detailedErrors.push({
+          field: path,
+          messages: Object.values(error.constraints),
+          receivedValue: error.value,
+        });
+      }
+
+      if (error.children && error.children.length > 0) {
+        shoutAtErrors(error.children, path);
+      }
+    });
+  };
+
+  shoutAtErrors(validationErrors);
 
   return new BadRequestException({
     statusCode: 400,
     error: 'Bad Request',
-    errors: apiErrors,
+    message: 'Validation failed',
+    errors: detailedErrors,
   });
 }


### PR DESCRIPTION
### Brief description

Looks like when sending the older JSON input to Postman on the PUT player endpoint it ran into this issue: 

`Error putting data to https://devapi.altzone.fi/player/ - HTTP/1.1 400 Bad Request: {"statusCode":400,"error":"Bad Request","errors":[]}`

The error message setup had to be refactored to counter this for good, since in its current form it just didn't accept the old format before the change when the playerAvatar was updated to an object, but instead of giving a proper error message explaining why, it just went quiet. This has now been addressed with a proper error message explanation. Here's the message:

<img width="857" height="907" alt="postman_output_JSON" src="https://github.com/user-attachments/assets/446f655c-0ace-421f-b688-f3926fd36531" />



### Change list

- `main.ts`: Deleted the currently unused imports. 
- Refactored the `const` variable with a helper function and a lot more stuff to give the user a better output when the wrong `JSON` is the input. 
- Added a general message "`Validation failed`" in the bottom of the function. 

Tested on Postman too and the output can be seen on the image. 
