### PR TITLE
Tick bit/651 feature request clan role creation modification and granting someone a role should happen through a vote followup

### DIFF
--- a/src/clan/clan.service.ts
+++ b/src/clan/clan.service.ts
@@ -80,7 +80,7 @@ export class ClanService {
 
     if (process.env.NODE_ENV === 'test') {
       clanToCreate.name = `T_${Math.random().toString(36).substring(7, 12)}`;
-      console.log('DEBUG: Test running on DB ->', this.connection.name);
+      // console.log('DEBUG: Test running on DB ->', this.connection.name);
     }
 
     const [clan, clanErrors] = await this.basicService.createOne<Clan, ClanDto>(
@@ -169,7 +169,7 @@ export class ClanService {
       _id: clanId,
     } as UpdateClanDto;
 
-    return this.clanRoleService.applyGovernance(clanId, fullBody, body);
+    return await this.clanRoleService.applyGovernance(clanId, fullBody, body);
   }
 
   async readOneById(_id: string, options?: TReadByIdOptions) {
@@ -179,7 +179,7 @@ export class ClanService {
         publicReferences.includes(ref),
       );
     }
-    return this.basicService.readOneById<ClanDto>(_id, optionsToApply);
+    return await this.basicService.readOneById<ClanDto>(_id, optionsToApply);
   }
 
   async readAll(options?: TIServiceReadManyOptions) {
@@ -189,14 +189,14 @@ export class ClanService {
         publicReferences.includes(ref),
       );
     }
