### PR TITLE
Add AvatarData into the chat reaction setup

### DIFF
--- a/src/chat/dto/addReaction.dto.ts
+++ b/src/chat/dto/addReaction.dto.ts
@@ -1,4 +1,6 @@
-import { IsMongoId, IsOptional, IsString } from 'class-validator';
+import { IsMongoId, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { AvatarDto } from '../../player/dto/avatar.dto';
 
 /**
  * DTO for adding reaction to a chat message.
@@ -18,4 +20,12 @@ export class AddReactionDto {
   @IsString()
   @IsOptional()
   emoji: string;
+
+  /**
+   * Optional avatar data of the reacting player.
+   */
+  @IsOptional()     
+  @ValidateNested()
+  @Type(() => AvatarDto)
+  avatarData?: AvatarDto;
 }

--- a/src/chat/dto/reaction.dto.ts
+++ b/src/chat/dto/reaction.dto.ts
@@ -1,4 +1,6 @@
-import { Expose } from 'class-transformer';
+import { Expose, Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { AvatarDto } from '../../player/dto/avatar.dto';
 
 /**
  * DTO representing a single chat message.
@@ -24,4 +26,12 @@ export class ReactionDto {
    */
   @Expose()
   sender_id: string;
+
+  /**
+   * Avatar data of the user who reacted
+   */
+  @Expose()
+  @Type(() => AvatarDto)
+  @ApiPropertyOptional({ type: () => AvatarDto })
+  avatarData?: AvatarDto;
 }

--- a/src/chat/schema/reaction.schema.ts
+++ b/src/chat/schema/reaction.schema.ts
@@ -1,5 +1,5 @@
 import { Prop } from '@nestjs/mongoose';
-
+import { Avatar, AvatarSchema } from '../../player/schemas/avatar.schema';
 export class Reaction {
   @Prop({ type: String, required: true })
   playerName: string;
@@ -13,4 +13,7 @@ export class Reaction {
     default: 'legacy_system',
   })
   sender_id: string;
+
+  @Prop({ type: AvatarSchema, required: false })
+  avatarData?: Avatar;
 }

--- a/src/chat/service/baseChat.service.ts
+++ b/src/chat/service/baseChat.service.ts
@@ -126,6 +126,7 @@ export abstract class BaseChatService {
       client.user.name,
       reaction.emoji,
       client.user.playerId,
+      reaction.avatarData,
       options,
     );
 

--- a/src/chat/service/chat.service.ts
+++ b/src/chat/service/chat.service.ts
@@ -14,6 +14,7 @@ import {
 import { UpdateChatMessageDto } from '../dto/updateChatMessage.dto';
 import ServiceError from '../../common/service/basicService/ServiceError';
 import { SEReason } from '../../common/service/basicService/SEReason';
+import { Avatar } from '../../player/schemas/avatar.schema';
 
 @Injectable()
 export class ChatService {
@@ -49,6 +50,7 @@ export class ChatService {
    * @param playerName - Name of the player who reacted.
    * @param emoji - String representation of the emoji.
    * @param sender_id - Unique ID of the player reacting.
+   * @param avatarData - Optional avatar data of the player.
    * @param options - Optional mongoose ClientSession for transaction support.
    * @returns Message with added reaction.
    */
@@ -57,6 +59,7 @@ export class ChatService {
     playerName: string,
     emoji: string,
     sender_id: string,
+    avatarData?: Avatar,    
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<ChatMessageDto>> {
     const [message, error] =
@@ -68,7 +71,9 @@ export class ChatService {
       (r) => r.playerName !== playerName,
     );
 
-    if (emoji) message.reactions.push({ playerName, emoji, sender_id });
+    if (emoji) {
+      message.reactions.push({ playerName, emoji, sender_id, avatarData });
+    }
 
     const [, updateError] = await this.basicService.updateOneById(
       message._id,


### PR DESCRIPTION
### Brief description

Closes #861 

Implements AvatarData into the chat reaction setup successfully. On top of successful unit tests (when ran individually), backend testing for this was done through in-memory script execution, here's the output: 

```
[capomk@archlinux Altzone-Server]$ npx ts-node -e "
import 'reflect-metadata';
import { plainToInstance } from 'class-transformer';
import { ReactionDto } from './src/chat/dto/reaction.dto';

const sampleReaction = {
  playerName: 'ShadowKnight',
  emoji: '🔥',
  sender_id: '64f1a2b3c4d5e6f7a8b9c0d1',
  avatarData: {
    head: { id: 1, color: '#ff0000' },
    hair: 2,
    skinColor: '#FAD9B5'
  }
};
   
const result = plainToInstance(ReactionDto, sampleReaction, { excludeExtraneousValues: true });
console.log('Transformed ReactionDto:\n', JSON.stringify(result, null, 2));
"
Transformed ReactionDto:
 {
  "playerName": "ShadowKnight",
  "emoji": "🔥",
  "sender_id": "64f1a2b3c4d5e6f7a8b9c0d1",
  "avatarData": {
    "head": {
      "id": 1,
      "color": "#ff0000"
    },
    "hair": {
      "id": 2,
      "color": "#ffffff"
    },
    "skinColor": "#FAD9B5"
  }
}
[capomk@archlinux Altzone-Server]$ git add . 
[capomk@archlinux Altzone-Server]$ npx ts-node -e "
import 'reflect-metadata';
import { plainToInstance } from 'class-transformer';
import { ReactionDto } from './src/chat/dto/reaction.dto';

const reactionPayload = [
  {
    playerName: 'PlayerOne',
    emoji: '👍',
    sender_id: '123',
    avatarData: {
      head: 1,
      skinColor: '#ffffff'
    }
  },
  {
    playerName: 'PlayerTwo',
    emoji: '❤️',
    sender_id: '456',
    avatarData: {
      head: { id: 5, color: '#00ff00' },
      skinColor: '#000000'
    }
  }
];

const result = plainToInstance(ReactionDto, reactionPayload, { excludeExtraneousValues: true });
console.log('Reaction List with AvatarData:\n', JSON.stringify(result, null, 2));
"
Reaction List with AvatarData:
 [
  {
    "playerName": "PlayerOne",
    "emoji": "👍",
    "sender_id": "123",
    "avatarData": {
      "head": {
        "id": 1,
        "color": "#ffffff"
      },
      "skinColor": "#ffffff"
    }
  },
  {
    "playerName": "PlayerTwo",
    "emoji": "❤️",
    "sender_id": "456",
    "avatarData": {
      "head": {
        "id": 5,
        "color": "#00ff00"
      },
      "skinColor": "#000000"
    }
  }
]
[capomk@archlinux Altzone-Server]$
```


### Change list

- Adds new imports to `addReaction.dto.ts` just for the DTO in question, at least for the most part.
- Adds the AvatarData as an optional DTO in the same file with the imported functionality included.
- Similar setup on `reaction.dto.ts` as well.
- Implements the avatarSchema on `reaction.schema.ts`.
- `baseChatService.ts` and `chat.service.ts` were modified for the sole purpose of getting `npm run build` to pass. I followed the same setup that's been done on the previous parts of the async method, making sure to add the required fields to the class to make it work.
