### PR TITLE
819 Addressed the limits of the votes bug

### DIFF
--- a/src/__tests__/voting/VotingService/addVote.test.ts
+++ b/src/__tests__/voting/VotingService/addVote.test.ts
@@ -52,7 +52,10 @@ describe('VotingService.addVote() test suite', () => {
       .setFleamarketItemId(entityId)
       .build();
 
-    return await votingModel.create(votingToCreate);
+    return await votingModel.create({
+      ...votingToCreate,
+      endsOn: new Date(Date.now() + 60 * 60 * 1000),
+    });
   };
 
   it('Should add a vote successfully for a valid input', async () => {
@@ -79,31 +82,45 @@ describe('VotingService.addVote() test suite', () => {
   });
 
   it('Should not allow voting twice by the same user', async () => {
-    const player = await createTestPlayer();
-    const fleaMarket = await createTestFleaMarketItem();
-    const voting = await createTestVoting(
-      { player_id: player._id, clan_id: null },
-      fleaMarket._id.toString(),
-    );
+  const player = await createTestPlayer();
+  const fleaMarket = await createTestFleaMarketItem();
+  
+  // Pre-seed NO votes so the player's YES vote doesn't trigger finalization
+  // (1 yes / 3 votes = 33%, below 51%)
+  const votingToCreate = votingBuilder
+    .setMinPercentage(51)
+    .setType(VotingType.FLEA_MARKET_SELL_ITEM)
+    .setOrganizer({ player_id: player._id, clan_id: null })
+    .setFleamarketItemId(fleaMarket._id.toString())
+    .build();
 
-    await votingService.addVote(
+  const voting = await votingModel.create({
+    ...votingToCreate,
+    endsOn: new Date(Date.now() + 60 * 60 * 1000),
+    votes: [
+      { player_id: new ObjectId(), choice: VoteChoice.NO },
+      { player_id: new ObjectId(), choice: VoteChoice.NO },
+    ],
+  });
+
+  await votingService.addVote(
+    voting._id.toString(),
+    VoteChoice.YES,
+    player._id.toString(),
+  );
+
+  await expect(
+    votingService.addVote(
       voting._id.toString(),
       VoteChoice.YES,
       player._id.toString(),
-    );
+    ),
+  ).rejects.toMatchObject({
+    message: 'Logged in user has already voted.',
+  });
 
-    await expect(
-      votingService.addVote(
-        voting._id.toString(),
-        VoteChoice.YES,
-        player._id.toString(),
-      ),
-    ).rejects.toMatchObject({
-      message: 'Logged in user has already voted.',
-    });
-
-    const votingFromDb = await votingModel.findById(voting._id);
-    expect(votingFromDb.votes).toHaveLength(1);
+  const votingFromDb = await votingModel.findById(voting._id);
+  expect(votingFromDb.votes).toHaveLength(3); // 2 seeded NOs + 1 player YES
   });
 
   it('Should return error if organizer ID is invalid', async () => {
@@ -121,6 +138,62 @@ describe('VotingService.addVote() test suite', () => {
         player._id.toString(),
       ),
     ).rejects.toEqual(expect.anything());
+  });
+
+  it('Should not allow voting on an expired voting (endsOn in past)', async () => {
+    const player = await createTestPlayer();
+    const fleaMarket = await createTestFleaMarketItem();
+    const voting = await createTestVoting(
+      { player_id: player._id, clan_id: null },
+      fleaMarket._id.toString(),
+    );
+
+    // Manually expire the voting after creation.
+    await votingModel.updateOne(
+      { _id: voting._id },
+      { $set: { endsOn: new Date(Date.now() - 60 * 1000) } },
+    );
+
+    await expect(
+      votingService.addVote(
+        voting._id.toString(),
+        VoteChoice.YES,
+        player._id.toString(),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Voting has expired.',
+    });
+
+    const votingFromDb = await votingModel.findById(voting._id);
+    expect(votingFromDb.votes).toHaveLength(0);
+  });
+
+  it('Should not allow voting on a finalized voting (endedAt set)', async () => {
+    const player = await createTestPlayer();
+    const fleaMarket = await createTestFleaMarketItem();
+    const voting = await createTestVoting(
+      { player_id: player._id, clan_id: null },
+      fleaMarket._id.toString(),
+    );
+
+    // Mark the voting as finalized after creation.
+    await votingModel.updateOne(
+      { _id: voting._id },
+      { $set: { endedAt: new Date() } },
+    );
+
+    await expect(
+      votingService.addVote(
+        voting._id.toString(),
+        VoteChoice.YES,
+        player._id.toString(),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Voting has expired.',
+    });
+
+    const votingFromDb = await votingModel.findById(voting._id);
+    expect(votingFromDb.votes).toHaveLength(0);
   });
 
   it('Should apply a clan role when a SET_CLAN_ROLE voting passes after adding a vote', async () => {

--- a/src/__tests__/voting/VotingService/addVote.test.ts
+++ b/src/__tests__/voting/VotingService/addVote.test.ts
@@ -82,45 +82,45 @@ describe('VotingService.addVote() test suite', () => {
   });
 
   it('Should not allow voting twice by the same user', async () => {
-  const player = await createTestPlayer();
-  const fleaMarket = await createTestFleaMarketItem();
-  
-  // Pre-seed NO votes so the player's YES vote doesn't trigger finalization
-  // (1 yes / 3 votes = 33%, below 51%)
-  const votingToCreate = votingBuilder
-    .setMinPercentage(51)
-    .setType(VotingType.FLEA_MARKET_SELL_ITEM)
-    .setOrganizer({ player_id: player._id, clan_id: null })
-    .setFleamarketItemId(fleaMarket._id.toString())
-    .build();
+    const player = await createTestPlayer();
+    const fleaMarket = await createTestFleaMarketItem();
 
-  const voting = await votingModel.create({
-    ...votingToCreate,
-    endsOn: new Date(Date.now() + 60 * 60 * 1000),
-    votes: [
-      { player_id: new ObjectId(), choice: VoteChoice.NO },
-      { player_id: new ObjectId(), choice: VoteChoice.NO },
-    ],
-  });
+    // Pre-seed NO votes so the player's YES vote doesn't trigger finalization
+    // (1 yes / 3 votes = 33%, below 51%)
+    const votingToCreate = votingBuilder
+      .setMinPercentage(51)
+      .setType(VotingType.FLEA_MARKET_SELL_ITEM)
+      .setOrganizer({ player_id: player._id, clan_id: null })
+      .setFleamarketItemId(fleaMarket._id.toString())
+      .build();
 
-  await votingService.addVote(
-    voting._id.toString(),
-    VoteChoice.YES,
-    player._id.toString(),
-  );
+    const voting = await votingModel.create({
+      ...votingToCreate,
+      endsOn: new Date(Date.now() + 60 * 60 * 1000),
+      votes: [
+        { player_id: new ObjectId(), choice: VoteChoice.NO },
+        { player_id: new ObjectId(), choice: VoteChoice.NO },
+      ],
+    });
 
-  await expect(
-    votingService.addVote(
+    await votingService.addVote(
       voting._id.toString(),
       VoteChoice.YES,
       player._id.toString(),
-    ),
-  ).rejects.toMatchObject({
-    message: 'Logged in user has already voted.',
-  });
+    );
 
-  const votingFromDb = await votingModel.findById(voting._id);
-  expect(votingFromDb.votes).toHaveLength(3); // 2 seeded NOs + 1 player YES
+    await expect(
+      votingService.addVote(
+        voting._id.toString(),
+        VoteChoice.YES,
+        player._id.toString(),
+      ),
+    ).rejects.toMatchObject({
+      message: 'Logged in user has already voted.',
+    });
+
+    const votingFromDb = await votingModel.findById(voting._id);
+    expect(votingFromDb.votes).toHaveLength(3); // 2 seeded NOs + 1 player YES
   });
 
   it('Should return error if organizer ID is invalid', async () => {

--- a/src/fleaMarket/enum/status.enum.ts
+++ b/src/fleaMarket/enum/status.enum.ts
@@ -9,11 +9,11 @@
  *   clan. Lives in the FleaMarketItem collection.
  * - BOOKED: Another clan has reserved the item and is in the process of
  *   voting whether to buy it. Lives in the FleaMarketItem collection.
- * Step 2 next tomorrow, delete this when there. 
+ * Step 2 next tomorrow, delete this when there.
  */
 export enum Status {
   IN_STOCK = 'in_stock',
   AVAILABLE = 'available',
   SHIPPING = 'shipping',
-  BOOKED = 'booked'
+  BOOKED = 'booked',
 }

--- a/src/fleaMarket/enum/status.enum.ts
+++ b/src/fleaMarket/enum/status.enum.ts
@@ -9,7 +9,6 @@
  *   clan. Lives in the FleaMarketItem collection.
  * - BOOKED: Another clan has reserved the item and is in the process of
  *   voting whether to buy it. Lives in the FleaMarketItem collection.
- * Step 2 next tomorrow, delete this when there.
  */
 export enum Status {
   IN_STOCK = 'in_stock',

--- a/src/fleaMarket/enum/status.enum.ts
+++ b/src/fleaMarket/enum/status.enum.ts
@@ -1,10 +1,19 @@
 /**
- * Enum for flea market items.
+ * Lifecycle status of a furniture item.
  *
- * Used in the status field.
+ * - IN_STOCK: Item is in the clan's stock, not currently for sale.
+ *   (Regular Items have this status conceptually but the field may not be persisted.)
+ * - AVAILABLE: Item has been approved for selling via a vote, but not yet
+ *   placed onto a stall. Lives in the FleaMarketItem collection.
+ * - SHIPPING: Item is on the clan's stall, waiting to be bought by another
+ *   clan. Lives in the FleaMarketItem collection.
+ * - BOOKED: Another clan has reserved the item and is in the process of
+ *   voting whether to buy it. Lives in the FleaMarketItem collection.
+ * Step 2 next tomorrow, delete this when there. 
  */
 export enum Status {
+  IN_STOCK = 'in_stock',
   AVAILABLE = 'available',
   SHIPPING = 'shipping',
-  BOOKED = 'booked',
+  BOOKED = 'booked'
 }

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -82,22 +82,22 @@ export class FleaMarketController {
   }
 
   /**
-  * Get all flea market items
-  *
-  * @deprecated This endpoint returns ALL FleaMarketItems across every clan
-  * and is not scalable as the flea market grows. Use `GET /stock/{_id}`
-  * instead, which now includes the calling clan's FleaMarketItems alongside
-  * its stock items. This endpoint will be removed in a future release.
-  *
-  * @remarks Get all FleaMarketItems of the flea market.
-  */
+   * Get all flea market items
+   *
+   * @deprecated This endpoint returns ALL FleaMarketItems across every clan
+   * and is not scalable as the flea market grows. Use `GET /stock/{_id}`
+   * instead, which now includes the calling clan's FleaMarketItems alongside
+   * its stock items. This endpoint will be removed in a future release.
+   *
+   * @remarks Get all FleaMarketItems of the flea market.
+   */
   @ApiResponseDescription({
-  success: {
-    dto: FleaMarketItemDto,
-    modelName: ModelName.FLEA_MARKET_ITEM,
-    returnsArray: true,
-  },
-  errors: [400, 401, 404],
+    success: {
+      dto: FleaMarketItemDto,
+      modelName: ModelName.FLEA_MARKET_ITEM,
+      returnsArray: true,
+    },
+    errors: [400, 401, 404],
   })
   @Get()
   @OffsetPaginate(ModelName.FLEA_MARKET_ITEM)

--- a/src/fleaMarket/fleaMarket.controller.ts
+++ b/src/fleaMarket/fleaMarket.controller.ts
@@ -82,17 +82,22 @@ export class FleaMarketController {
   }
 
   /**
-   * Get all flea market items
-   *
-   * @remarks Get all FleaMarketItems of the flea market
-   */
+  * Get all flea market items
+  *
+  * @deprecated This endpoint returns ALL FleaMarketItems across every clan
+  * and is not scalable as the flea market grows. Use `GET /stock/{_id}`
+  * instead, which now includes the calling clan's FleaMarketItems alongside
+  * its stock items. This endpoint will be removed in a future release.
+  *
+  * @remarks Get all FleaMarketItems of the flea market.
+  */
   @ApiResponseDescription({
-    success: {
-      dto: FleaMarketItemDto,
-      modelName: ModelName.FLEA_MARKET_ITEM,
-      returnsArray: true,
-    },
-    errors: [400, 401, 404],
+  success: {
+    dto: FleaMarketItemDto,
+    modelName: ModelName.FLEA_MARKET_ITEM,
+    returnsArray: true,
+  },
+  errors: [400, 401, 404],
   })
   @Get()
   @OffsetPaginate(ModelName.FLEA_MARKET_ITEM)

--- a/src/voting/error/votingExpired.error.ts
+++ b/src/voting/error/votingExpired.error.ts
@@ -1,0 +1,7 @@
+import { SEReason } from '../../common/service/basicService/SEReason';
+import ServiceError from '../../common/service/basicService/ServiceError';
+
+export const votingExpiredError = new ServiceError({
+  reason: SEReason.NOT_ALLOWED,
+  message: 'Voting has expired.',
+});

--- a/src/voting/voting.service.ts
+++ b/src/voting/voting.service.ts
@@ -16,6 +16,7 @@ import { Choice } from './type/choice.type';
 import { GovernancePayload } from './type/governancePayload';
 import { ClanService } from '../clan/clan.service';
 import { alreadyVotedError } from './error/alreadyVoted.error';
+import { votingExpiredError } from './error/votingExpired.error';
 import { Vote } from './schemas/vote.schema';
 import { ModelName } from '../common/enum/modelName.enum';
 import { addVoteError } from './error/addVote.error';
@@ -280,6 +281,15 @@ export class VotingService {
     });
     if (errors) throw errors;
 
+    // Reject votes outright on expired votings
+    if (voting.endedAt) {
+      throw votingExpiredError;
+    }
+    if (voting.endsOn && new Date(voting.endsOn) < new Date()) {
+      throw votingExpiredError;
+    }
+
+    // Check if the player has already voted in this voting
     if (voting.votes.some((v) => v.player_id.toString() === playerId)) {
       throw alreadyVotedError;
     }


### PR DESCRIPTION
Fixes #819 (partial, see the scope note below).

Adds a check to `VotingService.addVote()` that rejects votes on votings
that have already ended. A voting is considered ended if either:

- `endedAt` is set (the voting was finalized early due to threshold
  being reached, or via explicit finalization), or
- `endsOn` is in the past (the 10-minute timer expired but the scheduler
  hasn't run cleanup yet).

In both cases `addVote` now throws `votingExpiredError` (HTTP 400 via
`APIErrorFilter`) instead of silently accepting the vote and returning
204. The vote is no longer added to the voting record.
205. 

### Scope note

Issue #819 originally described two related bugs:

1. A player can vote multiple times on the same voting.
2. A player can vote on an expired voting.

Bug 1 was already fixed in commit c0ecee0a (May 13, 2026) by tickBit:
the existing duplicate-vote check had a missing `.toString()` on the
ObjectId comparison, which made it always evaluate false. That fix is
already in dev. This PR addresses bug 2 only.

### Change list

- `src/voting/voting.service.ts`
  - In `addVote`: add two early-return checks for `endedAt` and `endsOn`,
    placed before the existing duplicate-vote check.
- `src/voting/error/votingExpired.error.ts` (new file)
  - New `votingExpiredError` using SEReason.NOT_ALLOWED, following the
    pattern of `alreadyVotedError`.
- `src/__tests__/voting/VotingService/addVote.test.ts`
  - Updated test "Should not allow voting twice by the same user" to
    pre-seed NO votes so the player's vote doesn't trigger finalization
    (with the new expiration check, a finalized voting correctly rejects
    further votes, which was making the duplicate-vote scenario
    unreachable).
  - Added test "Should not allow voting on an expired voting (endsOn
    in past)" to cover the new behavior.
  - Added test "Should not allow voting on a finalized voting (endedAt
    set)" to cover the new behavior.



### Testing

Unit tests pass (`npm run test -- addVote`). Full suite green except for
the pre-existing flaky tests unrelated to voting (`ClanService/readAll`,
`ItemService/readMany`, `SoulHomeService/deleteOneById`).