-    return this.basicService.readMany<ClanDto>(optionsToApply);
+    return await this.basicService.readMany<ClanDto>(optionsToApply);
   }
 
   async updateOne(
     updateInfo: Partial<Clan>,
     options: TIServiceUpdateOneOptions,
   ) {
-    return this.basicService.updateOne(updateInfo, options);
+    return await this.basicService.updateOne(updateInfo, options);
   }
 
   /**
@@ -240,54 +240,40 @@ export class ClanService {
           }
         }
 
-        // Build the update object using MongoDB operators
-        const mongooseUpdate: any = {};
+        const toDeleteStrings = (updateData.admin_idsToDelete || []).map(id => String(id));
+        const adminsAfterDeletion = (clan.admin_ids || [])
+          .map(id => String(id))
+          .filter(adminId => !toDeleteStrings.includes(adminId));
+        const adminIds = Array.from(new Set([
+          ...adminsAfterDeletion,
+          ...(updateData.admin_idsToAdd || [])
+            .map(id => String(id))
+            .filter(adminId => !toDeleteStrings.includes(adminId)),
+        ]));
+        const playersInClan: string[] = [];
 
-        // Check if we have both operations - if so, consolidate them
-        const hasDeletions = updateData.admin_idsToDelete && (updateData.admin_idsToDelete || []).length > 0;
-        const hasAdditions = updateData.admin_idsToAdd && (updateData.admin_idsToAdd || []).length > 0;
-
-        if (hasDeletions && hasAdditions) {
-          // Both operations: use $set to consolidate (avoid $pull/$addToSet conflict)
-          let finalAdminIds = (clan.admin_ids || []).map(id => String(id));
-          
-          // Remove admins to delete
-          const toDeleteStrings = (updateData.admin_idsToDelete || []).map(id => String(id));
-          finalAdminIds = finalAdminIds.filter(adminId => !toDeleteStrings.includes(adminId));
-          
-          // Add new admins
-          const uniqueAdmins = new Set([
-            ...finalAdminIds,
-            ...(updateData.admin_idsToAdd || []).map(id => String(id))
-          ]);
-          finalAdminIds = Array.from(uniqueAdmins);
-
-          mongooseUpdate.$set = { admin_ids: finalAdminIds };
-        } else if (hasDeletions) {
-          // Only deletions: use $pull - iterate and pull each ID individually
-          // MongoDB $pull with string values - pull each admin to delete
-          const adminsToPull = (updateData.admin_idsToDelete || []).map(id => String(id));
-          
-          // If multiple admins to delete, use $in; if single, use direct value
-          if (adminsToPull.length === 1) {
-            mongooseUpdate.$pull = { admin_ids: adminsToPull[0] };
-          } else {
-            mongooseUpdate.$pull = { admin_ids: { $in: adminsToPull } };
+        for (const player_id of adminIds) {
+          const [player] = await this.playerService.readOneById<Player>(
+            player_id,
+          );
+          if (player?.clan_id?.toString() === id.toString()) {
+            playersInClan.push(player_id);
           }
-        } else if (hasAdditions) {
-          // Only additions: use $addToSet
-          mongooseUpdate.$addToSet = {
-            admin_ids: { 
-              $each: (updateData.admin_idsToAdd || []).map(id => String(id)) 
-            }
-          };
+        }
+
+        if (playersInClan.length === 0) {
+          return [false, [new ServiceError({
+            reason: SEReason.REQUIRED,
+            field: 'admin_ids',
+            message: 'Clan must have at least one admin'
+          })]];
         }
 
         // Only pass the admin_ids update to the service
         // Don't include other fields when handling admin changes
         const [wasUpdated, updateErrors] = await this.basicService.updateOneById(
             id, 
-            mongooseUpdate, 
+            { admin_ids: playersInClan }, 
             options
         );
 

--- a/src/clan/role/clanRole.service.ts
+++ b/src/clan/role/clanRole.service.ts
@@ -31,6 +31,7 @@ import { VotingQueue } from '../../voting/voting.queue';
 import { VotingQueueName } from '../../voting/enum/VotingQueue.enum';
 import { VotingDto } from '../../voting/dto/voting.dto';
 import { GovernancePayload } from '../../voting/type/governancePayload';
+import { VoteChoice } from '../../voting/enum/choiceType.enum';
 
 @Injectable()
 export default class ClanRoleService {
@@ -382,59 +383,31 @@ export default class ClanRoleService {
   }
 
   async checkVotingOnExpire(voting: VotingDto): Promise<IServiceReturn<true>> {
-    if (process.env.NODE_ENV === 'test') {
-      console.log('DEBUG Test 1 - checkVotingOnExpire called');
-      console.log('  votingService exists:', !!this.votingService);
-    }
-    if (!this.votingService) {
-      if (process.env.NODE_ENV === 'test') {
-        console.log('  votingService is null, returning early');
-      }
+    const votePassed = this.votingService
+      ? await this.votingService.checkVotingSuccess(voting)
+      : voting.votes?.length > 0 &&
+        (voting.votes.filter((vote) => vote.choice === VoteChoice.YES).length /
+          voting.votes.length) *
+          100 >=
+          (voting.minPercentage || 51);
+    if (!votePassed) {
       return [true, null];
     }
 
-    try {
-      const votePassed = await this.votingService.checkVotingSuccess(voting);
-      if (process.env.NODE_ENV === 'test') {
-        console.log('  votePassed:', votePassed);
-      }
+    if (!voting.setClanRole?.player_id || !voting.setClanRole?.role_id) {
+      return [null, [new ServiceError({
+        reason: SEReason.REQUIRED,
+        field: 'setClanRole',
+        value: voting.setClanRole,
+        message: 'Voting is missing player_id or role_id for clan role update',
+      })]];
+    }
 
-      if (votePassed && voting.setClanRole) {
-        const playerIdToUpdate = voting.setClanRole.player_id?.toString ? voting.setClanRole.player_id.toString() : voting.setClanRole.player_id;
-        const roleIdToSet = voting.setClanRole.role_id;
-        
-        if (process.env.NODE_ENV === 'test') {
-          console.log('DEBUG Test 1 - Player role update:');
-          console.log('  votePassed:', votePassed);
-          console.log('  voting.setClanRole exists:', !!voting.setClanRole);
-          console.log('  playerIdToUpdate:', playerIdToUpdate);
-          console.log('  roleIdToSet:', roleIdToSet);
-        }
-        
-        if (playerIdToUpdate && roleIdToSet) {
-          // Find the player, manually assign the role_id, and save
-          const player = await this.playerModel.findById(playerIdToUpdate);
-          if (process.env.NODE_ENV === 'test') {
-            console.log('  Found player:', !!player);
-          }
-          if (player) {
-            player.clanRole_id = roleIdToSet;
-            const savedPlayer = await player.save();
-            if (process.env.NODE_ENV === 'test') {
-              console.log('  Saved player clanRole_id:', savedPlayer.clanRole_id);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      if (process.env.NODE_ENV === 'test') {
-        console.log('  Error in checkVotingSuccess:', error instanceof Error ? error.message : error);
-      }
-    }
-    
-    if (process.env.NODE_ENV === 'test') {
-      await new Promise(resolve => setTimeout(resolve, 300));
-    }
+    const [, updateErrors] = await this.playerBasicService.updateOneById(
+      voting.setClanRole.player_id.toString(),
+      { clanRole_id: new ObjectId(voting.setClanRole.role_id.toString()) },
+    );
+    if (updateErrors) return [null, updateErrors];
 
     return [true, null];
   }


### PR DESCRIPTION
### Brief description

I've been trying to get a hold of this PR.

Fixed clan role vote finalization so successful votes reliably update the player’s role, and invalid voting payloads are handled explicitly instead of silently doing nothing.

Locally `npm run test:ci` may give some errors, but after that `npm run test:ci-retry-failed` gives all green.

I haven't test this in practice, only corrected the 2 errors, that previously persisted.

### Change list

- Fixed clan admin updates so removed admin IDs are not accidentally kept or re-added.
- Ensured clan admin lists only keep players who actually belong to the clan.

- Updated clan role voting finalization to validate missing player_id / role_id data.
- Fixed accepted clan role votes so they reliably update the player’s clanRole_id.
- Removed brittle manual player save/debug logic from clan role vote finalization.

About the checkVotingOnExpire() method.

Now it:

- immediately returns [true, null] if the vote did not go through
- returns a SEReason.REQUIRED error if a player_id or role_id is missing in an approved SET_CLAN_ROLE vote
- updates the player's role via playerBasicService.updateOneById(...)
- removes the test debug and manual findById/save workarounds at the same time