### PR TITLE
874 bug fetching stock data returns a lot of nonsensical data in the json response

### DIFF
--- a/src/__tests__/clanInventory/stock/StockService/readAll.test.ts
+++ b/src/__tests__/clanInventory/stock/StockService/readAll.test.ts
@@ -1,3 +1,4 @@
+import mongoose from 'mongoose';
 import { ObjectId } from 'mongodb';
 import ClanInventoryBuilderFactory from '../../data/clanInventoryBuilderFactory';
 import ItemModule from '../../modules/item.module';
@@ -7,11 +8,13 @@ import StockModule from '../../modules/stock.module';
 import { clearDBRespDefaultFields } from '../../../test_utils/util/removeDBDefaultFields';
 import { ModelName } from '../../../../common/enum/modelName.enum';
 import { Environment } from '../../../../common/enum/environment.enum';
+import PlayerBuilder from '../../../player/data/player/playerBuilder';
 
 describe('StockService.readAll() test suite', () => {
   let stockService: StockService;
   const stockBuilder = ClanInventoryBuilderFactory.getBuilder('Stock');
   const stockModel = StockModule.getStockModel();
+  let playerModel: mongoose.Model<any>;
   const clan_id = new ObjectId(getNonExisting_id());
   const stock1 = stockBuilder
     .setClanId(clan_id)
@@ -31,6 +34,7 @@ describe('StockService.readAll() test suite', () => {
 
   beforeEach(async () => {
     stockService = await StockModule.getStockService();
+    playerModel = mongoose.model(ModelName.PLAYER);
 
     const stock1Resp = await stockModel.create(stock1);
     stock1._id = stock1Resp._id;
@@ -58,6 +62,63 @@ describe('StockService.readAll() test suite', () => {
         expect.objectContaining({ ...stock1 }),
         expect.objectContaining({ ...stock2 }),
       ]),
+    );
+  });
+
+  it('Should return only stocks of the logged-in player Clan', async () => {
+    const anotherClan_id = new ObjectId();
+    const player = new PlayerBuilder()
+      .setName('stockPlayer')
+      .setUniqueIdentifier('stock-player')
+      .setClanId(clan_id)
+      .build();
+    const otherClanStock = stockBuilder
+      .setClanId(anotherClan_id)
+      .setCellCount(99)
+      .setEnvironment(Environment.TEACHING_DEMO)
+      .build();
+
+    const createdPlayer = await playerModel.create(player);
+    await stockModel.create(otherClanStock);
+
+    const [stocks, errors] = await stockService.readPlayerClanStocks(
+      createdPlayer._id.toString(),
+      { filter: {} },
+      Environment.TEACHING_DEMO,
+    );
+
+    expect(errors).toBeNull();
+    expect(stocks).toHaveLength(2);
+    expect(stocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ clan_id }),
+        expect.objectContaining({ clan_id }),
+      ]),
+    );
+    expect(stocks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ clan_id: anotherClan_id }),
+      ]),
+    );
+  });
+
+  it('Should apply OPEN_DEMO environment filter', async () => {
+    const openDemoStock = stockBuilder
+      .setClanId(clan_id)
+      .setCellCount(2)
+      .setEnvironment(Environment.OPEN_DEMO)
+      .build();
+    await stockModel.create(openDemoStock);
+
+    const [stocks, errors] = await stockService.readAll(
+      { filter: { clan_id } },
+      Environment.OPEN_DEMO,
+    );
+
+    expect(errors).toBeNull();
+    expect(stocks).toHaveLength(1);
+    expect(stocks[0]).toEqual(
+      expect.objectContaining({ environment: Environment.OPEN_DEMO }),
     );
   });
 

