### PR TITLE
convert time values to milliseconds in box/session service

### DIFF
--- a/src/__tests__/box/SessionStarterService/start.test.ts
+++ b/src/__tests__/box/SessionStarterService/start.test.ts
@@ -100,7 +100,7 @@ describe('SessionStarterService.start() test suite', () => {
 
     const now = new Date().getTime();
     const boxInDB = await boxModel.findById(existingBox._id);
-    const timeAfterWeek = now + 60 * 60 * 24 * 7;
+    const timeAfterWeek = now + 60 * 60 * 24 * 7 * 1000;
 
     expect(boxInDB.sessionResetTime).toBeLessThanOrEqual(timeAfterWeek);
   });
@@ -110,7 +110,7 @@ describe('SessionStarterService.start() test suite', () => {
 
     const now = new Date().getTime();
     const boxInDB = await boxModel.findById(existingBox._id);
-    const timeAfterMonth = now + 60 * 60 * 24 * 30;
+    const timeAfterMonth = now + 60 * 60 * 24 * 30 * 1000;
 
     expect(boxInDB.boxRemovalTime).toBeLessThanOrEqual(timeAfterMonth);
   });

--- a/src/box/sessionStarter/sessionStarter.service.ts
+++ b/src/box/sessionStarter/sessionStarter.service.ts
@@ -69,8 +69,8 @@ export default class SessionStarterService {
       this.passwordGenerator.generatePassword('fi') + `-${randNumber}`;
 
     const now = new Date().getTime();
-    const timeAfterWeek = now + 60 * 60 * 24 * 7;
-    const timeAfterMonth = now + 60 * 60 * 24 * 30;
+    const timeAfterWeek = now + 60 * 60 * 24 * 7 * 1000;
+    const timeAfterMonth = now + 60 * 60 * 24 * 30 * 1000;
 
     const [boxInDB, error] = await this.getAndValidateBox(box_id);
     if (error) return [null, error];


### PR DESCRIPTION
### Brief description

This PR converts the numerical times in SessionStarterService into milliseconds.
Because `const now = new Date().getTime();` returns current date in milliseconds the other time variables must be in milliseconds too.

### Change list

- updated `src/box/sessionStarter/sessionStarter.service.ts` and `src/__tests__/box/SessionStarterService/start.test.ts`
  - multiply `const timeAfterWeek` and `const timeAfterMonth` by 1000 to convert them into milliseconds:
  ```
    const now = new Date().getTime();
    const timeAfterWeek = now + 60 * 60 * 24 * 7 * 1000;
    const timeAfterMonth = now + 60 * 60 * 24 * 30 * 1000;
```