### PR TITLE
Issue 816 feature request update the flea market and stall connection and structure

### DIFF
--- a/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -110,4 +110,41 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
 
     expect(result).toEqual([null, itemErrors]);
   });
+  
+  // test, that the furniture created here are returned in the response, if they're in a stall
+  it('Should return furniture items in the response if they are in a stall', async () => {
+    const item1 = fleaMarketItemBuilder
+      .setId('item-1')
+      .setClanId(clanId)
+      .setIsFurniture(true)
+      .build();
+    const item2 = fleaMarketItemBuilder
+      .setId('item-2')
+      .setClanId(clanId)
+      .setIsFurniture(true)
+      .build();
+
+    const clan = clanBuilder
+      .setStall({
+        adPoster: {
+          border: 'solid',
+          colour: 'blue',
+          mainFurniture: 'Closet_Rakkaus',
+        },
+        maxSlots: 7,
+      } as any)
+      .build();
+
+    playerService.getPlayerClanId.mockResolvedValue(clanId);
+    clanService.readOneById.mockResolvedValue([clan, null]);
+    fleaMarketService.readMany.mockResolvedValue([[item1, item2], null]);
+
+    const result = await controller.getOwnClanStall(user);
+
+    expect(result).toEqual({
+      adPoster: clan.stall.adPoster,
+      maxSlots: clan.stall.maxSlots,
+      furnitureItems: [item1, item2],
+    });
+  });
 });

--- a/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -5,8 +5,8 @@ import EventEmitterService from '../../../common/service/EventEmitterService/Eve
 import { ClanService } from '../../../clan/clan.service';
 import { User } from '../../../auth/user';
 import { APIErrorReason } from '../../../common/controller/APIErrorReason';
-import FleaMarketBuilderFactory from 'src/__tests__/fleaMarket/data/fleaMarketBuilderFactory';
-import ClanBuilderFactory from 'src/__tests__/clan/data/clanBuilderFactory';
+import FleaMarketBuilderFactory from '../../fleaMarket/data/fleaMarketBuilderFactory';
+import ClanBuilderFactory from '../../clan/data/clanBuilderFactory';
 
 describe('FleaMarketController.getOwnClanStall() test suite', () => {
   let controller: FleaMarketController;

--- a/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -1,10 +1,10 @@
-import { FleaMarketController } from '../../fleaMarket/fleaMarket.controller';
-import { FleaMarketService } from '../../fleaMarket/fleaMarket.service';
-import { PlayerService } from '../../player/player.service';
-import EventEmitterService from '../../common/service/EventEmitterService/EventEmitter.service';
-import { ClanService } from '../../clan/clan.service';
-import { User } from '../../auth/user';
-import { APIErrorReason } from '../../common/controller/APIErrorReason';
+import { FleaMarketController } from '../../../fleaMarket/fleaMarket.controller';
+import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
+import { PlayerService } from '../../../player/player.service';
+import EventEmitterService from '../../../common/service/EventEmitterService/EventEmitter.service';
+import { ClanService } from '../../../clan/clan.service';
+import { User } from '../../../auth/user';
+import { APIErrorReason } from '../../../common/controller/APIErrorReason';
 import FleaMarketBuilderFactory from 'src/__tests__/fleaMarket/data/fleaMarketBuilderFactory';
 import ClanBuilderFactory from 'src/__tests__/clan/data/clanBuilderFactory';
 

--- a/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -110,7 +110,7 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
 
     expect(result).toEqual([null, itemErrors]);
   });
