### PR TITLE
901 bug in matchmaking custom match does not require roomid and small other bugs in matchmaking

### DIFF
--- a/doc/matchmaking-mqtt-notifications.md
+++ b/doc/matchmaking-mqtt-notifications.md
@@ -5,8 +5,8 @@ The implementation lives in `src/matchmaking/matchmaking.notifier.ts`, and the
 state changes that trigger the events are handled by
 `src/matchmaking/matchmaking.service.ts`.
 
-Matchmaking topics currently do not start with `/`. Frontend subscriptions must
-use the exact topic strings shown below.
+Matchmaking topics currently start with `/`. Frontend subscriptions must use
+the exact topic strings shown below.
 
 ## Subscribe Topics
 

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -4,6 +4,7 @@ import { MatchType } from '../../../matchmaking/enum/matchType.enum';
 import { TeamSide } from '../../../matchmaking/enum/teamSide.enum';
 import { MatchmakingService } from '../../../matchmaking/matchmaking.service';
 import { ActiveMatch } from '../../../matchmaking/type/activeMatch.type';
+import { SEReason } from '../../../common/service/basicService/SEReason';
 
 class InMemoryRedisService {
   readonly values = new Map<string, string>();
@@ -241,6 +242,31 @@ describe('MatchmakingService flow', () => {
       'MATCH_STARTED',
       expect.objectContaining({ id: matchedInvite.matchId }),
     );
+  });
+
+  it('returns REQUIRED error when joining a CUSTOM invite without roomId', async () => {
+    const { service } = createService();
+    const roomId = '665af23e5e982f0013aa334b';
+
+    const [invite, createErrors] = await service.createInvite('player-1', {
+      matchType: MatchType.CUSTOM,
+      roomId,
+    });
+
+    const [joinResult, joinErrors] = await service.joinInvite(
+      invite.id,
+      'player-2',
+      {} as any,
+    );
+
+    expect(createErrors).toBeNull();
+    expect(joinResult).toBeNull();
+    expect(joinErrors).toHaveLength(1);
+    expect(joinErrors[0]).toMatchObject({
+      reason: SEReason.REQUIRED,
+      field: 'roomId',
+      message: 'CUSTOM invite joins require roomId.',
+    });
   });
 
   it('finishes a RANDOM match with personal leaderboard updates only', async () => {

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -5,6 +5,7 @@ import { TeamSide } from '../../../matchmaking/enum/teamSide.enum';
 import { MatchmakingService } from '../../../matchmaking/matchmaking.service';
 import { ActiveMatch } from '../../../matchmaking/type/activeMatch.type';
 import { SEReason } from '../../../common/service/basicService/SEReason';
+import ServiceError from '../../../common/service/basicService/ServiceError';
 
 class InMemoryRedisService {
   readonly values = new Map<string, string>();
@@ -394,6 +395,122 @@ describe('MatchmakingService flow', () => {
       {
         $inc: { battlePoints: 50 },
       },
+    );
+  });
+
+  it('returns service errors when player leaderboard update fails while finishing a match', async () => {
+    const { redis, playerService, clanService, notifier, service } =
+      createService();
+    const updateError = new ServiceError({
+      reason: SEReason.NOT_FOUND,
+      field: 'playerId',
+      value: 'player-1',
+      message: 'Player not found.',
+    });
+    const match: ActiveMatch = {
+      id: 'match-player-error',
+      matchType: MatchType.RANDOM,
+      status: MatchStatus.ACTIVE,
+      teamSize: 1,
+      teams: [
+        {
+          side: TeamSide.A,
+          participants: [{ playerId: 'player-1', isBot: false }],
+        },
+        {
+          side: TeamSide.B,
+          participants: [{ playerId: 'player-2', isBot: false }],
+        },
+      ],
+      startedAt: '2026-07-06T08:00:00.000Z',
+    };
+    playerService.updatePlayerById.mockResolvedValueOnce([
+      null,
+      [updateError],
+    ]);
+    await redis.set(
+      'matchmaking:match:match-player-error',
+      JSON.stringify(match),
+    );
+
+    const [finishedMatch, errors] = await service.finishMatch(
+      'match-player-error',
+      'player-1',
+      { winningSide: TeamSide.A },
+    );
+
+    const storedMatch = JSON.parse(
+      await redis.get('matchmaking:match:match-player-error'),
+    ) as ActiveMatch;
+
+    expect(finishedMatch).toBeNull();
+    expect(errors).toEqual([updateError]);
+    expect(storedMatch.status).toBe(MatchStatus.ACTIVE);
+    expect(clanService.basicService.updateOneById).not.toHaveBeenCalled();
+    expect(redis.delete).not.toHaveBeenCalledWith(CacheKeys.PLAYER_LEADERBOARD);
+    expect(redis.delete).not.toHaveBeenCalledWith(CacheKeys.CLAN_LEADERBOARD);
+    expect(notifier.matchEvent).not.toHaveBeenCalledWith(
+      'match-player-error',
+      'MATCH_FINISHED',
+      expect.anything(),
+    );
+  });
+
+  it('returns service errors when clan leaderboard update fails while finishing a CLAN match', async () => {
+    const { redis, clanService, notifier, service } = createService();
+    const updateError = new ServiceError({
+      reason: SEReason.NOT_FOUND,
+      field: 'clanId',
+      value: 'clan-1',
+      message: 'Clan not found.',
+    });
+    const match: ActiveMatch = {
+      id: 'match-clan-error',
+      matchType: MatchType.CLAN,
+      status: MatchStatus.ACTIVE,
+      teamSize: 1,
+      teams: [
+        {
+          side: TeamSide.A,
+          clanId: 'clan-1',
+          participants: [{ playerId: 'player-1', isBot: false }],
+        },
+        {
+          side: TeamSide.B,
+          clanId: 'clan-2',
+          participants: [{ playerId: 'player-2', isBot: false }],
+        },
+      ],
+      startedAt: '2026-07-06T08:00:00.000Z',
+    };
+    clanService.basicService.updateOneById.mockResolvedValueOnce([
+      null,
+      [updateError],
+    ]);
+    await redis.set(
+      'matchmaking:match:match-clan-error',
+      JSON.stringify(match),
+    );
+
+    const [finishedMatch, errors] = await service.finishMatch(
+      'match-clan-error',
+      'player-1',
+      { winningSide: TeamSide.A },
+    );
+
+    const storedMatch = JSON.parse(
+      await redis.get('matchmaking:match:match-clan-error'),
+    ) as ActiveMatch;
+
+    expect(finishedMatch).toBeNull();
+    expect(errors).toEqual([updateError]);
+    expect(storedMatch.status).toBe(MatchStatus.ACTIVE);
+    expect(redis.delete).not.toHaveBeenCalledWith(CacheKeys.PLAYER_LEADERBOARD);
+    expect(redis.delete).not.toHaveBeenCalledWith(CacheKeys.CLAN_LEADERBOARD);
+    expect(notifier.matchEvent).not.toHaveBeenCalledWith(
+      'match-clan-error',
+      'MATCH_FINISHED',
+      expect.anything(),
     );
   });
 });

