### PR TITLE
Switch @AddType('PlayerDto') to class PlayerDto

### DIFF
--- a/src/player/dto/player.dto.ts
+++ b/src/player/dto/player.dto.ts
@@ -9,7 +9,6 @@ import { AvatarDto } from './avatar.dto';
 import { Min } from 'class-validator';
 import { EmotionDto } from './emotion.dto';
 
-@AddType('PlayerDto')
 export class StatDetailDto {
   @Expose()
   name: string;
@@ -20,6 +19,7 @@ export class StatDetailDto {
   @Expose()
   wins: number;
 }
+@AddType('PlayerDto')
 export class PlayerDto {
   /**
    * Unique player ID
@@ -197,7 +197,7 @@ export class PlayerDto {
   @Type(() => StatDetailDto)
   @Expose()
   favouriteCharacter?: StatDetailDto;
-   /* A historical list of emotions recorded by the player on a daily basis.
+  /* A historical list of emotions recorded by the player on a daily basis.
    * Each entry contains the emotion type and the timestamp of the recording.
    * @type {[EmotionDto]}
    */


### PR DESCRIPTION
### Brief description

Small bug fix for #821 . One decorator switched to correct place.

For future reference: If `export class StatDetailDto` ever needs a decorator, it should be `@AddType('StatDetailDto')`.

### Change list

- `player.dto.ts`
