### PR TITLE
Update PUT method with Swagger's RequestBody

### DIFF
--- a/src/player/dto/modifyAvatar.dto.ts
+++ b/src/player/dto/modifyAvatar.dto.ts
@@ -1,7 +1,7 @@
 import { IsHexColor, IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { AvatarPieceDto } from './avatar.dto';
-import AddType from 'src/common/base/decorator/AddType.decorator';
+import AddType from '../../common/base/decorator/AddType.decorator';
 import { ApiProperty } from '@nestjs/swagger';
 
 /**

--- a/src/player/dto/modifyAvatar.dto.ts
+++ b/src/player/dto/modifyAvatar.dto.ts
@@ -1,16 +1,20 @@
 import { IsHexColor, IsOptional, ValidateNested } from 'class-validator';
 import { Type } from 'class-transformer';
 import { AvatarPieceDto } from './avatar.dto';
+import AddType from 'src/common/base/decorator/AddType.decorator';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * Data Transfer Object for partially updating an avatar's configuration.
  * All fields are optional to allow for specific component updates.
  */
+@AddType('ModifyAvatarDto')
 export class ModifyAvatarDto {
   /**
    * Optional update for the avatar's head shape.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -20,6 +24,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's hair style or color.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -29,6 +34,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's eyes.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -38,6 +44,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's nose.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -47,6 +54,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's mouth.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -56,6 +64,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's eyebrows.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -65,6 +74,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's clothing.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -74,6 +84,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's footwear.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)
@@ -83,6 +94,7 @@ export class ModifyAvatarDto {
    * Optional update for the avatar's hand or glove configuration.
    * @type {AvatarPieceDto}
    */
+  @ApiProperty({ type: () => AvatarPieceDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AvatarPieceDto)

--- a/src/player/dto/updatePlayer.dto.ts
+++ b/src/player/dto/updatePlayer.dto.ts
@@ -117,6 +117,7 @@ export class UpdatePlayerDto {
   /**
    * Update avatar configuration
    */
+  @ApiProperty({ type: () => ModifyAvatarDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => ModifyAvatarDto)

--- a/src/player/player.controller.ts
+++ b/src/player/player.controller.ts
@@ -14,7 +14,6 @@ import { UpdatePlayerDto } from './dto/updatePlayer.dto';
 import { PlayerDto } from './dto/player.dto';
 import { _idDto } from '../common/dto/_id.dto';
 import { BasicDELETE } from '../common/base/decorator/BasicDELETE.decorator';
-import { BasicPUT } from '../common/base/decorator/BasicPUT.decorator';
 import { ModelName } from '../common/enum/modelName.enum';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
 import { Authorize } from '../authorization/decorator/Authorize';
@@ -31,6 +30,7 @@ import ApiResponseDescription from '../common/swagger/response/ApiResponseDescri
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import { isEqual } from 'lodash';
+import { MongooseError } from 'mongoose';
 
 @Controller('player')
 export default class PlayerController {
@@ -122,7 +122,7 @@ export default class PlayerController {
   @Put()
   @HttpCode(204)
   @Authorize({ action: Action.update, subject: UpdatePlayerDto })
-  @BasicPUT(ModelName.PLAYER)
+  @UniformResponse()
   public async update(@Body() body: UpdatePlayerDto) {
     const [player, _] = await this.service.getPlayerById(body._id);
 
@@ -130,7 +130,8 @@ export default class PlayerController {
 
     await this.emitEventIfAvatarChange(player, body);
 
-    return playerUpdateResults;
+    if (playerUpdateResults instanceof MongooseError)
+      return playerUpdateResults;
   }
 
   /**

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -200,7 +200,7 @@ export default class ProfileController {
   })
   @Put()
   @Authorize({ action: Action.update, subject: UpdateProfileDto })
-  @BasicPUT(ModelName.PROFILE)
+  @UniformResponse(ModelName.PROFILE)
   public async update(@Body() body: UpdateProfileDto) {
     return this.service.updateOneById(body);
   }

--- a/src/profile/profile.controller.ts
+++ b/src/profile/profile.controller.ts
@@ -15,7 +15,6 @@ import { UpdateProfileDto } from './dto/updateProfile.dto';
 import { ProfileDto } from './dto/profile.dto';
 import { BasicGET } from '../common/base/decorator/BasicGET.decorator';
 import { BasicDELETE } from '../common/base/decorator/BasicDELETE.decorator';
-import { BasicPUT } from '../common/base/decorator/BasicPUT.decorator';
 import { ModelName } from '../common/enum/modelName.enum';
 import { NoAuth } from '../auth/decorator/NoAuth.decorator';
 import { Action } from '../authorization/enum/action.enum';


### PR DESCRIPTION
### Brief description

This PR fixed `PUT` method for endpoint `/player` and `/profile` with adding requestBody as `UpdatePlayerDto`/`UpdateProfileDto`.

### Change list

- `updatePlayerDto.ts` - Add `@ApiProperty` for indicating `ModifyAvatarDto` properties
- `ModifyAvatarDto.ts` - Add `@ApiProperty` for indicating `AvatarPieceDto` properties
- `player.controller.ts` - Add `@UniformResponse`, return value if `MongooseError` appeared, if success - 204 with no content.
- `profile.controller.ts` - Add `@UniformResponse` for indicating `UpdateProfileDto` properties on Swagger's RequestBody