### PR TITLE
890 bug get itemsteal returns 500 internal server error if no request body is provided

### DIFF
--- a/src/__tests__/clanInventory/item/guards/AuthGuard/canActivate.test.ts
+++ b/src/__tests__/clanInventory/item/guards/AuthGuard/canActivate.test.ts
@@ -64,6 +64,21 @@ describe('StealTokenGuard.canActivate() test suite', () => {
     await expect(throwsNotAuthorized).rejects.toThrow(expectedException);
   });
 
+  it('Should throw NOT_AUTHORIZED APIError if the request body is not provided', async () => {
+    const context = contextBuilder
+      .setHttpRequest({ query: undefined, body: undefined })
+      .build();
+
+    const throwsNotAuthorized = async () =>
+      await stealGuard.canActivate(context);
+
+    const expectedException = new APIError({
+      reason: APIErrorReason.NOT_AUTHORIZED,
+      message: 'steal_token is not provided',
+    });
+    await expect(throwsNotAuthorized).rejects.toThrow(expectedException);
+  });
+
   it('Should throw UnauthorizedException if the steal token is not valid', async () => {
     const bodyWithInvalidToken = {
       body: { steal_token: 'invalid-steal-token' },

--- a/src/clanInventory/item/guards/StealToken.guard.ts
+++ b/src/clanInventory/item/guards/StealToken.guard.ts
@@ -17,7 +17,8 @@ export class StealTokenGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
-    const stealToken = request.query.steal_token ?? request.body.steal_token;
+    const stealToken =
+      request.query?.steal_token ?? request.body?.steal_token ?? undefined;
 
     if (!stealToken) {
       throw new APIError({


### PR DESCRIPTION
### Brief description

This PR should fix a bug with endpoint GET /item/steal where it returns internal server error if no request body is provided instead of throwing unauthorized API Error like was intended to do.

### Change list

- updated `src/clanInventory/item/guards/StealToken.guard.ts`
  - check that `request.body.steal_token` or `request.query.steal_token` is not undefined before accessing `stealToken` (avoid TypeError that caused internal server error) 

- updated `src/__tests__/clanInventory/item/guards/AuthGuard/canActivate.test.ts`
  - added a new test that checks if Unauthorized APIError is thrown if no request body is provided 

