### PR TITLE
Hotfix regarding issue 816

### DIFF
--- a/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
+++ b/src/__tests__/fleaMarket/fleaMarketController/getOwnClanStall.test.ts
@@ -2,11 +2,12 @@ import { FleaMarketController } from '../../../fleaMarket/fleaMarket.controller'
 import { FleaMarketService } from '../../../fleaMarket/fleaMarket.service';
 import { PlayerService } from '../../../player/player.service';
 import EventEmitterService from '../../../common/service/EventEmitterService/EventEmitter.service';
-import { ClanService } from '../../../clan/clan.service';
 import { User } from '../../../auth/user';
 import { APIErrorReason } from '../../../common/controller/APIErrorReason';
 import FleaMarketBuilderFactory from '../../fleaMarket/data/fleaMarketBuilderFactory';
-import ClanBuilderFactory from '../../clan/data/clanBuilderFactory';
+import { StallResponse } from '../../../fleaMarket/stall/dto/stallResponse.dto';
+import { IServiceReturn } from '../../../common/service/basicService/IService';
+import ServiceError from '../../../common/service/basicService/ServiceError';
 
 describe('FleaMarketController.getOwnClanStall() test suite', () => {
   let controller: FleaMarketController;
@@ -14,11 +15,9 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
   let fleaMarketService: jest.Mocked<Partial<FleaMarketService>>;
   let playerService: jest.Mocked<Partial<PlayerService>>;
   let emitterService: jest.Mocked<Partial<EventEmitterService>>;
-  let clanService: jest.Mocked<Partial<ClanService>>;
 
   const fleaMarketItemBuilder =
     FleaMarketBuilderFactory.getBuilder('FleaMarketItemDto');
-  const clanBuilder = ClanBuilderFactory.getBuilder('ClanDto');
 
   const playerId = '69e3e045a752c7ade8734165';
   const clanId = '69e3e045a752c7ade873416f';
@@ -26,15 +25,12 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
 
   beforeEach(() => {
     fleaMarketService = {
-      readMany: jest.fn(),
+      getClanFurnitureItems: jest.fn(),
     };
     playerService = {
       getPlayerClanId: jest.fn(),
     };
     emitterService = {};
-    clanService = {
-      readOneById: jest.fn(),
-    };
 
     controller = new FleaMarketController(
       fleaMarketService as unknown as FleaMarketService,
@@ -43,7 +39,7 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
     );
   });
 
-  it('Should return clan stall data with furniture items accepted for selling', async () => {
+  it("Should return clan furniture items whether they're in the stall or not", async () => {
     const item1 = fleaMarketItemBuilder
       .setId('item-1')
       .setClanId(clanId)
@@ -55,36 +51,22 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
       .setIsFurniture(true)
       .build();
 
-    const clan = clanBuilder
-      .setStall({
-        adPoster: {
-          border: 'solid',
-          colour: 'blue',
-          mainFurniture: 'Closet_Rakkaus',
-        },
-        maxSlots: 7,
-      } as any)
-      .build();
-
     playerService.getPlayerClanId.mockResolvedValue(clanId);
-    clanService.readOneById.mockResolvedValue([clan, null]);
-    fleaMarketService.readMany.mockResolvedValue([[item1, item2], null]);
+
+    const serviceReturn: IServiceReturn<StallResponse> = [
+      { furnitureItems: ['item-1', 'item-2'] },
+      null,
+    ];
+    fleaMarketService.getClanFurnitureItems.mockResolvedValue(serviceReturn);
 
     const result = await controller.getOwnClanStall(user);
 
-    expect(playerService.getPlayerClanId).toHaveBeenCalledWith(playerId);
-    expect(clanService.readOneById).toHaveBeenCalledWith(clanId);
-    expect(fleaMarketService.readMany).toHaveBeenCalledWith({
-      filter: {
-        clan_id: clanId,
-        isFurniture: true,
-      },
-    });
-    expect(result).toEqual({
-      adPoster: clan.stall.adPoster,
-      maxSlots: clan.stall.maxSlots,
-      furnitureItems: [item1, item2],
-    });
+    // check that the created items are returned in the response
+    expect(result[0]).toBeDefined();
+    expect(result[0].furnitureItems).toHaveLength(2);
+    expect(result[0].furnitureItems).toEqual(
+      expect.arrayContaining(['item-1', 'item-2']),
+    );
   });
 
   it('Should throw NOT_AUTHORIZED if player is not in a clan', async () => {
@@ -97,54 +79,17 @@ describe('FleaMarketController.getOwnClanStall() test suite', () => {
   });
 
   it('Should return service errors if flea market has no furniture items for the clan', async () => {
-    const clan = clanBuilder.build();
-    const itemErrors = [
+    const itemErrors: ServiceError[] = [
       { message: 'Could not find any objects with specified condition' },
-    ] as any;
+    ] as unknown as ServiceError[];
 
     playerService.getPlayerClanId.mockResolvedValue(clanId);
-    clanService.readOneById.mockResolvedValue([clan, null]);
-    fleaMarketService.readMany.mockResolvedValue([null, itemErrors]);
+
+    const serviceReturn: IServiceReturn<StallResponse> = [null, itemErrors];
+    fleaMarketService.getClanFurnitureItems.mockResolvedValue(serviceReturn);
 
     const result = await controller.getOwnClanStall(user);
 
     expect(result).toEqual([null, itemErrors]);
-  });
-
-  // test, that the furniture created here are returned in the response, if they're in a stall
-  it('Should return furniture items in the response if they are in a stall', async () => {
-    const item1 = fleaMarketItemBuilder
-      .setId('item-1')
-      .setClanId(clanId)
-      .setIsFurniture(true)
-      .build();
-    const item2 = fleaMarketItemBuilder
-      .setId('item-2')
-      .setClanId(clanId)
-      .setIsFurniture(true)
-      .build();
-
-    const clan = clanBuilder
-      .setStall({
-        adPoster: {
-          border: 'solid',
-          colour: 'blue',
-          mainFurniture: 'Closet_Rakkaus',
-        },
-        maxSlots: 7,
-      } as any)
-      .build();
-
-    playerService.getPlayerClanId.mockResolvedValue(clanId);
-    clanService.readOneById.mockResolvedValue([clan, null]);
-    fleaMarketService.readMany.mockResolvedValue([[item1, item2], null]);
-
-    const result = await controller.getOwnClanStall(user);
-
-    expect(result).toEqual({
-      adPoster: clan.stall.adPoster,
-      maxSlots: clan.stall.maxSlots,
-      furnitureItems: [item1, item2],
-    });
   });
 });

--- a/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
+++ b/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
@@ -83,7 +83,7 @@ describe('StallService.ReadAll() test suite', () => {
     const createdClan1 = await clanModel.create(clanToCreate1);
     const createdClan2 = await clanModel.create(clanToCreate2);
 
-    await fleaMarketItemModel.create(
+    const furniture1 = await fleaMarketItemModel.create(
       fleaMarketItemBuilder
         .setName(ItemName.CLOSET_RAKKAUS)
         .setUnityKey('stall-readall-clan1-furniture')
@@ -91,7 +91,7 @@ describe('StallService.ReadAll() test suite', () => {
         .setIsFurniture(true)
         .build(),
     );
-    await fleaMarketItemModel.create(
+    const furniture2 = await fleaMarketItemModel.create(
       fleaMarketItemBuilder
         .setName(ItemName.WORK_TABLE)
         .setUnityKey('stall-readall-clan2-furniture')
@@ -112,7 +112,11 @@ describe('StallService.ReadAll() test suite', () => {
 
     expect(error).toBeNull();
     expect(result).toHaveLength(2);
+
+    expect(result[0].furnitureItemIds).toEqual([furniture1._id.toString()]);
     expect(result[0].furnitureItems).toEqual([ItemName.CLOSET_RAKKAUS]);
+
+    expect(result[1].furnitureItemIds).toEqual([furniture2._id.toString()]);
     expect(result[1].furnitureItems).toEqual([ItemName.WORK_TABLE]);
   });
 

--- a/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
+++ b/src/__tests__/fleaMarket/stall/StallService/readAll.test.ts
@@ -9,6 +9,7 @@ import { SEReason } from '../../../../common/service/basicService/SEReason';
 import { ClanService } from '../../../../clan/clan.service';
 import FleaMarketItemBuilder from '../../data/fleaMarket/FleaMarketItemBuilder';
 import { ItemName } from '../../../../clanInventory/item/enum/itemName.enum';
+import { Status } from '../../../../fleaMarket/enum/status.enum';
 
 describe('StallService.ReadAll() test suite', () => {
   let stallService: StallService;
@@ -117,6 +118,66 @@ describe('StallService.ReadAll() test suite', () => {
     expect(result[0].furnitureItems).toEqual([ItemName.CLOSET_RAKKAUS]);
 
     expect(result[1].furnitureItemIds).toEqual([furniture2._id.toString()]);
+    expect(result[1].furnitureItems).toEqual([ItemName.WORK_TABLE]);
+  });
+
+  it('Should return only available furniture items belonging to each clan stall', async () => {
+    const createdClan1 = await clanModel.create(clanToCreate1);
+    const createdClan2 = await clanModel.create(clanToCreate2);
+
+    const clan1StallFurniture = await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.CLOSET_RAKKAUS)
+        .setUnityKey('stall-readall-clan1-available-furniture')
+        .setClanId(createdClan1._id.toString())
+        .setIsFurniture(true)
+        .setStatus(Status.AVAILABLE)
+        .build(),
+    );
+
+    const clan2StallFurniture = await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.WORK_TABLE)
+        .setUnityKey('stall-readall-clan2-available-furniture')
+        .setClanId(createdClan2._id.toString())
+        .setIsFurniture(true)
+        .setStatus(Status.AVAILABLE)
+        .build(),
+    );
+
+    await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.MIRROR_RAKKAUS)
+        .setUnityKey('stall-readall-clan1-shipping-furniture')
+        .setClanId(createdClan1._id.toString())
+        .setIsFurniture(true)
+        .setStatus(Status.SHIPPING)
+        .build(),
+    );
+
+    await fleaMarketItemModel.create(
+      fleaMarketItemBuilder
+        .setName(ItemName.CARPET_RAKKAUS)
+        .setUnityKey('stall-readall-clan1-available-nonfurniture')
+        .setClanId(createdClan1._id.toString())
+        .setIsFurniture(false)
+        .setStatus(Status.AVAILABLE)
+        .build(),
+    );
+
+    const [result, error] = await stallService.readAll();
+
+    expect(error).toBeNull();
+    expect(result).toHaveLength(2);
+
+    expect(result[0].furnitureItemIds).toEqual([
+      clan1StallFurniture._id.toString(),
+    ]);
+    expect(result[0].furnitureItems).toEqual([ItemName.CLOSET_RAKKAUS]);
+
+    expect(result[1].furnitureItemIds).toEqual([
+      clan2StallFurniture._id.toString(),
+    ]);
     expect(result[1].furnitureItems).toEqual([ItemName.WORK_TABLE]);
   });
 

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -166,12 +166,12 @@ export class ClanShopService {
       voting._id,
     );
     if (deleteError) await cancelTransaction(session, deleteError);
-    
+
     await session.commitTransaction();
     await session.endSession();
-    
+
     return endTransaction(session, true);
-  } 
+  }
 
   /**
    * Handles the event when a vote is rejected.

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -114,7 +114,7 @@ export class FleaMarketController {
    * Notice that if a FleaMarketItem has already "Shipping" status 403 will be returned.
    *
    */
-  // @HasClanRights([ClanBasicRight.SHOP]) TODO: Temporary disable for testing
+  @HasClanRights([ClanBasicRight.SHOP])
   @ApiResponseDescription({
     success: {
       status: 204,

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -98,7 +98,7 @@ export class FleaMarketService {
   async getClanFurnitureItems(
     clan_id: string,
   ): Promise<IServiceReturn<StallResponse>> {
-    const [items, itemErrors] = await this.itemService.readMany({
+    const [items, itemErrors] = await this.basicService.readMany({
       filter: {
         clan_id: clan_id,
         isFurniture: true,
@@ -109,7 +109,7 @@ export class FleaMarketService {
 
     return [
       {
-        furnitureItems: items.map((item) => item._id.toString()),
+        furnitureItems: items,
       },
       null,
     ];

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -89,31 +89,27 @@ export class FleaMarketService {
   }
 
   /**
-   * Fetches all furniture items of a clan for the flea market.
+   * Fetches all furniture items of a clan.
    *
    * @param clan_id - The id of clan the logged-in user belongs to
    * @returns An object containing the clan's ad poster, max stall slots, and furniture items, or an array of service errors if any occurred.
    *
    */
-  async getClanFurnitureItems(clan_id: string): Promise<IServiceReturn<StallResponse[]>> {
-    const [clan, clanErrors] = await this.clanService.readOneById(clan_id);
-    if (clanErrors) return [null, clanErrors];
-
-    // read items from flea market with the clan_id and isFurniture filter
-    const [items, itemErrors] = await this.readMany({
+  async getClanFurnitureItems(
+    clan_id: string,
+  ): Promise<IServiceReturn<StallResponse>> {
+    const [items, itemErrors] = await this.itemService.readMany({
       filter: {
-        clan_id: clan_id,
-        isFurniture: true,
-      },
-    });
+          clan_id: clan_id,
+          isFurniture: true,
+        },
+      });
 
     if (itemErrors) return [null, itemErrors];
 
-    return {
-      adPoster: clan.stall?.adPoster ?? null,
-      maxSlots: clan.stall?.maxSlots ?? 0,
-      furnitureItems: items,
-    };
+    return [{
+      furnitureItems: items.map(item => item._id.toString())
+    }, null];
   }
 
   /**

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -100,16 +100,19 @@ export class FleaMarketService {
   ): Promise<IServiceReturn<StallResponse>> {
     const [items, itemErrors] = await this.itemService.readMany({
       filter: {
-          clan_id: clan_id,
-          isFurniture: true,
-        },
-      });
+        clan_id: clan_id,
+        isFurniture: true,
+      },
+    });
 
     if (itemErrors) return [null, itemErrors];
 
-    return [{
-      furnitureItems: items.map(item => item._id.toString())
-    }, null];
+    return [
+      {
+        furnitureItems: items.map((item) => item._id.toString()),
+      },
+      null,
+    ];
   }
 
   /**

--- a/src/fleaMarket/stall/dto/stallResponse.dto.ts
+++ b/src/fleaMarket/stall/dto/stallResponse.dto.ts
@@ -48,13 +48,14 @@ export class StallResponse {
   maxSlots?: number;
 
   /**
-   * ID of the stall's furniture items
-   * The ID is indirectly related to the stall the furniture item is in
-   * @example "507f1f77bcf86cd799440011"
+   * IDs of the stall's furniture items
+   * These IDs are related to the furniture items in the stall and can
+   * be used to fetch more detailed information about the items if needed.
+   * @example ["507f1f77bcf86cd799440011", "507f1f77bcf86cd799440012"]
    */
   @Expose()
-  _id?: string;
-  
+  furnitureItemIds?: string[];
+
   /**
    * Furniture items that are currently in the stall
    * @example ["chair", "lamp"]

--- a/src/fleaMarket/stall/dto/stallResponse.dto.ts
+++ b/src/fleaMarket/stall/dto/stallResponse.dto.ts
@@ -48,6 +48,14 @@ export class StallResponse {
   maxSlots?: number;
 
   /**
+   * ID of the stall's furniture items
+   * The ID is indirectly related to the stall the furniture item is in
+   * @example "507f1f77bcf86cd799440011"
+   */
+  @Expose()
+  _id?: string;
+  
+  /**
    * Furniture items that are currently in the stall
    * @example ["chair", "lamp"]
    */

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -59,12 +59,12 @@ export class StallService {
 
       // return ID of furniture item and furniture name
       const furnitureItemIds = furnitureItems.length
-      ? furnitureItems.map((item) => item._id.toString())
-      : [];
-    
+        ? furnitureItems.map((item) => item._id.toString())
+        : [];
+
       const furnitureItemNames = furnitureItems.length
-      ? furnitureItems.map((item) => item.name)
-      : [];
+        ? furnitureItems.map((item) => item.name)
+        : [];
 
       stallsWithFurniture.push({
         adPoster: stall.adPoster,

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -57,14 +57,19 @@ export class StallService {
         isFurniture: true,
       });
 
-      // if clan's stall has no furniture items, return empty list, otherwise return list of furniture item names
+      // return ID of furniture item and furniture name
+      const furnitureItemIds = furnitureItems.length
+      ? furnitureItems.map((item) => item._id.toString())
+      : [];
+    
       const furnitureItemNames = furnitureItems.length
-        ? furnitureItems.map((item) => item.name)
-        : [];
+      ? furnitureItems.map((item) => item.name)
+      : [];
 
       stallsWithFurniture.push({
         adPoster: stall.adPoster,
         maxSlots: stall.maxSlots,
+        furnitureItemIds: furnitureItemIds,
         furnitureItems: furnitureItemNames,
       });
     }

--- a/src/fleaMarket/stall/stall.service.ts
+++ b/src/fleaMarket/stall/stall.service.ts
@@ -10,6 +10,7 @@ import { Stall } from '../../clan/stall/stall.schema';
 import { FleaMarketAdPosterDto } from './dto/adPoster.dto';
 import { Model } from 'mongoose';
 import { FleaMarketItem } from '../fleaMarketItem.schema';
+import { Status } from '../enum/status.enum';
 @Injectable()
 export class StallService {
   constructor(
@@ -55,6 +56,7 @@ export class StallService {
       const furnitureItems = await this.fleaMarketItemModel.find({
         clan_id: clan._id,
         isFurniture: true,
+        status: Status.AVAILABLE,
       });
 
       // return ID of furniture item and furniture name


### PR DESCRIPTION
### Brief description

For completeness and to full fill client side's requirements also furniture IDs are now returned. They tell indirectly to which stall the furniture belongs to (GET /stall).

Example object:
{
  "adPoster": { "border": "solid", "colour": "blue" },
  "maxSlots": 7,
  "furnitureItemIds": ["507f1f77bcf86cd799440011", "507f1f77bcf86cd799440022"],
  "furnitureItems": ["Chair_Rakkaus", "Table_Lamppu"]
}

I forgot in the previous PR to uncomment one line related to testing. Now it's fixed.

For some reason from file `clanShop.service.ts` line `return endTransaction(session, true);` was missing, even though I hadn't touched that file. I committed the missing line, too.

GET /stall/ownClan returns furniture items from basicService.

### Change list

- among other files also `src\fleaMarket\stall\dto\stallResponse.dto` was changed so, that furniture IDs are returned, they indirectly refer to the stall the furniture belong to