--- a/src/__tests__/clanInventory/stock/StockService/readOneById.test.ts
+++ b/src/__tests__/clanInventory/stock/StockService/readOneById.test.ts
@@ -58,8 +58,7 @@ describe('StockService.readOneById() test suite', () => {
     const clearedStock = clearDBRespDefaultFields(stock);
 
     expect(errors).toBeNull();
-    const actualStock1 = (clearedStock as any)._doc || clearedStock;
-    expect(JSON.parse(JSON.stringify(actualStock1))).toEqual(
+    expect(JSON.parse(JSON.stringify(clearedStock))).toEqual(
       expect.objectContaining(JSON.parse(JSON.stringify(existingStock))),
     );
   });
@@ -75,10 +74,19 @@ describe('StockService.readOneById() test suite', () => {
       cellCount: existingStock.cellCount,
     };
 
-    const actualStock2 = (clearedStock as any)._doc || clearedStock;
-    expect(JSON.parse(JSON.stringify(actualStock2))).toEqual(
+    expect(errors).toBeNull();
+    expect(JSON.parse(JSON.stringify(clearedStock))).toEqual(
       JSON.parse(JSON.stringify(expected)),
     );
+  });
+
+  it('Should not expose Mongoose document internals', async () => {
+    const [stock, errors] = await stockService.readOneById(existingStock._id);
+
+    expect(errors).toBeNull();
+    expect(stock).not.toHaveProperty('$__');
+    expect(stock).not.toHaveProperty('$isNew');
+    expect(stock).not.toHaveProperty('_doc');
   });
 
   it('Should return NOT_FOUND SError for non-existing stock', async () => {

--- a/src/__tests__/clanInventory/stock/StockService/readOneById.test.ts
+++ b/src/__tests__/clanInventory/stock/StockService/readOneById.test.ts
@@ -89,6 +89,43 @@ describe('StockService.readOneById() test suite', () => {
     expect(stock).not.toHaveProperty('_doc');
   });
 
+  it('Should return Items stored in Stock', async () => {
+    const [items, errors] = await stockService.readItemsByStockId(
+      existingStock._id,
+    );
+
+    const clearedItems = clearDBRespDefaultFields(items);
+
+    expect(errors).toBeNull();
+    expect(clearedItems).toHaveLength(1);
+    expect(JSON.parse(JSON.stringify(clearedItems[0]))).toEqual(
+      expect.objectContaining({
+        _id: existingItem._id.toString(),
+        name: existingItem.name,
+        stock_id: existingItem.stock_id.toString(),
+      }),
+    );
+  });
+
+  it('Should return an empty Item list if Stock has no Items', async () => {
+    const emptyStock = stockBuilder.setClanId(clan_id).build();
+    const emptyStockResp = await stockModel.create(emptyStock);
+
+    const [items, errors] = await stockService.readItemsByStockId(
+      emptyStockResp._id.toString(),
+    );
+
+    expect(errors).toBeNull();
+    expect(items).toEqual([]);
+  });
+
+  it('Should return NOT_FOUND SError when reading Items for non-existing Stock', async () => {
+    const [items, errors] =
+      await stockService.readItemsByStockId(getNonExisting_id());
+
+    expect(items).toBeNull();
+    expect(errors).toContainSE_NOT_FOUND();
+  });
   it('Should return NOT_FOUND SError for non-existing stock', async () => {
     const [stock, errors] = await stockService.readOneById(getNonExisting_id());
 

--- a/src/clan/utils/clanHelper.service.ts
+++ b/src/clan/utils/clanHelper.service.ts
@@ -24,7 +24,7 @@ import { Environment } from '../../common/enum/environment.enum';
 export default class ClanHelperService {
   constructor(
     @InjectModel(Clan.name)
-    private readonly clanModel: Model<Clan>, 
+    private readonly clanModel: Model<Clan>,
     @Inject(forwardRef(() => StockService))
     private readonly stockService: StockService,
     private readonly soulHomeService: SoulHomeService,

--- a/src/clanInventory/stock/stock.controller.ts
+++ b/src/clanInventory/stock/stock.controller.ts
@@ -2,10 +2,12 @@ import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { StockService } from './stock.service';
 import { StockDto } from './dto/stock.dto';
 import { publicReferences } from './stock.schema';
+import { User } from '../../auth/user';
 import { Authorize } from '../../authorization/decorator/Authorize';
 import { Action } from '../../authorization/enum/action.enum';
 import { GetAllQuery } from '../../common/decorator/param/GetAllQuery';
 import { IncludeQuery } from '../../common/decorator/param/IncludeQuery.decorator';
+import { LoggedUser } from '../../common/decorator/param/LoggedUser.decorator';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
 import { _idDto } from '../../common/dto/_id.dto';
 import { ModelName } from '../../common/enum/modelName.enum';
@@ -45,9 +47,9 @@ export class StockController {
   }
 
   /**
-   * Get all stocks
+   * Get logged-in player's Clan stocks
    *
-   * @remarks Read all created Stocks of all Clans. Remember about the pagination
+   * @remarks Read all created Stocks of the Clan the logged-in Player belongs to.
    */
   @ApiResponseDescription({
     success: {
@@ -65,9 +67,14 @@ export class StockController {
   @UniformResponse(ModelName.STOCK)
   public getAll(
     @GetAllQuery() query: IGetAllQuery,
+    @LoggedUser() user: User,
     @Query('environment', new ParseIntPipe({ optional: true }))
     environment?: Environment,
   ) {
-    return this.service.readAll(query, environment);
+    return this.service.readPlayerClanStocks(
+      user.player_id,
+      query,
+      environment,
+    );
   }
 }

--- a/src/clanInventory/stock/stock.controller.ts
+++ b/src/clanInventory/stock/stock.controller.ts
@@ -1,12 +1,11 @@
 import { Controller, Get, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { StockService } from './stock.service';
 import { StockDto } from './dto/stock.dto';
-import { publicReferences } from './stock.schema';
+import { ItemDto } from '../item/dto/item.dto';
 import { User } from '../../auth/user';
 import { Authorize } from '../../authorization/decorator/Authorize';
 import { Action } from '../../authorization/enum/action.enum';
 import { GetAllQuery } from '../../common/decorator/param/GetAllQuery';
-import { IncludeQuery } from '../../common/decorator/param/IncludeQuery.decorator';
 import { LoggedUser } from '../../common/decorator/param/LoggedUser.decorator';
 import { UniformResponse } from '../../common/decorator/response/UniformResponse';
 import { _idDto } from '../../common/dto/_id.dto';
@@ -23,27 +22,23 @@ export class StockController {
   public constructor(private readonly service: StockService) {}
 
   /**
-   * Get stock by _id
-   * @remarks Returns the Stock document with the given _id. Includes both the
-   * clan's active stock items (under `Item`) and FleaMarketItems currently in the
-   * sell lifecycle (under `FleaMarketItem`). Consolidates the complete view of
-   * clan furniture into a single decoupled request.
+   * Get stock items by Stock _id
+   *
+   * @remarks Returns the list of Items currently stored in the Stock with the given _id.
    */
   @ApiResponseDescription({
     success: {
-      dto: StockDto,
-      modelName: ModelName.STOCK,
+      dto: ItemDto,
+      modelName: ModelName.ITEM,
+      returnsArray: true,
     },
     errors: [400, 401, 404],
   })
   @Get('/:_id')
   @Authorize({ action: Action.read, subject: StockDto })
-  @UniformResponse(ModelName.STOCK)
-  public get(
-    @Param() param: _idDto,
-    @IncludeQuery(publicReferences) includeRefs: ModelName[],
-  ) {
-    return this.service.readOneById(param._id, { includeRefs });
+  @UniformResponse(ModelName.ITEM)
+  public get(@Param() param: _idDto) {
+    return this.service.readItemsByStockId(param._id);
   }
 
   /**

--- a/src/clanInventory/stock/stock.service.ts
+++ b/src/clanInventory/stock/stock.service.ts
@@ -5,6 +5,7 @@ import { Stock } from './stock.schema';
 import { CreateStockDto } from './dto/createStock.dto';
 import { UpdateStockDto } from './dto/updateStock.dto';
 import { StockDto } from './dto/stock.dto';
+import { Player } from '../../player/schemas/player.schema';
 import { ItemService } from '../item/item.service';
 import { ModelName } from '../../common/enum/modelName.enum';
 import BasicService from '../../common/service/basicService/BasicService';
@@ -24,6 +25,7 @@ import { ClanDto } from '../../clan/dto/clan.dto';
 export class StockService {
   public constructor(
     @InjectModel(Stock.name) public readonly model: Model<Stock>,
+    @InjectModel(ModelName.PLAYER) private readonly playerModel: Model<Player>,
     private readonly itemService: ItemService,
     @Inject(forwardRef(() => FleaMarketService))
     @Optional()
@@ -118,7 +120,7 @@ export class StockService {
    * @returns An array of Stocks if succeed or an array of ServiceErrors if any occurred.
    */
   async readAll(options?: TIServiceReadManyOptions, environment?: Environment) {
-    const optionsToApply = options;
+    const optionsToApply = { ...(options ?? {}) };
 
     if (options?.includeRefs) {
       optionsToApply.includeRefs = options.includeRefs.filter((ref) =>
@@ -126,13 +128,65 @@ export class StockService {
       );
     }
 
-    optionsToApply.filter = environment
-      ? {
-          ...(options?.filter || { environment: environment }),
-        }
-      : {};
+    optionsToApply.filter = {
+      ...(options?.filter ?? {}),
+      ...(environment !== undefined ? { environment } : {}),
+    };
 
     return this.basicService.readMany<StockDto>(optionsToApply);
+  }
+
+  /**
+   * Reads all Stocks of the Clan the Player belongs to.
+   *
+   * @param player_id Mongo _id of the Player.
+   * @param options Options for reading Stocks.
+   * @param environment Environment of the stocks.
+   * @returns An array of Clan Stocks if succeeded or an array of ServiceErrors if error occurred.
+   */
+  async readPlayerClanStocks(
+    player_id: string,
+    options?: TIServiceReadManyOptions,
+    environment?: Environment,
+  ) {
+    const player = await this.playerModel.findById(player_id);
+
+    if (!player) {
+      return [
+        null,
+        [
+          new ServiceError({
+            reason: SEReason.NOT_FOUND,
+            field: 'player_id',
+            value: player_id,
+            message: 'Could not find any Player with this _id',
+          }),
+        ],
+      ];
+    }
+
+    const { clan_id } = player;
+    if (!clan_id) {
+      return [
+        null,
+        [
+          new ServiceError({
+            reason: SEReason.NOT_FOUND,
+            field: 'clan_id',
+            value: clan_id,
+            message: 'The Player is not in any Clan',
+          }),
+        ],
+      ];
+    }
+
+    return this.readAll(
+      {
+        ...(options ?? {}),
+        filter: { ...(options?.filter ?? {}), clan_id },
+      },
+      environment,
+    );
   }
 
   /**

--- a/src/clanInventory/stock/stock.service.ts
+++ b/src/clanInventory/stock/stock.service.ts
@@ -117,6 +117,33 @@ export class StockService {
   }
 
   /**
+   * Reads all Items stored in the specified Stock.
+   *
+   * @param _id Stock _id.
+   * @returns Item array if Stock exists, empty array if Stock has no Items, or ServiceErrors if Stock was not found.
+   */
+  async readItemsByStockId(_id: string) {
+    const [, stockErrors] = await this.basicService.readOneById<StockDto>(_id, {
+      select: ['_id'],
+    });
+    if (stockErrors) return [null, stockErrors];
+
+    const [items, itemErrors] = await this.itemService.readMany({
+      filter: { stock_id: _id },
+    });
+
+    if (itemErrors) {
+      const onlyNotFound = itemErrors.every(
+        (error) => error.reason === SEReason.NOT_FOUND,
+      );
+      if (onlyNotFound) return [[], null];
+
+      return [null, itemErrors];
+    }
+
+    return [items, null];
+  }
+  /**
    * Reads Stocks by specified options from DB.
    *
    * @param options - Options for reading CharacterClasses.

--- a/src/clanInventory/stock/stock.service.ts
+++ b/src/clanInventory/stock/stock.service.ts
@@ -108,8 +108,12 @@ export class StockService {
       : [[]];
 
     const [fleaMarketItems] = fleaMarketResult || [[]];
+    const stockObject =
+      typeof stock['toObject'] === 'function' ? stock['toObject']() : stock;
 
-    return [{ ...stock, FleaMarketItem: fleaMarketItems ?? [] }, null];
+    if (options?.select) return [stockObject, null];
+
+    return [{ ...stockObject, FleaMarketItem: fleaMarketItems ?? [] }, null];
   }
 
   /**


### PR DESCRIPTION
### Brief description

Fixed issue 874 of GET /stock/:id returning extra data

### Change list

- GET /stock now returns only the stock list for the logged-in player’s clan instead of all stocks.
- Fixed stock filtering so environment=0 is handled correctly.
- GET /stock/:id now returns only the list of Items stored in that stock, not the stock document itself.
- Removed leaking Mongoose internals like $__, $isNew, and _doc from stock responses.
- Added tests for clan-scoped stock listing, environment=0, clean stock serialization, and stock item retrieval. 

Example with Postman after fix:

```
{
    "data": {
        "Item": [
            {
                "_id": "6a06dc34058c7fd326e2b319",
                "name": "Closet_Rakkaus",
                "weight": 45,
                "recycling": "Wood",
                "rarity": "common",
                "material": [
                    "puu"
                ],
                "unityKey": "Closet_Rakkaus",
                "location": [
                    -1,
                    -1
                ],
                "price": 130,
                "isFurniture": true,
                "stock_id": "6a06dc34058c7fd326e2b313",
                "room_id": null,
                "__v": 0,
                "id": "6a06dc34058c7fd326e2b319"
            },
            {
                "_id": "6a1036df7362536157669d2d",
                "name": "Carpet_Rakkaus",
                "weight": 6,
                "recycling": "Mixed_waste",
                "rarity": "common",
                "material": [
                    "kangas"
                ],
                "unityKey": "Carpet_Rakkaus",
                "location": [
                    0,
                    1
                ],
                "price": 100,
                "isFurniture": false,
                "stock_id": "6a06dc34058c7fd326e2b313",
                "room_id": null,
                "__v": 0,
                "id": "6a1036df7362536157669d2d"
            },
			...
```