### PR TITLE
Fix issue 807: GET friendship_id from /friendship

### DIFF
--- a/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
@@ -22,7 +22,7 @@ export default class FriendlistDtoBuilder
     this.base._friendship_id = friendshipId;
     return this;
   }
-  
+
   setId(Id: string): this {
     this.base._id = Id;
     return this;

--- a/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
+++ b/src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts
@@ -6,6 +6,7 @@ export default class FriendlistDtoBuilder
   implements IDataBuilder<FriendlistDto>
 {
   private readonly base: FriendlistDto = {
+    _friendship_id: new ObjectId().toString(),
     _id: new ObjectId().toString(),
     name: 'defaultName',
     avatar: undefined,
@@ -17,6 +18,11 @@ export default class FriendlistDtoBuilder
     return { ...this.base } as FriendlistDto;
   }
 
+  setFriendshipId(friendshipId: string): this {
+    this.base._friendship_id = friendshipId;
+    return this;
+  }
+  
   setId(Id: string): this {
     this.base._id = Id;
     return this;

--- a/src/friendship/dto/friend-list.dto.ts
+++ b/src/friendship/dto/friend-list.dto.ts
@@ -6,6 +6,15 @@ export class FriendlistDto {
   @Expose()
   @ExtractField()
   /**
+   * friendship ID of the friends
+   *
+   * @example "60f7c2d9a2d3c7b7e56d01df"
+   */
+  _friendship_id: string;
+  
+  @Expose()
+  @ExtractField()
+  /**
    * player ID of the friend
    *
    * @example "60f7c2d9a2d3c7b7e56d01df"

--- a/src/friendship/dto/friend-list.dto.ts
+++ b/src/friendship/dto/friend-list.dto.ts
@@ -11,7 +11,7 @@ export class FriendlistDto {
    * @example "60f7c2d9a2d3c7b7e56d01df"
    */
   _friendship_id: string;
-  
+
   @Expose()
   @ExtractField()
   /**

--- a/src/friendship/friendship.service.ts
+++ b/src/friendship/friendship.service.ts
@@ -53,6 +53,7 @@ export class FriendshipService {
           doc.playerA._id.toString() === me ? doc.playerB : doc.playerA;
 
         return {
+          _friendship_id: doc._id.toString(),
           _id: friend._id.toString(),
           name: friend.name,
           avatar: friend.avatar,


### PR DESCRIPTION
### Brief description

Fix to issue 807 as requested: GET from /friendship gives now `_friendship_id`, too.

Tested with Postman and added test to `src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts`

### Change list

- `src/__tests__/friendship/data/builder/FriendlistDtoBuilder.ts`
- `src/friendship/dto/friend-list.dto.ts`
- `src/friendship/friendship.service.ts`

### Other info

This fix is done over 14.4.2026 dev branch update.
