### PR TITLE
895 bug battle match id handling is inconsistent between start result and conflict resolution

### DIFF
--- a/src/__tests__/gameData/dto/battleMatchIdDto.test.ts
+++ b/src/__tests__/gameData/dto/battleMatchIdDto.test.ts
@@ -1,0 +1,72 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { BattleResultDto } from '../../../gameData/dto/battleResult.dto';
+import { SubmitResultDto } from '../../../gameData/dto/submitResult.dto';
+import { RequestType } from '../../../gameData/enum/requestType.enum';
+
+describe('Battle matchId DTO validation test suite', () => {
+  const matchId = '665af23e5e982f0013aa9999';
+  const player1Id = '665af23e5e982f0013aa1111';
+  const player2Id = '665af23e5e982f0013aa2222';
+
+  function createBattleResultDto(overrides: Partial<BattleResultDto> = {}) {
+    const dto = new BattleResultDto();
+    dto.type = RequestType.RESULT;
+    dto.matchId = matchId;
+    dto.team1 = [player1Id];
+    dto.team2 = [player2Id];
+    dto.duration = 120;
+    dto.result = 1;
+
+    return Object.assign(dto, overrides);
+  }
+
+  function createSubmitResultDto(overrides: Partial<SubmitResultDto> = {}) {
+    const dto = new SubmitResultDto();
+    dto.matchId = matchId;
+    dto.duration = 120;
+    dto.result = 1;
+
+    return Object.assign(dto, overrides);
+  }
+
+  it('Should pass BattleResultDto validation with a MongoId matchId', async () => {
+    const dto = createBattleResultDto();
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('Should fail BattleResultDto validation with a non-MongoId matchId', async () => {
+    const dto = createBattleResultDto({ matchId: 'test-steal-001' });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('matchId');
+    expect(errors[0].constraints?.isMongoId).toBe(
+      'matchId must be a mongodb id',
+    );
+  });
+
+  it('Should pass SubmitResultDto validation with a MongoId matchId', async () => {
+    const dto = createSubmitResultDto();
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('Should fail SubmitResultDto validation with a non-MongoId matchId', async () => {
+    const dto = createSubmitResultDto({ matchId: 'test-steal-001' });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('matchId');
+    expect(errors[0].constraints?.isMongoId).toBe(
+      'matchId must be a mongodb id',
+    );
+  });
+});

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -1,0 +1,100 @@
+import { Types } from 'mongoose';
+import GameDataModule from '../modules/gameData.module';
+import { GameDataService } from '../../../gameData/gameData.service';
+import { Game } from '../../../gameData/game.schema';
+import { GameType } from '../../../gameData/enum/gameType.enum';
+import { BattleStatus } from '../../../gameData/enum/battleStatus.enum';
+
+describe('GameDataService battle lifecycle test suite', () => {
+  const gameDataModel = GameDataModule.getGameModel();
+
+  let gameDataService: GameDataService;
+
+  beforeEach(async () => {
+    await gameDataModel.deleteMany({});
+    gameDataService = await GameDataModule.getGameDataService();
+  });
+
+  it('Should register a battle using the provided matchId as document _id', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    const battle = await gameDataService.registerBattle({
+      gameType: GameType.MATCHMAKING,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      matchId,
+    });
+
+    const battleInDb = await gameDataModel.findById(matchId);
+
+    expect(battle._id.toString()).toBe(matchId);
+    expect(battleInDb?._id.toString()).toBe(matchId);
+    expect(battleInDb?.status).toBe(BattleStatus.OPEN);
+  });
+
+  it('Should submit a battle result by finding the battle with matchId as _id', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    await gameDataService.registerBattle({
+      gameType: GameType.MATCHMAKING,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      matchId,
+    });
+
+    const battle = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      team1PlayerId,
+    );
+
+    expect(battle._id.toString()).toBe(matchId);
+    expect(battle.receivedResults).toHaveLength(1);
+    expect(battle.receivedResults[0].playerId.toString()).toBe(team1PlayerId);
+    expect(battle.status).toBe(BattleStatus.OPEN);
+  });
+
+  it('Should resolve a conflicting battle by document _id', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    const battle: Partial<Game> = {
+      _id: matchId,
+      gameType: GameType.MATCHMAKING,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      status: BattleStatus.PROCESSING,
+      receivedResults: [
+        {
+          playerId: team1PlayerId,
+          winnerTeam: 1,
+          duration: 120,
+        },
+        {
+          playerId: team2PlayerId,
+          winnerTeam: 2,
+          duration: 120,
+        },
+      ],
+    };
+
+    await gameDataModel.create(battle);
+    await (
+      gameDataService as unknown as {
+        resolveConflict: (_id: string) => Promise<void>;
+      }
+    ).resolveConflict(matchId);
+
+    const battleInDb = await gameDataModel.findById(matchId);
+
+    expect(battleInDb?.status).toBe(BattleStatus.COMPLETED);
+    expect(battleInDb?.finalWinner).toBe(1);
+  });
+});

--- a/src/gameData/dto/battleResult.dto.ts
+++ b/src/gameData/dto/battleResult.dto.ts
@@ -2,7 +2,6 @@ import {
   IsArray,
   IsEnum,
   IsInt,
-  IsString,
   IsMongoId,
   IsPositive,
   IsNotEmpty,
@@ -25,7 +24,7 @@ export class BattleResultDto {
    * This is used to look up the existing game record in the database.
    * * @example "665af23e5e982f0013aa9999"
    */
-  @IsString()
+  @IsMongoId()
   @IsNotEmpty()
   matchId: string;
 

--- a/src/gameData/dto/submitResult.dto.ts
+++ b/src/gameData/dto/submitResult.dto.ts
@@ -1,10 +1,10 @@
 import {
-  IsString,
   IsInt,
   IsNotEmpty,
   Min,
   Max,
   IsPositive,
+  IsMongoId,
 } from 'class-validator';
 
 export class SubmitResultDto {
@@ -12,7 +12,7 @@ export class SubmitResultDto {
    * The unique identifier for the battle match.
    * @example "665af23e5e982f0013aa9999"
    */
-  @IsString()
+  @IsMongoId()
   @IsNotEmpty()
   matchId: string;
 

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -426,12 +426,12 @@ export class GameDataService {
   /**
    * Forcibly resolves a battle conflict after the "Final Call" period.
    * Uses a majority vote based on received results and defaults to Team 1 if tied.
-   * * @param matchId - The unique identifier of the battle to resolve.
+   * @param _id - The unique identifier of the battle to resolve (matchId).
    * @returns A promise that resolves once the conflict is settled and rewards are issued.
    * @private
    */
-  private async resolveConflict(matchId: string) {
-    const battle = await this.model.findOne({ matchId });
+  private async resolveConflict(_id: string) {
+    const battle = await this.model.findOne({ _id });
     if (!battle || battle.status === BattleStatus.COMPLETED) return;
 
     const results = battle.receivedResults;


### PR DESCRIPTION
### Brief description

Fixes issue #895 : now MongoID is required and used consistently.

### Change list

- `battleResut.dto.ts` and `submitBattleResult.dto.ts`: Require matchId to be MongoID
- `resolveConflict.ts` look for `_id` in the database instead of `matchId`
- added 2 new test files to cover changes and battle life cycle (resolve conflict)