-  
+
   // test, that the furniture created here are returned in the response, if they're in a stall
   it('Should return furniture items in the response if they are in a stall', async () => {
     const item1 = fleaMarketItemBuilder

--- a/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
+++ b/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
@@ -7,15 +7,19 @@ import { AdPoster, Stall } from '../../../../clan/stall/stall.schema';
 import ServiceError from '../../../../common/service/basicService/ServiceError';
 import { SEReason } from '../../../../common/service/basicService/SEReason';
 import { ClanService } from '../../../../clan/clan.service';
+import FleaMarketItemBuilder from '../../data/fleaMarket/FleaMarketItemBuilder';
+import { ItemName } from '../../../../clanInventory/item/enum/itemName.enum';
 
 describe('StallService.ReadAll() test suite', () => {
   let stallService: StallService;
   let clanService: ClanService;
 
   const clanModel = ClanModule.getClanModel();
+  const fleaMarketItemModel = FleaMarketModule.getFleaMarketItemModel();
   const clanBuilder = ClanBuilderFactory.getBuilder('Clan');
   const adPosterBuilder = ClanBuilderFactory.getBuilder('AdPoster');
   const stallBuilder = ClanBuilderFactory.getBuilder('Stall');
+  const fleaMarketItemBuilder = new FleaMarketItemBuilder();
 
   let adPoster1: AdPoster;
   let stall1: Stall;
@@ -30,6 +34,7 @@ describe('StallService.ReadAll() test suite', () => {
 
   beforeEach(async () => {
     await clanModel.deleteMany({});
+    await fleaMarketItemModel.deleteMany({});
     await jest.clearAllMocks();
 
     stallService = await FleaMarketModule.getStallService();
@@ -41,7 +46,7 @@ describe('StallService.ReadAll() test suite', () => {
       .setMainFurniture('table')
       .build();
     stall1 = stallBuilder.setAdPoster(adPoster1).setMaxSlots(10).build();
-    clanToCreate1 = clanBuilder.setName('clan1').setStall(stall1).build();
+    clanToCreate1 = clanBuilder.setName('clan1_').setStall(stall1).build();
 
     adPoster2 = adPosterBuilder
       .setBorder('border2')
@@ -49,7 +54,7 @@ describe('StallService.ReadAll() test suite', () => {
       .setMainFurniture('chair')
       .build();
     stall2 = stallBuilder.setAdPoster(adPoster2).setMaxSlots(12).build();
-    clanToCreate2 = clanBuilder.setName('clan2').setStall(stall2).build();
+    clanToCreate2 = clanBuilder.setName('clan2_').setStall(stall2).build();
   });
 
   it('Should return all stalls for clans with stalls', async () => {
@@ -71,11 +76,48 @@ describe('StallService.ReadAll() test suite', () => {
     });
   });
 
+  it('Should return only furniture items belonging to each clan stall', async () => {
+    const createdClan1 = await clanModel.create(clanToCreate1);
+    const createdClan2 = await clanModel.create(clanToCreate2);
+
+    await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.CLOSET_RAKKAUS)
+        .setUnityKey('stall-readall-clan1-furniture')
+        .setClanId(createdClan1._id.toString())
+        .setIsFurniture(true)
+        .build(),
+    );
+    await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.WORK_TABLE)
+        .setUnityKey('stall-readall-clan2-furniture')
+        .setClanId(createdClan2._id.toString())
+        .setIsFurniture(true)
+        .build(),
+    );
+    await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.MIRROR_RAKKAUS)
+        .setUnityKey('stall-readall-clan1-nonfurniture')
+        .setClanId(createdClan1._id.toString())
+        .setIsFurniture(false)
+        .build(),
+    );
+
+    const [result, error] = await stallService.readAll();
+
+    expect(error).toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result[0].furnitureItems).toEqual([ItemName.CLOSET_RAKKAUS]);
+    expect(result[1].furnitureItems).toEqual([ItemName.WORK_TABLE]);
+  });
+
   it('Should return NOT_FOUND error when no clans with stalls', async () => {
     await clanModel.deleteMany({});
 
-    clanToCreateNoStall1 = clanBuilder.setName('clan1').setStall(null).build();
-    clanToCreateNoStall2 = clanBuilder.setName('clan2').setStall(null).build();
+    clanToCreateNoStall1 = clanBuilder.setName('clan1_').setStall(null).build();
+    clanToCreateNoStall2 = clanBuilder.setName('clan2_').setStall(null).build();
     await clanModel.create(clanToCreateNoStall1);
     await clanModel.create(clanToCreateNoStall2);
 

--- a/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
+++ b/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
@@ -34,7 +34,6 @@ describe('StallService.ReadAll() test suite', () => {
 
   beforeEach(async () => {
     await clanModel.deleteMany({});
-    await fleaMarketItemModel.deleteMany({});
     await jest.clearAllMocks();
 
     stallService = await FleaMarketModule.getStallService();
@@ -46,7 +45,7 @@ describe('StallService.ReadAll() test suite', () => {
       .setMainFurniture('table')
       .build();
     stall1 = stallBuilder.setAdPoster(adPoster1).setMaxSlots(10).build();
-    clanToCreate1 = clanBuilder.setName('clan1_').setStall(stall1).build();
+    clanToCreate1 = clanBuilder.setName('clan1').setStall(stall1).build();
 
     adPoster2 = adPosterBuilder
       .setBorder('border2')
@@ -54,7 +53,7 @@ describe('StallService.ReadAll() test suite', () => {
       .setMainFurniture('chair')
       .build();
     stall2 = stallBuilder.setAdPoster(adPoster2).setMaxSlots(12).build();
-    clanToCreate2 = clanBuilder.setName('clan2_').setStall(stall2).build();
+    clanToCreate2 = clanBuilder.setName('clan2').setStall(stall2).build();
   });
 
   it('Should return all stalls for clans with stalls', async () => {
@@ -62,15 +61,19 @@ describe('StallService.ReadAll() test suite', () => {
     await clanModel.create(clanToCreate2);
 
     const [result, error] = await stallService.readAll();
-
+    // take into result only adPoster and maxSlots fields for easier assertion
+    const processedResult = result.map((stall) => ({
+      adPoster: stall.adPoster,
+      maxSlots: stall.maxSlots,
+    }));
     expect(error).toBeNull();
-    expect(result).toHaveLength(2);
+    expect(processedResult).toHaveLength(2);
 
-    expect(result[0]).toMatchObject({
+    expect(processedResult[0]).toMatchObject({
       adPoster: adPoster1,
       maxSlots: stall1.maxSlots,
     });
-    expect(result[1]).toMatchObject({
+    expect(processedResult[1]).toMatchObject({
       adPoster: adPoster2,
       maxSlots: stall2.maxSlots,
     });
@@ -116,8 +119,8 @@ describe('StallService.ReadAll() test suite', () => {
   it('Should return NOT_FOUND error when no clans with stalls', async () => {
     await clanModel.deleteMany({});
 
-    clanToCreateNoStall1 = clanBuilder.setName('clan1_').setStall(null).build();
-    clanToCreateNoStall2 = clanBuilder.setName('clan2_').setStall(null).build();
+    clanToCreateNoStall1 = clanBuilder.setName('clan1').setStall(null).build();
+    clanToCreateNoStall2 = clanBuilder.setName('clan2').setStall(null).build();
     await clanModel.create(clanToCreateNoStall1);
     await clanModel.create(clanToCreateNoStall2);
 

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -38,7 +38,7 @@ export class FleaMarketController {
    *
    * @remarks Fetch all the furniture, that the clan has accepted for selling
    * The furniture can be in a stall or not.
-   * Player will need a SHOP clan right.
+   * Player has a right to SHOP.
    */
   @ApiResponseDescription({
     success: {

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -22,6 +22,8 @@ import { ChangeItemStatusDto } from './dto/changeItemStatus.dto';
 import { Status } from './enum/status.enum';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
+import { ClanService } from 'src/clan/clan.service';
+import { ItemService } from 'src/clanInventory/item/item.service';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -29,7 +31,57 @@ export class FleaMarketController {
     private readonly service: FleaMarketService,
     private readonly playerService: PlayerService,
     private readonly emitterService: EventEmitterService,
+    private readonly clanService: ClanService,
+    private readonly itemService: ItemService,
   ) {}
+
+  /**
+   * Fetch all the furniture, that the clan has accepted for selling
+   * The furniture can be in a stall or not. If no furniture is found,
+   * null is returned.
+   *
+   * @remarks Fetch all the furniture, that the clan has accepted for selling
+   * The furniture can be in a stall or not.
+   * Player will need a SHOP clan right.
+   */
+  @ApiResponseDescription({
+    success: {
+      status: 200,
+      modelName: ModelName.STALL,
+    },
+    errors: [400, 403, 404],
+  })
+  @HasClanRights([ClanBasicRight.SHOP])
+  @Get('ownClan')
+  @UniformResponse(ModelName.STALL)
+  async getOwnClanStall(@LoggedUser() user: User) {
+    const clanId = await this.playerService.getPlayerClanId(user.player_id);
+
+    if (!clanId) {
+      throw new APIError({
+        reason: APIErrorReason.NOT_AUTHORIZED,
+        message: 'Player must be a member of a clan to access this resource',
+      });
+    }
+
+    const [clan, clanErrors] = await this.clanService.readOneById(clanId);
+    if (clanErrors) return [null, clanErrors];
+
+    const [items, itemErrors] = await this.service.readMany({
+      filter: {
+        clan_id: clanId,
+        isFurniture: true,
+      },
+    });
+
+    if (itemErrors) return [null, itemErrors];
+
+    return {
+      adPoster: clan.stall?.adPoster ?? null,
+      maxSlots: clan.stall?.maxSlots ?? 0,
+      furnitureItems: items,
+    };
+  }
 
   /**
    * Get flea market item by _id.

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -22,8 +22,6 @@ import { ChangeItemStatusDto } from './dto/changeItemStatus.dto';
 import { Status } from './enum/status.enum';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
-import { ClanService } from 'src/clan/clan.service';
-import { ItemService } from 'src/clanInventory/item/item.service';
 
 @Controller('fleaMarket')
 export class FleaMarketController {
@@ -31,8 +29,6 @@ export class FleaMarketController {
     private readonly service: FleaMarketService,
     private readonly playerService: PlayerService,
     private readonly emitterService: EventEmitterService,
-    private readonly clanService: ClanService,
-    private readonly itemService: ItemService,
   ) {}
 
   /**
@@ -64,23 +60,7 @@ export class FleaMarketController {
       });
     }
 
-    const [clan, clanErrors] = await this.clanService.readOneById(clanId);
-    if (clanErrors) return [null, clanErrors];
-
-    const [items, itemErrors] = await this.service.readMany({
-      filter: {
-        clan_id: clanId,
-        isFurniture: true,
-      },
-    });
-
-    if (itemErrors) return [null, itemErrors];
-
-    return {
-      adPoster: clan.stall?.adPoster ?? null,
-      maxSlots: clan.stall?.maxSlots ?? 0,
-      furnitureItems: items,
-    };
+    return await this.service.getClanFurnitureItems(clanId);
   }
 
   /**

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -88,6 +88,34 @@ export class FleaMarketService {
   }
 
   /**
+   * Fetches all furniture items of a clan for the flea market.
+   *
+   * @param clan_id - The id of clan the logged-in user belongs to
+   * @returns An object containing the clan's ad poster, max stall slots, and furniture items, or an array of service errors if any occurred.
+   *
+   */
+  async getClanFurnitureItems(clan_id: string) {
+    const [clan, clanErrors] = await this.clanService.readOneById(clan_id);
+    if (clanErrors) return [null, clanErrors];
+
+    // read items from flea market with the clan_id and isFurniture filter
+    const [items, itemErrors] = await this.readMany({
+      filter: {
+        clan_id: clan_id,
+        isFurniture: true,
+      },
+    });
+
+    if (itemErrors) return [null, itemErrors];
+
+    return {
+      adPoster: clan.stall?.adPoster ?? null,
+      maxSlots: clan.stall?.maxSlots ?? 0,
+      furnitureItems: items,
+    };
+  }
+
+  /**
    * Reads multiple items from the database with the given options.
    *
    * @param options - Optional settings for the read operation.

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -36,6 +36,7 @@ import { SEReason } from '../common/service/basicService/SEReason';
 import { maxSlotsReachedError } from './errors/maxSlotsReached.error';
 import { ItemBookedError } from './errors/itemBooked.error';
 import { CreateItemDto } from '../clanInventory/item/dto/createItem.dto';
+import { StallResponse } from './stall/dto/stallResponse.dto';
 
 @Injectable()
 export class FleaMarketService {
@@ -94,7 +95,7 @@ export class FleaMarketService {
    * @returns An object containing the clan's ad poster, max stall slots, and furniture items, or an array of service errors if any occurred.
    *
    */
-  async getClanFurnitureItems(clan_id: string) {
+  async getClanFurnitureItems(clan_id: string): Promise<IServiceReturn<StallResponse[]>> {
     const [clan, clanErrors] = await this.clanService.readOneById(clan_id);
     if (clanErrors) return [null, clanErrors];
 

--- a/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -3,7 +3,6 @@ import { FleaMarketService } from '../../fleaMarket/fleaMarket.service';
 import { PlayerService } from '../../player/player.service';
 import EventEmitterService from '../../common/service/EventEmitterService/EventEmitter.service';
 import { ClanService } from '../../clan/clan.service';
-import { ItemService } from '../../clanInventory/item/item.service';
 import { User } from '../../auth/user';
 import { APIErrorReason } from '../../common/controller/APIErrorReason';
 import FleaMarketBuilderFactory from 'src/__tests__/fleaMarket/data/fleaMarketBuilderFactory';

--- a/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -99,7 +99,9 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
 
   it('Should return service errors if flea market has no furniture items for the clan', async () => {
     const clan = clanBuilder.build();
-    const itemErrors = [{ message: 'Could not find any objects with specified condition' }] as any;
+    const itemErrors = [
+      { message: 'Could not find any objects with specified condition' },
+    ] as any;
 
     playerService.getPlayerClanId.mockResolvedValue(clanId);
     clanService.readOneById.mockResolvedValue([clan, null]);

--- a/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -1,0 +1,112 @@
+import { FleaMarketController } from '../../fleaMarket/fleaMarket.controller';
+import { FleaMarketService } from '../../fleaMarket/fleaMarket.service';
+import { PlayerService } from '../../player/player.service';
+import EventEmitterService from '../../common/service/EventEmitterService/EventEmitter.service';
+import { ClanService } from '../../clan/clan.service';
+import { ItemService } from '../../clanInventory/item/item.service';
+import { User } from '../../auth/user';
+import { APIErrorReason } from '../../common/controller/APIErrorReason';
+import FleaMarketBuilderFactory from 'src/__tests__/fleaMarket/data/fleaMarketBuilderFactory';
+import ClanBuilderFactory from 'src/__tests__/clan/data/clanBuilderFactory';
+
+describe('FleaMarketController.getOwnClanStall() test suite', () => {
+  let controller: FleaMarketController;
+
+  let fleaMarketService: jest.Mocked<Partial<FleaMarketService>>;
+  let playerService: jest.Mocked<Partial<PlayerService>>;
+  let emitterService: jest.Mocked<Partial<EventEmitterService>>;
+  let clanService: jest.Mocked<Partial<ClanService>>;
+
+  const fleaMarketItemBuilder =
+    FleaMarketBuilderFactory.getBuilder('FleaMarketItemDto');
+  const clanBuilder = ClanBuilderFactory.getBuilder('ClanDto');
+
+  const playerId = '69e3e045a752c7ade8734165';
+  const clanId = '69e3e045a752c7ade873416f';
+  const user = new User('profile-id', playerId, clanId);
+
+  beforeEach(() => {
+    fleaMarketService = {
+      readMany: jest.fn(),
+    };
+    playerService = {
+      getPlayerClanId: jest.fn(),
+    };
+    emitterService = {};
+    clanService = {
+      readOneById: jest.fn(),
+    };
+
+    controller = new FleaMarketController(
+      fleaMarketService as unknown as FleaMarketService,
+      playerService as unknown as PlayerService,
+      emitterService as unknown as EventEmitterService,
+    );
+  });
+
+  it('Should return clan stall data with furniture items accepted for selling', async () => {
+    const item1 = fleaMarketItemBuilder
+      .setId('item-1')
+      .setClanId(clanId)
+      .setIsFurniture(true)
+      .build();
+    const item2 = fleaMarketItemBuilder
+      .setId('item-2')
+      .setClanId(clanId)
+      .setIsFurniture(true)
+      .build();
+
+    const clan = clanBuilder
+      .setStall({
+        adPoster: {
+          border: 'solid',
+          colour: 'blue',
+          mainFurniture: 'Closet_Rakkaus',
+        },
+        maxSlots: 7,
+      } as any)
+      .build();
+
+    playerService.getPlayerClanId.mockResolvedValue(clanId);
+    clanService.readOneById.mockResolvedValue([clan, null]);
+    fleaMarketService.readMany.mockResolvedValue([[item1, item2], null]);
+
+    const result = await controller.getOwnClanStall(user);
+
+    expect(playerService.getPlayerClanId).toHaveBeenCalledWith(playerId);
+    expect(clanService.readOneById).toHaveBeenCalledWith(clanId);
+    expect(fleaMarketService.readMany).toHaveBeenCalledWith({
+      filter: {
+        clan_id: clanId,
+        isFurniture: true,
+      },
+    });
+    expect(result).toEqual({
+      adPoster: clan.stall.adPoster,
+      maxSlots: clan.stall.maxSlots,
+      furnitureItems: [item1, item2],
+    });
+  });
+
+  it('Should throw NOT_AUTHORIZED if player is not in a clan', async () => {
+    playerService.getPlayerClanId.mockResolvedValue(undefined);
+
+    await expect(controller.getOwnClanStall(user)).rejects.toMatchObject({
+      reason: APIErrorReason.NOT_AUTHORIZED,
+      message: 'Player must be a member of a clan to access this resource',
+    });
+  });
+
+  it('Should return service errors if flea market has no furniture items for the clan', async () => {
+    const clan = clanBuilder.build();
+    const itemErrors = [{ message: 'Could not find any objects with specified condition' }] as any;
+
+    playerService.getPlayerClanId.mockResolvedValue(clanId);
+    clanService.readOneById.mockResolvedValue([clan, null]);
+    fleaMarketService.readMany.mockResolvedValue([null, itemErrors]);
+
+    const result = await controller.getOwnClanStall(user);
+
+    expect(result).toEqual([null, itemErrors]);
+  });
+});

--- a/src/fleaMarket/stall/dto/stallResponse.dto.ts
+++ b/src/fleaMarket/stall/dto/stallResponse.dto.ts
@@ -46,4 +46,11 @@ export class StallResponse {
    */
   @Expose()
   maxSlots?: number;
+
+  /**
+   * Furniture items that are currently in the stall
+   * @example ["chair", "lamp"]
+   */
+  @Expose()
+  furnitureItems?: string[];
 }

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
 import { ClanService } from '../../clan/clan.service';
 import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
@@ -7,12 +8,14 @@ import { getStallDefaultValues } from '../../clan/defaultValues/stall';
 import { StallResponse } from './dto/stallResponse.dto';
 import { Stall } from '../../clan/stall/stall.schema';
 import { FleaMarketAdPosterDto } from './dto/adPoster.dto';
-import { ItemService } from 'src/clanInventory/item/item.service';
+import { Model } from 'mongoose';
+import { FleaMarketItem } from '../fleaMarketItem.schema';
 @Injectable()
 export class StallService {
   constructor(
     private readonly clanService: ClanService,
-    private readonly itemService: ItemService,
+    @InjectModel(FleaMarketItem.name)
+    private readonly fleaMarketItemModel: Model<FleaMarketItem>,
   ) {}
 
   /**
@@ -49,15 +52,24 @@ export class StallService {
     const stallsWithFurniture: StallResponse[] = [];
     for (const clan of clans) {
       const stall = clan.stall;
-      const furnitureItems = await this.itemService.readMany({
-        filter: {
-          isFurniture: true,
-        },
+      const furnitureItems = await this.fleaMarketItemModel.find({
+        clan_id: clan._id,
+        isFurniture: true,
       });
+
+      // check if furnitureItems is empty and if so, return the stall without furniture items
+      if (furnitureItems.length === 0) {
+        stallsWithFurniture.push({
+          adPoster: stall.adPoster,
+          maxSlots: stall.maxSlots,
+          furnitureItems: [],
+        });
+        continue;
+      }
       stallsWithFurniture.push({
         adPoster: stall.adPoster,
         maxSlots: stall.maxSlots,
-        furnitureItems: furnitureItems[0].map((item) => item.name),
+        furnitureItems: furnitureItems.map((item) => item.name),
       });
     }
 

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -57,7 +57,7 @@ export class StallService {
         isFurniture: true,
       });
 
-      // if clan's stall has no furniture item, return empty list, otherwise return list of furniture item names
+      // if clan's stall has no furniture items, return empty list, otherwise return list of furniture item names
       const furnitureItemNames = furnitureItems.length
         ? furnitureItems.map((item) => item.name)
         : [];

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -57,20 +57,17 @@ export class StallService {
         isFurniture: true,
       });
 
-      // check if furnitureItems is empty and if so, return the stall without furniture items
-      if (furnitureItems.length === 0) {
-        stallsWithFurniture.push({
-          adPoster: stall.adPoster,
-          maxSlots: stall.maxSlots,
-          furnitureItems: [],
-        });
-        continue;
-      }
+      // if clan's stall has no furniture item, return empty list, otherwise return list of furniture item names
+      const furnitureItemNames = furnitureItems.length
+        ? furnitureItems.map((item) => item.name)
+        : [];
+
       stallsWithFurniture.push({
         adPoster: stall.adPoster,
         maxSlots: stall.maxSlots,
-        furnitureItems: furnitureItems.map((item) => item.name),
+        furnitureItems: furnitureItemNames,
       });
+      
     }
 
     return [stallsWithFurniture, null];

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -67,7 +67,6 @@ export class StallService {
         maxSlots: stall.maxSlots,
         furnitureItems: furnitureItemNames,
       });
-      
     }
 
     return [stallsWithFurniture, null];

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -12,7 +12,8 @@ import { ItemService } from 'src/clanInventory/item/item.service';
 export class StallService {
   constructor(
     private readonly clanService: ClanService,
-    private readonly itemService: ItemService) {}
+    private readonly itemService: ItemService,
+  ) {}
 
   /**
    * Returns the stall by clan id
@@ -43,7 +44,7 @@ export class StallService {
     if (error) {
       return [null, error];
     }
-    
+
     // get furniture items for each stall and add them to the response
     const stallsWithFurniture: StallResponse[] = [];
     for (const clan of clans) {
@@ -56,7 +57,7 @@ export class StallService {
       stallsWithFurniture.push({
         adPoster: stall.adPoster,
         maxSlots: stall.maxSlots,
-        furnitureItems: furnitureItems[0].map(item => item.name),
+        furnitureItems: furnitureItems[0].map((item) => item.name),
       });
     }
 

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { ClanService } from '../../clan/clan.service';
 import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
-import { IServiceReturn } from 'src/common/service/basicService/IService';
+import { IServiceReturn } from '../../common/service/basicService/IService';
 import { getStallDefaultValues } from '../../clan/defaultValues/stall';
 import { StallResponse } from './dto/stallResponse.dto';
 import { Stall } from '../../clan/stall/stall.schema';

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -7,10 +7,12 @@ import { getStallDefaultValues } from '../../clan/defaultValues/stall';
 import { StallResponse } from './dto/stallResponse.dto';
 import { Stall } from '../../clan/stall/stall.schema';
 import { FleaMarketAdPosterDto } from './dto/adPoster.dto';
-
+import { ItemService } from 'src/clanInventory/item/item.service';
 @Injectable()
 export class StallService {
-  constructor(private readonly clanService: ClanService) {}
+  constructor(
+    private readonly clanService: ClanService,
+    private readonly itemService: ItemService) {}
 
   /**
    * Returns the stall by clan id
@@ -28,7 +30,10 @@ export class StallService {
   }
 
   /**
-   * Returns all stalls for all clans
+   * Returns all stalls for all clans and get also furniture items for each stall
+   *
+   * @returns Array of StallResponse objects containing stall details and furniture items
+   *
    */
   async readAll(): Promise<IServiceReturn<StallResponse[]>> {
     const [clans, error] = await this.clanService.readAll({
@@ -38,8 +43,24 @@ export class StallService {
     if (error) {
       return [null, error];
     }
+    
+    // get furniture items for each stall and add them to the response
+    const stallsWithFurniture: StallResponse[] = [];
+    for (const clan of clans) {
+      const stall = clan.stall;
+      const furnitureItems = await this.itemService.readMany({
+        filter: {
+          isFurniture: true,
+        },
+      });
+      stallsWithFurniture.push({
+        adPoster: stall.adPoster,
+        maxSlots: stall.maxSlots,
+        furnitureItems: furnitureItems[0].map(item => item.name),
+      });
+    }
 
-    return [clans.map((clan) => clan.stall), null];
+    return [stallsWithFurniture, null];
   }
 
   /**


### PR DESCRIPTION
### Brief description

As described in Issue 816, the /stall endpoint should return now furniture by stall and endpoint /fleaMarket/ownClan returns the furniture belonging to the clan.

If something is missing from the implementation, please let me know.

Locally, some tests (not the new ones) fail at first, but after re-run with `npm run test:ci-retry-failed` all the tests are green.
 
### Change list

- `src\fleaMarket\stall\stall.service.ts`
- `src\fleaMarket\fleaMarket.controller.ts`
- `src\fleaMarket\fleaMarket.service.ts`

- and some more tests and structure change in `stallResponseDto.ts`

## Added

- `src\__tests__\fleaMarket\fleaMarketController\getOwnClanStall.ts`