--- a/src/matchmaking/dto/joinMatchmakingInvite.dto.ts
+++ b/src/matchmaking/dto/joinMatchmakingInvite.dto.ts
@@ -7,8 +7,7 @@ export class JoinMatchmakingInviteDto {
    * @example "665af23e5e982f0013aa334b"
    */
   @IsMongoId()
-  @IsOptional()
-  roomId?: string;
+  roomId: string;
 
   /**
    * Optional client version for isolating incompatible matchmaking pools.

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -918,6 +918,17 @@ export class MatchmakingService {
       ];
     }
 
+    if (invite.matchType === MatchType.CUSTOM && !body.roomId) {
+      return [
+        new ServiceError({
+          reason: SEReason.REQUIRED,
+          field: 'roomId',
+          value: body.roomId,
+          message: 'CUSTOM invite joins require roomId.',
+        }),
+      ];
+    }
+
     if (invite.matchType === MatchType.CUSTOM && body.roomId) {
       if (body.roomId !== invite.roomId) {
         return [

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -824,8 +824,8 @@ export class MatchmakingService {
   }
 
   /**
-   * Re-saves a completed match with the shorter finished-match TTL and removes
-   * per-player active-match pointers.
+   * Re-saves a completed match and keeps per-player match lookups available
+   * for the shorter finished-match TTL.
    */
   private async saveFinishedMatch(match: ActiveMatch) {
     await this.redisService.set(

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -333,7 +333,10 @@ export class MatchmakingService {
       result: { winningSide: body.winningSide },
     };
 
-    await this.updateLeaderboardsForFinishedMatch(finishedMatch);
+    const leaderboardErrors =
+      await this.updateLeaderboardsForFinishedMatch(finishedMatch);
+    if (leaderboardErrors) return [null, leaderboardErrors];
+
     await this.saveFinishedMatch(finishedMatch);
     await this.invalidateLeaderboardCaches();
     await this.notifier.matchEvent(
@@ -718,12 +721,14 @@ export class MatchmakingService {
   private async updateLeaderboardsForFinishedMatch(match: ActiveMatch) {
     const playerErrors =
       await this.updatePlayerLeaderboardForFinishedMatch(match);
-    if (playerErrors) throw playerErrors;
+    if (playerErrors) return playerErrors;
 
-    if (match.matchType !== MatchType.CLAN) return;
+    if (match.matchType !== MatchType.CLAN) return null;
 
     const clanErrors = await this.updateClanLeaderboardForFinishedMatch(match);
-    if (clanErrors) throw clanErrors;
+    if (clanErrors) return clanErrors;
+
+    return null;
   }
 
   private async updatePlayerLeaderboardForFinishedMatch(match: ActiveMatch) {


### PR DESCRIPTION
### Brief description

Fixes issue #901 .

In the `joinMatchmakingInvite.dto.ts` `roomId` is required and related error for missing `roomId` is handled.
Also in `updateLeaderboardsForFinishedMatch()` (`matchmaking.service.ts`) errors are returned like in the reset of code (IServerReturn-style).

Documentation improvements.

### Change list

- `matchmaking.service.ts`
- `joinMatchmakingInvite.dto.ts`
- test code additions
