### PR TITLE
858 feature request add clan name to the playerdata that is received from the server

### DIFF
--- a/src/__tests__/player/PlayerService/getAll.test.ts
+++ b/src/__tests__/player/PlayerService/getAll.test.ts
@@ -139,19 +139,15 @@ describe('PlayerService.getAll() test suite', () => {
       includeRefs: [ModelName.CLAN],
     })) as [PlayerObject[], ServiceError[]];
 
+    const clearedResp = clearDBRespDefaultFields(players[0]);
+    const { roles: dbRoles, ...clan } = clearedResp.Clan;
+    const { roles: existingClanRoles, ...clanWithoutRoles } =
+    clearDBRespDefaultFields(existingClan);
     expect(errors).toBeNull();
 
-    const { roles: dbRoles1, ...clan1 } = players[0].Clan as Clan;
-    const { roles: existingClanRoles1, ...clanWithoutRoles1 } = existingClan;
-
-    expect(clan1).toEqual(expect.objectContaining(clanWithoutRoles1));
-    expect(dbRoles1).toEqual(existingClanRoles1);
-
-    const { roles: dbRoles2, ...clan2 } = players[1].Clan as Clan;
-    const { roles: existingClanRoles2, ...clanWithoutRoles2 } = existingClan;
-
-    expect(clan2).toEqual(expect.objectContaining(clanWithoutRoles2));
-    expect(dbRoles2).toEqual(existingClanRoles2);
+    expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));
+    expect(dbRoles).toEqual(existingClanRoles);
+    expect(errors).toBeNull();
   });
 
   it('Should ignore non-existing references requested', async () => {

--- a/src/__tests__/player/PlayerService/getAll.test.ts
+++ b/src/__tests__/player/PlayerService/getAll.test.ts
@@ -8,9 +8,7 @@ import { ModelName } from '../../../common/enum/modelName.enum';
 import { clearDBRespDefaultFields } from '../../test_utils/util/removeDBDefaultFields';
 import { Player } from '../../../player/schemas/player.schema';
 import ServiceError from '../../../common/service/basicService/ServiceError';
-import { PlayerDto } from '../../../player/dto/player.dto';
 import { PlayerObject } from 'src/common/type/playerObject.type';
-import { ClanDto } from 'src/clan/dto/clan.dto';
 
 describe('PlayerService.getAll() test suite', () => {
   let playerService: PlayerService;

--- a/src/__tests__/player/PlayerService/getAll.test.ts
+++ b/src/__tests__/player/PlayerService/getAll.test.ts
@@ -7,6 +7,10 @@ import ClanModule from '../../clan/modules/clan.module';
 import { ModelName } from '../../../common/enum/modelName.enum';
 import { clearDBRespDefaultFields } from '../../test_utils/util/removeDBDefaultFields';
 import { Player } from '../../../player/schemas/player.schema';
+import ServiceError from '../../../common/service/basicService/ServiceError';
+import { PlayerDto } from '../../../player/dto/player.dto';
+import { PlayerObject } from 'src/common/type/playerObject.type';
+import { ClanDto } from 'src/clan/dto/clan.dto';
 
 describe('PlayerService.getAll() test suite', () => {
   let playerService: PlayerService;
@@ -110,9 +114,9 @@ describe('PlayerService.getAll() test suite', () => {
   });
 
   it('Should return desc sorted by name players if requested', async () => {
-    const [players, errors] = await playerService.getAll({
+    const [players, errors] = (await playerService.getAll({
       sort: { name: -1 },
-    });
+    })) as [PlayerObject[], ServiceError[]];
 
     expect(errors).toBeNull();
     expect(players[0].name).toBe(player2.name);
@@ -120,10 +124,10 @@ describe('PlayerService.getAll() test suite', () => {
   });
 
   it('Should be able to skip first found player in DB if requested', async () => {
-    const [players, errors] = await playerService.getAll({
+    const [players, errors] = (await playerService.getAll({
       skip: 1,
       sort: { name: -1 },
-    });
+    })) as [PlayerObject[], ServiceError[]];
 
     expect(errors).toBeNull();
     expect(players).toHaveLength(1);
@@ -131,19 +135,19 @@ describe('PlayerService.getAll() test suite', () => {
   });
 
   it("Should include get players' clan if requested", async () => {
-    const [players, errors] = await playerService.getAll({
+    const [players, errors] = (await playerService.getAll({
       includeRefs: [ModelName.CLAN],
-    });
+    })) as [PlayerObject[], ServiceError[]];
 
     expect(errors).toBeNull();
 
-    const { roles: dbRoles1, ...clan1 } = (players[0].Clan as any).toObject();
+    const { roles: dbRoles1, ...clan1 } = players[0].Clan as Clan;
     const { roles: existingClanRoles1, ...clanWithoutRoles1 } = existingClan;
 
     expect(clan1).toEqual(expect.objectContaining(clanWithoutRoles1));
     expect(dbRoles1).toEqual(existingClanRoles1);
 
-    const { roles: dbRoles2, ...clan2 } = (players[1].Clan as any).toObject();
+    const { roles: dbRoles2, ...clan2 } = players[1].Clan as Clan;
     const { roles: existingClanRoles2, ...clanWithoutRoles2 } = existingClan;
 
     expect(clan2).toEqual(expect.objectContaining(clanWithoutRoles2));

--- a/src/__tests__/player/PlayerService/getAll.test.ts
+++ b/src/__tests__/player/PlayerService/getAll.test.ts
@@ -142,7 +142,7 @@ describe('PlayerService.getAll() test suite', () => {
     const clearedResp = clearDBRespDefaultFields(players[0]);
     const { roles: dbRoles, ...clan } = clearedResp.Clan;
     const { roles: existingClanRoles, ...clanWithoutRoles } =
-    clearDBRespDefaultFields(existingClan);
+      clearDBRespDefaultFields(existingClan);
     expect(errors).toBeNull();
 
     expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));

--- a/src/__tests__/player/PlayerService/getPlayerById.test.ts
+++ b/src/__tests__/player/PlayerService/getPlayerById.test.ts
@@ -1,4 +1,5 @@
-import util from 'util';import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
+import util from 'util';
+import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
 import PlayerModule from '../../player/modules/player.module';
 import { getNonExisting_id } from '../../test_utils/util/getNonExisting_id';
 import { PlayerService } from '../../../player/player.service';
@@ -10,7 +11,6 @@ import { clearDBRespDefaultFields } from '../../test_utils/util/removeDBDefaultF
 import { Player } from '../../../player/schemas/player.schema';
 
 describe('PlayerService.getPlayerById() test suite', () => {
-  
   let playerService: PlayerService;
   const playerBuilder = PlayerBuilderFactory.getBuilder('CreatePlayerDto');
   const updatePlayerBuilder =
@@ -44,7 +44,7 @@ describe('PlayerService.getPlayerById() test suite', () => {
     const [player, errors] = await playerService.getPlayerById(
       existingPlayer._id,
     );
-    
+
     expect(errors).toBeNull();
     expect(player).toBeDefined();
 
@@ -58,7 +58,7 @@ describe('PlayerService.getPlayerById() test suite', () => {
       }),
     );
   });
-  
+
   it('Should return NOT_FOUND ServiceError for non-existing player', async () => {
     const [player, errors] =
       await playerService.getPlayerById(getNonExisting_id());
@@ -92,17 +92,17 @@ describe('PlayerService.getPlayerById() test suite', () => {
   });
 
   it("Should include get player's clan if requested", async () => {
-
     const [player, errors] = await playerService.getPlayerById(
       existingPlayer._id,
-      { includeRefs: [ModelName.CLAN] }
+      { includeRefs: [ModelName.CLAN] },
     );
 
     expect(errors).toBeNull();
 
-     const clearedClan = clearDBRespDefaultFields(player.Clan);
-     const { roles: dbRoles, ...clan } = clearedClan;
-     const { roles: existingClanRoles, ...clanWithoutRoles } = clearDBRespDefaultFields(existingClan);
+    const clearedClan = clearDBRespDefaultFields(player.Clan);
+    const { roles: dbRoles, ...clan } = clearedClan;
+    const { roles: existingClanRoles, ...clanWithoutRoles } =
+      clearDBRespDefaultFields(existingClan);
 
     expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));
     expect(dbRoles).toEqual(existingClanRoles);

--- a/src/__tests__/player/PlayerService/getPlayerById.test.ts
+++ b/src/__tests__/player/PlayerService/getPlayerById.test.ts
@@ -1,4 +1,4 @@
-import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
+import util from 'util';import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
 import PlayerModule from '../../player/modules/player.module';
 import { getNonExisting_id } from '../../test_utils/util/getNonExisting_id';
 import { PlayerService } from '../../../player/player.service';
@@ -10,6 +10,7 @@ import { clearDBRespDefaultFields } from '../../test_utils/util/removeDBDefaultF
 import { Player } from '../../../player/schemas/player.schema';
 
 describe('PlayerService.getPlayerById() test suite', () => {
+  
   let playerService: PlayerService;
   const playerBuilder = PlayerBuilderFactory.getBuilder('CreatePlayerDto');
   const updatePlayerBuilder =
@@ -43,17 +44,21 @@ describe('PlayerService.getPlayerById() test suite', () => {
     const [player, errors] = await playerService.getPlayerById(
       existingPlayer._id,
     );
-
+    
     expect(errors).toBeNull();
-    expect(player as any).toEqual(
+    expect(player).toBeDefined();
+
+    const clearedResp = clearDBRespDefaultFields(player);
+    const clearedExpected = clearDBRespDefaultFields(existingPlayer);
+    expect(clearedResp).toEqual(
       expect.objectContaining({
-        ...existingPlayer,
+        ...clearedExpected,
         updatedAt: expect.any(Date),
         createdAt: expect.any(Date),
       }),
     );
   });
-
+  
   it('Should return NOT_FOUND ServiceError for non-existing player', async () => {
     const [player, errors] =
       await playerService.getPlayerById(getNonExisting_id());
@@ -87,15 +92,17 @@ describe('PlayerService.getPlayerById() test suite', () => {
   });
 
   it("Should include get player's clan if requested", async () => {
+
     const [player, errors] = await playerService.getPlayerById(
       existingPlayer._id,
-      { includeRefs: [ModelName.CLAN] },
+      { includeRefs: [ModelName.CLAN] }
     );
 
     expect(errors).toBeNull();
 
-    const { roles: dbRoles, ...clan } = player.Clan;
-    const { roles: existingClanRoles, ...clanWithoutRoles } = existingClan;
+     const clearedClan = clearDBRespDefaultFields(player.Clan);
+     const { roles: dbRoles, ...clan } = clearedClan;
+     const { roles: existingClanRoles, ...clanWithoutRoles } = clearDBRespDefaultFields(existingClan);
 
     expect(clan).toEqual(expect.objectContaining(clanWithoutRoles));
     expect(dbRoles).toEqual(existingClanRoles);

--- a/src/__tests__/player/PlayerService/getPlayerById.test.ts
+++ b/src/__tests__/player/PlayerService/getPlayerById.test.ts
@@ -1,4 +1,3 @@
-import util from 'util';
 import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
 import PlayerModule from '../../player/modules/player.module';
 import { getNonExisting_id } from '../../test_utils/util/getNonExisting_id';

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -25,7 +25,7 @@ import {
 import { InjectConnection } from '@nestjs/mongoose';
 import { IServiceReturn } from '../common/service/basicService/IService';
 import { OnEvent } from '@nestjs/event-emitter';
-import ServiceError from 'src/common/service/basicService/ServiceError';
+import ServiceError from '../common/service/basicService/ServiceError';
 @Injectable()
 export class ClanShopService {
   constructor(

--- a/src/clanShop/clanShop.service.ts
+++ b/src/clanShop/clanShop.service.ts
@@ -25,6 +25,7 @@ import {
 import { InjectConnection } from '@nestjs/mongoose';
 import { IServiceReturn } from '../common/service/basicService/IService';
 import { OnEvent } from '@nestjs/event-emitter';
+import ServiceError from 'src/common/service/basicService/ServiceError';
 @Injectable()
 export class ClanShopService {
   constructor(
@@ -55,7 +56,7 @@ export class ClanShopService {
   ): Promise<IServiceReturn<boolean>> {
     const [player, playerError] =
       await this.playerService.getPlayerById(playerId);
-    if (playerError) return [null, playerError];
+    if (playerError) return [null, playerError as ServiceError[]];
 
     const [clan, clanError] = await this.clanService.readOneById(clanId);
     if (clanError) return [null, clanError];
@@ -153,7 +154,8 @@ export class ClanShopService {
 
     const [player, playerError] =
       await this.playerService.getPlayerById(playerId);
-    if (playerError) return cancelTransaction(session, playerError);
+    if (playerError)
+      return cancelTransaction(session, playerError as ServiceError[]);
 
     const [voting, votingErrors] = await this.votingService.startVoting(
       {

--- a/src/common/type/playerObject.type.ts
+++ b/src/common/type/playerObject.type.ts
@@ -1,0 +1,27 @@
+import { Types } from 'mongoose';
+import { CustomCharacter } from '../../player/customCharacter/customCharacter.schema';
+import { ClanDto } from '../../clan/dto/clan.dto';
+
+export type PlayerObject = {
+  _id: string;
+  name: string;
+  points: number;
+  battlePoints: number;
+  claimableRewards: number[];
+  backpackCapacity: number;
+  uniqueIdentifier: string;
+  above13?: boolean;
+  parentalAuth?: boolean;
+  currentAvatarId?: number;
+  avatar?: any;
+  gameStatistics?: any;
+  classStatistics?: Map<string, { gamesPlayed: number; wins: number }>;
+  characterStatistics?: Map<string, { gamesPlayed: number; wins: number }>;
+  profile_id?: string;
+  clan_id?: string;
+  clanRole_id?: string | null;
+  battleCharacter_ids?: string[] | Types.ObjectId[];
+  Clan?: ClanDto;
+  CustomCharacter?: CustomCharacter[];
+  clanName?: string | null;
+};

--- a/src/fleaMarket/fleaMarket.service.ts
+++ b/src/fleaMarket/fleaMarket.service.ts
@@ -188,7 +188,7 @@ export class FleaMarketService {
   ): Promise<IServiceReturn<boolean>> {
     const [player, playerError] =
       await this.playerService.getPlayerById(playerId);
-    if (playerError) return [null, playerError];
+    if (playerError) return [null, playerError as ServiceError[]];
 
     const [clan, clanError] = await this.clanService.readOneById(clanId);
     if (clanError) return [null, clanError];
@@ -232,7 +232,8 @@ export class FleaMarketService {
 
     const [player, playerErrors] =
       await this.playerService.getPlayerById(playerId);
-    if (playerErrors) return await cancelTransaction(session, playerErrors);
+    if (playerErrors)
+      return await cancelTransaction(session, playerErrors as ServiceError[]);
 
     const newItem = await this.helperService.itemToCreateFleaMarketItem(
       item,
@@ -369,7 +370,7 @@ export class FleaMarketService {
   ): Promise<IServiceReturn<boolean>> {
     const [player, playerError] =
       await this.playerService.getPlayerById(playerId);
-    if (playerError) return [false, playerError];
+    if (playerError) return [false, playerError as ServiceError[]];
 
     const [clan, clanError] = await this.clanService.readOneById(clanId);
     if (clanError) return [false, clanError];
@@ -418,7 +419,7 @@ export class FleaMarketService {
 
     const [player, playerErrors] =
       await this.playerService.getPlayerById(playerId);
-    if (playerErrors) return [false, playerErrors];
+    if (playerErrors) return [false, playerErrors as ServiceError[]];
 
     const [voting, err] = await this.handleBooking(clan, item, player);
     if (err) return [false, err];
@@ -804,7 +805,7 @@ export class FleaMarketService {
   ): Promise<IServiceReturn<VotingDto>> {
     const [player, playerErrors] =
       await this.playerService.getPlayerById(player_id);
-    if (playerErrors) return [null, playerErrors];
+    if (playerErrors) return [null, playerErrors as ServiceError[]];
 
     const [item, itemErrors] =
       await this.basicService.readOneById<FleaMarketItemDto>(item_id);

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -229,14 +229,14 @@ export class GameDataService {
       playerIds[0],
     );
     if (team1Errors) {
-      return [null, team1Errors];
+      return [null, team1Errors as ServiceError[]];
     }
 
     const [team2Player, team2Errors] = await this.playerService.getPlayerById(
       playerIds[1],
     );
     if (team2Errors) {
-      return [null, team2Errors];
+      return [null, team2Errors as ServiceError[]];
     }
 
     const clanIds = {

--- a/src/onlinePlayers/onlinePlayers.service.ts
+++ b/src/onlinePlayers/onlinePlayers.service.ts
@@ -38,7 +38,7 @@ export class OnlinePlayersService {
     const { player_id, status, client_version } = playerInfo;
 
     const [player, errors] = await this.playerService.getPlayerById(player_id);
-    if (errors) return [null, errors];
+    if (errors) return [null, errors as ServiceError[]];
 
     const payload: OnlinePlayer = {
       _id: player_id,

--- a/src/player/dto/player.dto.ts
+++ b/src/player/dto/player.dto.ts
@@ -6,7 +6,7 @@ import AddType from '../../common/base/decorator/AddType.decorator';
 import { GameStatisticsDto } from './gameStatistics.dto';
 import { TaskDto } from './task.dto';
 import { AvatarDto } from './avatar.dto';
-import { Min } from 'class-validator';
+import { IsOptional, Min } from 'class-validator';
 import { EmotionDto } from './emotion.dto';
 
 export class StatDetailDto {
@@ -207,4 +207,8 @@ export class PlayerDto {
   @Type(() => EmotionDto)
   @Expose()
   emotions?: EmotionDto[];
+  
+  @Expose()
+  @IsOptional()
+  clanName?: string;
 }

--- a/src/player/dto/player.dto.ts
+++ b/src/player/dto/player.dto.ts
@@ -207,7 +207,7 @@ export class PlayerDto {
   @Type(() => EmotionDto)
   @Expose()
   emotions?: EmotionDto[];
-  
+
   @Expose()
   @IsOptional()
   clanName?: string;

--- a/src/player/player.controller.ts
+++ b/src/player/player.controller.ts
@@ -37,6 +37,7 @@ import { isEqual } from 'lodash';
 import { IServiceReturn } from '../common/service/basicService/IService';
 import { EmotionCheckDto } from './dto/emotionCheck.dto';
 import { MongooseError } from 'mongoose';
+import ServiceError from '../common/service/basicService/ServiceError';
 
 @Controller('player')
 export default class PlayerController {

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -126,7 +126,7 @@ export class PlayerService
     const clanIds = Array.from(
       new Set(
         playerObjects
-          .map(p => p.clan_id ? p.clan_id.toString() : null)
+          .map((p) => (p.clan_id ? p.clan_id.toString() : null))
           .filter(Boolean),
       ),
     );

--- a/src/player/player.service.ts
+++ b/src/player/player.service.ts
@@ -29,6 +29,7 @@ import {
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { PlayerEmotion } from './enum/playerEmotion.enum';
 import { prizePool } from '../rewarder/const/prizePool';
+import { PlayerObject } from '../common/type/playerObject.type';
 
 @Injectable()
 @AddBasicService()
@@ -62,7 +63,7 @@ export class PlayerService
   async getPlayerById(
     _id: string,
     options?: TReadByIdOptions,
-  ): Promise<[PlayerDto, any]> {
+  ): Promise<[PlayerDto, PlayerObject | ServiceError[]]> {
     const optionsToApply = options;
     if (options?.includeRefs) {
       optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
@@ -79,9 +80,8 @@ export class PlayerService
       return [player, errors];
     }
 
-    const playerObject: any = (player as any).toObject
-      ? (player as any).toObject()
-      : player;
+    const playerObject = player;
+
     playerObject.favouriteClass = this.getFavourite(
       playerObject['classStatistics'],
     );
@@ -93,12 +93,21 @@ export class PlayerService
   }
 
   /**
-   * This method is used in the LeaderboardService and serves as a replacement
-   * for the deprecated readAll method from the BasicServiceDummyAbstract.
-   * It should be renamed to readAll when the service is updated to the new way.
+   * Retrieve players according to the provided options and attach each
+   * player's clan display name as clanName when available.
    *
-   * @param options - Options for reading players.
-   * @returns - An array of players if succeeded or an array of ServiceErrors if error occurred.
+   * - filters includeRefs to allowed public references
+   * - returns plain objects (not DTO instances) to avoid recursive DTO serialization
+   * - performs a batched lookup of clan names to avoid per-player queries and
+   *   circular conversions
+   *
+   * @param options TISericeReadManyOptions Optional
+   * read/pagination/includeRefs settings
+   *
+   * @return Promise <[any[], ServiceError[] | null]> Tuple where the first
+   * element is an array of player objects (each may include 'clanName?: string | null')
+   * and the second element contains service errors if any
+   *
    */
   async getAll(options?: TIServiceReadManyOptions) {
     const optionsToApply = options;
@@ -107,7 +116,44 @@ export class PlayerService
         publicReferences.includes(ref),
       );
 
-    return this.basicService.readMany<PlayerDto>(optionsToApply);
+    const [players, errors] =
+      await this.basicService.readMany<PlayerDto>(optionsToApply);
+
+    if (errors || !players) return [players, errors];
+
+    const playerObjects = players.map((p: PlayerDto | null) => p);
+
+    const clanIds = Array.from(
+      new Set(
+        playerObjects
+          .map(p => p.clan_id ? p.clan_id.toString() : null)
+          .filter(Boolean),
+      ),
+    );
+
+    if (clanIds.length > 0) {
+      const clanDocs = await Promise.all(
+        clanIds.map((cid) =>
+          this.requestHelperService.findOneRaw(
+            ModelName.CLAN,
+            { _id: cid },
+            { projection: { name: 1 } },
+          ),
+        ),
+      );
+
+      const clanMap = new Map<string, string | null>();
+      clanDocs.forEach((c: any) => {
+        if (c && c._id) clanMap.set(c._id.toString(), c.name ?? null);
+      });
+
+      playerObjects.forEach((p) => {
+        const key = p.clan_id ? p.clan_id.toString() : null;
+        p.clanName = key ? (clanMap.get(key) ?? null) : null;
+      });
+    }
+
+    return [playerObjects, null];
   }
 
   public clearCollectionReferences = async (
@@ -350,7 +396,7 @@ export class PlayerService
     emotion: PlayerEmotion,
   ): Promise<IServiceReturn<PlayerDto>> {
     const [player, errors] = await this.getPlayerById(playerId);
-    if (errors) return [null, errors];
+    if (errors) return [null, errors as ServiceError[]];
 
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -381,7 +427,7 @@ export class PlayerService
     );
     if (updateErrors) return [null, updateErrors];
 
-    return this.getPlayerById(playerId);
+    return this.getPlayerById(playerId) as Promise<IServiceReturn<PlayerDto>>;
   }
 
   /**

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -224,7 +224,8 @@ export class ProfileService
         includeRefs: [ModelName.CLAN],
       });
 
-    if (playerReadingErrors) return [null, playerReadingErrors];
+    if (playerReadingErrors)
+      return [null, playerReadingErrors as ServiceError[]];
     profile.Player = player;
 
     return [profile, null];


### PR DESCRIPTION
### Brief description

Clan's name now visible from endpoints with player object.

From Postman:

```
{
    "data": {
        "Player": [
            {
                "_id": "6a043d92aaacc61e8681495f",
                "name": "super 2",
                "points": 0,
                "battlePoints": 0,
                "claimableRewards": [],
                "backpackCapacity": 453,
                "uniqueIdentifier": "1415",
                "above13": true,
                "parentalAuth": null,
                "gameStatistics": {},
                "battleCharacter_ids": [],
                "currentAvatarId": null,
                "profile_id": "6a043d92aaacc61e8681495d",
                "clan_id": "6a019315ee393ee3d344e199",
                "avatar": null,
                "clanRole_id": "6a019315ee393ee3d344e19c",
                "playstyle": "Balanced",
                "carbonFootprint": 0,
                "clanCoinsAccumulated": 0,
                "emotions": [],
                "clanName": "super_clan"
            },
```
			
I tried to keep changes minimal, but I tried to improve the implementation so, that type `any` isn't used. Removing it from 1 endpoint caused small fixes to many places.

### Change list

Clan's name now visible from endpoints

`/player`
`/player/{_id}`

To avoid using type `any` I created a new type `PlayerObject`, too.

Some tests had to be changed a bit too and some other code files. All those changes are related to avoiding using type `any` somehow.