### PR TITLE
894 bug battlestart returns 500 when custom matchid is not a mongo objectid

### DIFF
--- a/src/__tests__/gameData/dto/startBattleDto.test.ts
+++ b/src/__tests__/gameData/dto/startBattleDto.test.ts
@@ -1,0 +1,47 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { StartBattleDto } from '../../../gameData/dto/startBattle.dto';
+import { GameType } from '../../../gameData/enum/gameType.enum';
+
+describe('StartBattleDto test suite', () => {
+  const player1Id = '665af23e5e982f0013aa1111';
+  const player2Id = '665af23e5e982f0013aa2222';
+  const matchId = '665af23e5e982f0013aa9999';
+
+  function createDto(overrides: Partial<StartBattleDto> = {}) {
+    const dto = new StartBattleDto();
+    dto.gameType = GameType.MATCHMAKING;
+    dto.team1 = [player1Id];
+    dto.team2 = [player2Id];
+
+    return Object.assign(dto, overrides);
+  }
+
+  it('Should pass validation without matchId', async () => {
+    const dto = createDto();
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('Should pass validation with a MongoId matchId', async () => {
+    const dto = createDto({ matchId });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('Should fail validation with a non-MongoId matchId', async () => {
+    const dto = createDto({ matchId: 'test-steal-001' });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('matchId');
+    expect(errors[0].constraints?.isMongoId).toBe(
+      'matchId must be a mongodb id',
+    );
+  });
+});

--- a/src/gameData/dto/startBattle.dto.ts
+++ b/src/gameData/dto/startBattle.dto.ts
@@ -3,7 +3,6 @@ import {
   IsArray,
   IsMongoId,
   IsOptional,
-  IsString,
 } from 'class-validator';
 import { GameType } from '../enum/gameType.enum';
 

--- a/src/gameData/dto/startBattle.dto.ts
+++ b/src/gameData/dto/startBattle.dto.ts
@@ -1,9 +1,4 @@
-import {
-  IsEnum,
-  IsArray,
-  IsMongoId,
-  IsOptional,
-} from 'class-validator';
+import { IsEnum, IsArray, IsMongoId, IsOptional } from 'class-validator';
 import { GameType } from '../enum/gameType.enum';
 
 export class StartBattleDto {

--- a/src/gameData/dto/startBattle.dto.ts
+++ b/src/gameData/dto/startBattle.dto.ts
@@ -32,10 +32,11 @@ export class StartBattleDto {
   team2: string[];
 
   /**
-   * Optional custom match ID. If these are not provided, the server generates one.
-   * @example "match_12345"
+   * Optional custom Mongo ObjectId-compatible match ID.
+   * If not provided, the server generates one.
+   * @example "665af23e5e982f0013aa9999"
    */
   @IsOptional()
-  @IsString()
+  @IsMongoId()
   matchId?: string;
 }


### PR DESCRIPTION
### Brief description

There used to be allowed in the `startBattle.dto.ts` `@IsString` custom matchId, but using custom string caused 500 internal server error. To accept custom string without 500 internal server error requires changes to database schema.

Now `matchId` field must be MongoDB style string. It can be custom string with if it's also a 24 byte MongoDB string at the same time.

I `git stash`ed the prettier/linting changes of other files.

Issue #894 

### Change list

- startBattle.dto.ts (require MongoID for matchId)
- added new test file for startBattle.dto.ts