### PR TITLE
839 bug in clanshop voting is not calculated with clan majority

### DIFF
--- a/src/__tests__/clanShop/clanShopService/checkVotingOnExpire.test.ts
+++ b/src/__tests__/clanShop/clanShopService/checkVotingOnExpire.test.ts
@@ -9,6 +9,7 @@ import FleaMarketBuilderFactory from '../../fleaMarket/data/fleaMarketBuilderFac
 import { VoteChoice } from '../../../voting/enum/choiceType.enum';
 import { VotingQueueName } from '../../../voting/enum/VotingQueue.enum';
 import { itemProperties } from '../../../clanInventory/item/const/itemProperties';
+import { VotingType } from '../../../voting/enum/VotingType.enum';
 
 jest.mock('mqtt', () => ({
   connect: jest.fn(() => ({
@@ -85,6 +86,37 @@ describe('ClanShopService.checkVotingOnExpire() test suite', () => {
 
     const dbItem = await itemModel.find();
     expect(dbItem[0]).toMatchObject(itemProperties[item.name]);
+  });
+
+  it('Should process a passed clan shop voting event and create an item immediately', async () => {
+    const voteToCreate = voteBuilder
+      .setChoice(VoteChoice.YES)
+      .setPlayerId(new ObjectId().toString())
+      .build();
+    const votingToCreate = votingBuilder
+      .setType(VotingType.SHOP_BUY_ITEM)
+      .setOrganizer({
+        player_id: player._id.toString(),
+        clan_id: clanToCreate._id.toString(),
+      })
+      .setShopItemName(item.name)
+      .addVote(voteToCreate)
+      .build();
+
+    await expect(
+      clanShopService.handleVotingPassed({ voting: votingToCreate }),
+    ).resolves.not.toThrow();
+
+    const dbItem = await itemModel.findOne({
+      stock_id: stockToCreate._id,
+      unityKey: item.name,
+    });
+
+    expect(dbItem).toMatchObject({
+      ...itemProperties[item.name],
+      stock_id: stockToCreate._id,
+      room_id: null,
+    });
   });
 
   it('Should process a rejected vote and return funds to the clan', async () => {

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -130,8 +130,7 @@ export class ClanShopService {
    * 2. Checks if the voting process was successful.
    *    - If successful, processes the passed vote and handles any errors.
    *    - If rejected, processes the rejected vote and handles any errors.
-   * 3. Deletes the voting record from the database and handles any errors.
-   * 4. Commits the transaction and ends the session.
+   * 3. Commits the transaction and ends the session.
    *
    * If any error occurs during the process, the transaction is canceled, and the session is ended.
    *
@@ -144,7 +143,7 @@ export class ClanShopService {
     const [session, sessionError] = await initializeSession(this.connection);
     if (sessionError) return [null, sessionError];
 
-    const votePassed = await this.votingService.checkVotingSuccess(voting);
+    const votePassed = await this.votingService.checkVotingSuccess(voting, true);
 
     if (votePassed) {
       const [, passedError] = await this.handleVotePassed(

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -25,6 +25,7 @@ import {
 } from '../common/function/Transactions';
 import { InjectConnection } from '@nestjs/mongoose';
 import { IServiceReturn } from '../common/service/basicService/IService';
+import { OnEvent } from '@nestjs/event-emitter';
 
 @Injectable()
 export class ClanShopService {
@@ -161,9 +162,32 @@ export class ClanShopService {
       if (rejectError) return cancelTransaction(session, rejectError);
     }
 
-    await this.votingService.finalizeVoting(voting._id);
+    if (!voting.endedAt) {
+      await this.votingService.finalizeVoting(voting._id);
+    }
 
     return await endTransaction(session, true);
+  }
+
+  @OnEvent('voting.passed')
+  async handleVotingPassed(payload: { voting: VotingDto }) {
+    if (payload.voting.type !== VotingType.SHOP_BUY_ITEM) return;
+
+    const clanId = payload.voting.organizer.clan_id;
+    const item = itemProperties[payload.voting.shopItemName];
+
+    const [clan, clanErrors] = await this.clanService.readOneById(clanId, {
+      includeRefs: [ModelName.STOCK],
+    });
+    if (clanErrors) return;
+
+    await this.checkVotingOnExpire({
+      voting: payload.voting,
+      price: item.price,
+      clanId,
+      stockId: clan.Stock._id,
+      queue: VotingQueueName.CLAN_SHOP,
+    });
   }
 
   /**

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -163,10 +163,7 @@ export class ClanShopService {
 
     await this.votingService.finalizeVoting(voting._id);
 
-    await session.commitTransaction();
-    await session.endSession();
-
-    return endTransaction(session, true);
+    return await endTransaction(session, true);
   }
 
   /**


### PR DESCRIPTION
### Brief description

When voting for buying an item, it happens with clan majority.
If there's clear majority before the 10 minutes of time, the voting ends.

### Change list

- similar implementation, than in the `fleaMarket.service.ts`
- `clanShop.service.ts`

The following change is important:

```
if (!voting.endedAt) {
  await this.votingService.finalizeVoting(voting._id);
}
return await endTransaction(session, true);

```

These lines:

```
await session.commitTransaction();
await session.endSession();
```

with

`endTransaction(session, true);`

cause a double commit to DB and runtime failure. `endTransaction` requires `await` before it, too. `await` is added now and those lines, that cause double commit are removed. In other words those two lines and `endTransaction` do the exact same thing. In this implementation, the both would cause a runtime error.