### PR TITLE
896 bug battle start validation and authorization are incomplete

### DIFF
--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -11,10 +11,21 @@ describe('GameDataService battle lifecycle test suite', () => {
   const gameDataModel = GameDataModule.getGameModel();
 
   let gameDataService: GameDataService;
+  let matchmakingService: {
+    validateBattleStart: jest.Mock;
+  };
 
   beforeEach(async () => {
     await gameDataModel.deleteMany({});
     gameDataService = await GameDataModule.getGameDataService();
+    matchmakingService = {
+      validateBattleStart: jest.fn(async () => null),
+    };
+    (
+      gameDataService as unknown as {
+        matchmakingService: typeof matchmakingService;
+      }
+    ).matchmakingService = matchmakingService;
     jest
       .spyOn(gameDataService.playerService, 'getPlayerById')
       .mockImplementation(async (playerId: string) => [
@@ -49,6 +60,12 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(battleInDb?._id.toString()).toBe(matchId);
     expect(battleInDb?.gameType).toBe(GameType.MATCHMAKING);
     expect(battleInDb?.status).toBe(BattleStatus.OPEN);
+    expect(matchmakingService.validateBattleStart).toHaveBeenCalledWith(
+      matchId,
+      team1PlayerId,
+      [team1PlayerId, team1SecondPlayerId],
+      [team2PlayerId, team2SecondPlayerId],
+    );
   });
 
   it('Should submit a battle result by finding the battle with matchId as _id', async () => {
@@ -137,7 +154,35 @@ describe('GameDataService battle lifecycle test suite', () => {
       field: 'matchId',
       message: 'Matchmaking battles require matchId.',
     });
+    expect(matchmakingService.validateBattleStart).not.toHaveBeenCalled();
     expect(await gameDataModel.countDocuments()).toBe(0);
+  });
+
+  it('Should not register a matchmaking battle when matchmaking validation fails', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    const validationError = new ServiceError({
+      reason: SEReason.VALIDATION,
+      field: 'teams',
+      message: 'Battle teams must match the active matchmaking match teams.',
+    });
+    matchmakingService.validateBattleStart.mockResolvedValueOnce([
+      validationError,
+    ]);
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.MATCHMAKING,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+        matchId,
+      },
+      team1PlayerId,
+    );
+
+    expect(result).toBe(validationError);
+    expect(await gameDataModel.findById(matchId)).toBeNull();
   });
 
   it('Should generate a matchId for a casual battle registered without matchId', async () => {

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -30,12 +30,15 @@ describe('GameDataService battle lifecycle test suite', () => {
     const team2PlayerId = new Types.ObjectId().toHexString();
     const team2SecondPlayerId = new Types.ObjectId().toHexString();
 
-    const battle = await gameDataService.registerBattle({
-      gameType: GameType.MATCHMAKING,
-      team1: [team1PlayerId, team1SecondPlayerId],
-      team2: [team2PlayerId, team2SecondPlayerId],
-      matchId,
-    }, team1PlayerId);
+    const battle = await gameDataService.registerBattle(
+      {
+        gameType: GameType.MATCHMAKING,
+        team1: [team1PlayerId, team1SecondPlayerId],
+        team2: [team2PlayerId, team2SecondPlayerId],
+        matchId,
+      },
+      team1PlayerId,
+    );
 
     const battleInDb = await gameDataModel.findById(matchId);
 
@@ -53,12 +56,15 @@ describe('GameDataService battle lifecycle test suite', () => {
     const team1PlayerId = new Types.ObjectId().toHexString();
     const team2PlayerId = new Types.ObjectId().toHexString();
 
-    await gameDataService.registerBattle({
-      gameType: GameType.MATCHMAKING,
-      team1: [team1PlayerId],
-      team2: [team2PlayerId],
-      matchId,
-    }, team1PlayerId);
+    await gameDataService.registerBattle(
+      {
+        gameType: GameType.MATCHMAKING,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+        matchId,
+      },
+      team1PlayerId,
+    );
 
     const battle = await gameDataService.handleBattleResult(
       {

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -4,6 +4,7 @@ import { GameDataService } from '../../../gameData/gameData.service';
 import { Game } from '../../../gameData/game.schema';
 import { GameType } from '../../../gameData/enum/gameType.enum';
 import { BattleStatus } from '../../../gameData/enum/battleStatus.enum';
+import ServiceError from '../../../common/service/basicService/ServiceError';
 
 describe('GameDataService battle lifecycle test suite', () => {
   const gameDataModel = GameDataModule.getGameModel();
@@ -13,23 +14,33 @@ describe('GameDataService battle lifecycle test suite', () => {
   beforeEach(async () => {
     await gameDataModel.deleteMany({});
     gameDataService = await GameDataModule.getGameDataService();
+    jest
+      .spyOn(gameDataService.playerService, 'getPlayerById')
+      .mockImplementation(async (playerId: string) => [
+        { _id: playerId } as any,
+        null,
+      ]);
   });
 
   it('Should register a battle using the provided matchId as document _id', async () => {
     const matchId = new Types.ObjectId().toHexString();
     const team1PlayerId = new Types.ObjectId().toHexString();
+    const team1SecondPlayerId = new Types.ObjectId().toHexString();
     const team2PlayerId = new Types.ObjectId().toHexString();
+    const team2SecondPlayerId = new Types.ObjectId().toHexString();
 
     const battle = await gameDataService.registerBattle({
       gameType: GameType.MATCHMAKING,
-      team1: [team1PlayerId],
-      team2: [team2PlayerId],
+      team1: [team1PlayerId, team1SecondPlayerId],
+      team2: [team2PlayerId, team2SecondPlayerId],
       matchId,
     });
 
     const battleInDb = await gameDataModel.findById(matchId);
 
-    expect(battle._id.toString()).toBe(matchId);
+    expect(battle).not.toBeInstanceOf(ServiceError);
+    const battleDocument = battle as Exclude<typeof battle, ServiceError>;
+    expect(battleDocument._id.toString()).toBe(matchId);
     expect(battleInDb?._id.toString()).toBe(matchId);
     expect(battleInDb?.status).toBe(BattleStatus.OPEN);
   });

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -41,7 +41,9 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(battle).not.toBeInstanceOf(ServiceError);
     const battleDocument = battle as Exclude<typeof battle, ServiceError>;
     expect(battleDocument._id.toString()).toBe(matchId);
+    expect(battleDocument.gameType).toBe(GameType.MATCHMAKING);
     expect(battleInDb?._id.toString()).toBe(matchId);
+    expect(battleInDb?.gameType).toBe(GameType.MATCHMAKING);
     expect(battleInDb?.status).toBe(BattleStatus.OPEN);
   });
 

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -5,6 +5,7 @@ import { Game } from '../../../gameData/game.schema';
 import { GameType } from '../../../gameData/enum/gameType.enum';
 import { BattleStatus } from '../../../gameData/enum/battleStatus.enum';
 import ServiceError from '../../../common/service/basicService/ServiceError';
+import { SEReason } from '../../../common/service/basicService/SEReason';
 
 describe('GameDataService battle lifecycle test suite', () => {
   const gameDataModel = GameDataModule.getGameModel();
@@ -34,7 +35,7 @@ describe('GameDataService battle lifecycle test suite', () => {
       team1: [team1PlayerId, team1SecondPlayerId],
       team2: [team2PlayerId, team2SecondPlayerId],
       matchId,
-    });
+    }, team1PlayerId);
 
     const battleInDb = await gameDataModel.findById(matchId);
 
@@ -57,7 +58,7 @@ describe('GameDataService battle lifecycle test suite', () => {
       team1: [team1PlayerId],
       team2: [team2PlayerId],
       matchId,
-    });
+    }, team1PlayerId);
 
     const battle = await gameDataService.handleBattleResult(
       {
@@ -109,5 +110,46 @@ describe('GameDataService battle lifecycle test suite', () => {
 
     expect(battleInDb?.status).toBe(BattleStatus.COMPLETED);
     expect(battleInDb?.finalWinner).toBe(1);
+  });
+
+  it('Should return REQUIRED error when matchmaking battle is registered without matchId', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.MATCHMAKING,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+      },
+      team1PlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.REQUIRED,
+      field: 'matchId',
+      message: 'Matchmaking battles require matchId.',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+  });
+
+  it('Should generate a matchId for a casual battle registered without matchId', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+      },
+      team1PlayerId,
+    );
+
+    expect(result).not.toBeInstanceOf(ServiceError);
+    const battle = result as Exclude<typeof result, ServiceError>;
+    expect(Types.ObjectId.isValid(battle._id.toString())).toBe(true);
+    expect(await gameDataModel.findById(battle._id)).not.toBeNull();
   });
 });

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -201,6 +201,34 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(result).not.toBeInstanceOf(ServiceError);
     const battle = result as Exclude<typeof result, ServiceError>;
     expect(Types.ObjectId.isValid(battle._id.toString())).toBe(true);
+    expect(battle.gameType).toBe(GameType.CASUAL);
     expect(await gameDataModel.findById(battle._id)).not.toBeNull();
+  });
+
+  it('Should only persist battle start fields explicitly supported by the schema', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CUSTOM,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+        unexpectedField: 'should-not-be-persisted',
+      } as any,
+      team1PlayerId,
+    );
+
+    expect(result).not.toBeInstanceOf(ServiceError);
+    const battle = result as Exclude<typeof result, ServiceError>;
+    const battleInDb = await gameDataModel.findById(battle._id).lean();
+
+    expect(battleInDb).toMatchObject({
+      gameType: GameType.CUSTOM,
+      status: BattleStatus.OPEN,
+      receivedResults: [],
+    });
+    expect(battleInDb).not.toHaveProperty('unexpectedField');
+    expect(battleInDb).not.toHaveProperty('matchId');
   });
 });

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -296,6 +296,138 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(await gameDataModel.findById(matchId)).toBeNull();
   });
 
+  it('Should not register a battle when requester is not in either team', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    const requesterPlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+      },
+      requesterPlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_AUTHORIZED,
+      message: 'Requester player must be in one of the teams',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+    expect(gameDataService.playerService.getPlayerById).not.toHaveBeenCalled();
+  });
+
+  it('Should not register a battle when either team is empty', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId],
+        team2: [],
+      },
+      team1PlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.MISCONFIGURED,
+      message: 'Both teams must have at least one player',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+    expect(gameDataService.playerService.getPlayerById).not.toHaveBeenCalled();
+  });
+
+  it('Should not register a battle when a player is in both teams', async () => {
+    const sharedPlayerId = new Types.ObjectId().toHexString();
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [sharedPlayerId],
+        team2: [sharedPlayerId],
+      },
+      sharedPlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.MISCONFIGURED,
+      message: 'A player cannot be in both teams',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+  });
+
+  it('Should not register a battle when a team1 player does not exist', async () => {
+    const missingPlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    const missingPlayerError = new ServiceError({
+      reason: SEReason.NOT_FOUND,
+      field: 'playerId',
+      value: missingPlayerId,
+      message: 'Player not found.',
+    });
+    (
+      gameDataService.playerService.getPlayerById as jest.Mock
+    ).mockImplementation(async (playerId: string) => {
+      if (playerId === missingPlayerId) return [null, [missingPlayerError]];
+
+      return [{ _id: playerId } as any, null];
+    });
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [missingPlayerId],
+        team2: [team2PlayerId],
+      },
+      missingPlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_FOUND,
+      message: 'One or more players in team 1 do not exist',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+  });
+
+  it('Should not register a battle when a team2 player does not exist', async () => {
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const missingPlayerId = new Types.ObjectId().toHexString();
+    const missingPlayerError = new ServiceError({
+      reason: SEReason.NOT_FOUND,
+      field: 'playerId',
+      value: missingPlayerId,
+      message: 'Player not found.',
+    });
+    (
+      gameDataService.playerService.getPlayerById as jest.Mock
+    ).mockImplementation(async (playerId: string) => {
+      if (playerId === missingPlayerId) return [null, [missingPlayerError]];
+
+      return [{ _id: playerId } as any, null];
+    });
+
+    const result = await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId],
+        team2: [missingPlayerId],
+      },
+      team1PlayerId,
+    );
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_FOUND,
+      message: 'One or more players in team 2 do not exist',
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
+  });
+
   it('Should generate a matchId for a casual battle registered without matchId', async () => {
     const team1PlayerId = new Types.ObjectId().toHexString();
     const team2PlayerId = new Types.ObjectId().toHexString();

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -92,10 +92,121 @@ describe('GameDataService battle lifecycle test suite', () => {
       team1PlayerId,
     );
 
-    expect(battle._id.toString()).toBe(matchId);
-    expect(battle.receivedResults).toHaveLength(1);
-    expect(battle.receivedResults[0].playerId.toString()).toBe(team1PlayerId);
-    expect(battle.status).toBe(BattleStatus.OPEN);
+    expect(battle).not.toBeInstanceOf(ServiceError);
+    const battleDocument = battle as Exclude<typeof battle, ServiceError>;
+    expect(battleDocument._id.toString()).toBe(matchId);
+    expect(battleDocument.receivedResults).toHaveLength(1);
+    expect(battleDocument.receivedResults[0].playerId.toString()).toBe(
+      team1PlayerId,
+    );
+    expect(battleDocument.status).toBe(BattleStatus.OPEN);
+  });
+
+  it('Should reject battle result from a player outside the battle teams', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    const outsiderPlayerId = new Types.ObjectId().toHexString();
+    await gameDataModel.create({
+      _id: matchId,
+      gameType: GameType.CASUAL,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      status: BattleStatus.OPEN,
+      receivedResults: [],
+    });
+
+    const result = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      outsiderPlayerId,
+    );
+    const battleInDb = await gameDataModel.findById(matchId);
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_AUTHORIZED,
+      field: 'playerId',
+      value: outsiderPlayerId,
+      message: 'Only battle participants can submit battle results.',
+    });
+    expect(battleInDb?.receivedResults).toHaveLength(0);
+  });
+
+  it('Should reject duplicate battle result from the same player', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    await gameDataModel.create({
+      _id: matchId,
+      gameType: GameType.CASUAL,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      status: BattleStatus.OPEN,
+      receivedResults: [
+        {
+          playerId: team1PlayerId,
+          winnerTeam: 1,
+          duration: 120,
+        },
+      ],
+    });
+
+    const result = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 110,
+        result: 2,
+      } as any,
+      team1PlayerId,
+    );
+    const battleInDb = await gameDataModel.findById(matchId);
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_ALLOWED,
+      field: 'playerId',
+      value: team1PlayerId,
+      message: 'Player has already submitted a result for this battle.',
+    });
+    expect(battleInDb?.receivedResults).toHaveLength(1);
+  });
+
+  it('Should reject battle result for a completed battle', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+    await gameDataModel.create({
+      _id: matchId,
+      gameType: GameType.CASUAL,
+      team1: [team1PlayerId],
+      team2: [team2PlayerId],
+      status: BattleStatus.COMPLETED,
+      finalWinner: 1,
+      receivedResults: [],
+    });
+
+    const result = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      team1PlayerId,
+    );
+    const battleInDb = await gameDataModel.findById(matchId);
+
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.NOT_ALLOWED,
+      field: 'status',
+      value: BattleStatus.COMPLETED,
+      message: 'Completed battle cannot receive new results.',
+    });
+    expect(battleInDb?.receivedResults).toHaveLength(0);
   });
 
   it('Should resolve a conflicting battle by document _id', async () => {

--- a/src/__tests__/gameData/modules/gameDataCommon.ts
+++ b/src/__tests__/gameData/modules/gameDataCommon.ts
@@ -8,6 +8,7 @@ import { GameEventsHandlerModule } from '../../../gameEventsHandler/gameEventsHa
 import { Game, GameSchema } from '../../../gameData/game.schema';
 import { GameDataService } from '../../../gameData/gameData.service';
 import { EventEmitterCommonModule } from '../../../common/service/EventEmitterService/EventEmitterCommon.module';
+import { MatchmakingService } from '../../../matchmaking/matchmaking.service';
 
 export default class GameDataCommonModule {
   private constructor() {}
@@ -27,7 +28,15 @@ export default class GameDataCommonModule {
           GameEventsHandlerModule,
           EventEmitterCommonModule,
         ],
-        providers: [GameDataService],
+        providers: [
+          GameDataService,
+          {
+            provide: MatchmakingService,
+            useValue: {
+              validateBattleStart: jest.fn(async () => null),
+            },
+          },
+        ],
       }).compile();
 
     return GameDataCommonModule.module;

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -143,6 +143,27 @@ const getStoredMatches = (redis: InMemoryRedisService) =>
     .filter(([key]) => key.startsWith('matchmaking:match:'))
     .map(([, value]) => JSON.parse(value) as ActiveMatch);
 
+const createActiveBattleStartMatch = (
+  overrides: Partial<ActiveMatch> = {},
+): ActiveMatch => ({
+  id: 'match-battle-start',
+  matchType: MatchType.RANDOM,
+  status: MatchStatus.ACTIVE,
+  teamSize: 1,
+  teams: [
+    {
+      side: TeamSide.A,
+      participants: [{ playerId: 'player-1', isBot: false }],
+    },
+    {
+      side: TeamSide.B,
+      participants: [{ playerId: 'player-2', isBot: false }],
+    },
+  ],
+  startedAt: '2026-07-06T08:00:00.000Z',
+  ...overrides,
+});
+
 describe('MatchmakingService flow', () => {
   it('creates an active RANDOM match from two ready invites and notifies real players', async () => {
     const { redis, notifier, service } = createService();
@@ -267,6 +288,109 @@ describe('MatchmakingService flow', () => {
       reason: SEReason.REQUIRED,
       field: 'roomId',
       message: 'CUSTOM invite joins require roomId.',
+    });
+  });
+
+  it('allows battle start validation for an active match with matching teams', async () => {
+    const { redis, service } = createService();
+    const match = createActiveBattleStartMatch();
+    await redis.set(`matchmaking:match:${match.id}`, JSON.stringify(match));
+
+    const errors = await service.validateBattleStart(
+      match.id,
+      'player-1',
+      ['player-1'],
+      ['player-2'],
+    );
+
+    expect(errors).toBeNull();
+  });
+
+  it('returns NOT_FOUND error when validating battle start for a missing match', async () => {
+    const { service } = createService();
+
+    const errors = await service.validateBattleStart(
+      'missing-match',
+      'player-1',
+      ['player-1'],
+      ['player-2'],
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      reason: SEReason.NOT_FOUND,
+      field: 'matchId',
+      value: 'missing-match',
+      message: 'Matchmaking match not found.',
+    });
+  });
+
+  it('rejects battle start validation for a finished match', async () => {
+    const { redis, service } = createService();
+    const match = createActiveBattleStartMatch({
+      id: 'finished-match',
+      status: MatchStatus.FINISHED,
+    });
+    await redis.set(`matchmaking:match:${match.id}`, JSON.stringify(match));
+
+    const errors = await service.validateBattleStart(
+      match.id,
+      'player-1',
+      ['player-1'],
+      ['player-2'],
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      reason: SEReason.NOT_ALLOWED,
+      field: 'matchId',
+      value: match.id,
+      message: 'Only active matchmaking matches can start battles.',
+    });
+  });
+
+  it('rejects battle start validation from a non-participant requester', async () => {
+    const { redis, service } = createService();
+    const match = createActiveBattleStartMatch({
+      id: 'outsider-match',
+    });
+    await redis.set(`matchmaking:match:${match.id}`, JSON.stringify(match));
+
+    const errors = await service.validateBattleStart(
+      match.id,
+      'player-3',
+      ['player-1'],
+      ['player-2'],
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      reason: SEReason.NOT_AUTHORIZED,
+      field: 'playerId',
+      value: 'player-3',
+      message: 'Only match participants can start a battle for the match.',
+    });
+  });
+
+  it('rejects battle start validation when request teams differ from match teams', async () => {
+    const { redis, service } = createService();
+    const match = createActiveBattleStartMatch({
+      id: 'team-mismatch-match',
+    });
+    await redis.set(`matchmaking:match:${match.id}`, JSON.stringify(match));
+
+    const errors = await service.validateBattleStart(
+      match.id,
+      'player-1',
+      ['player-2'],
+      ['player-1'],
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      reason: SEReason.VALIDATION,
+      field: 'teams',
+      message: 'Battle teams must match the active matchmaking match teams.',
     });
   });
 

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -85,8 +85,8 @@ export class GameDataController {
   @Post('battle/start')
   async startBattle(
     @LoggedUser() user: User, // require logged-in user
-    @Body() startBattleDto: StartBattleDto) {
-    
+    @Body() startBattleDto: StartBattleDto,
+  ) {
     // is the user is logged-in
     if (!user) {
       return new APIError({
@@ -94,26 +94,32 @@ export class GameDataController {
         message: 'User must be logged in to start a battle',
       });
     }
-    
+
     // get the player_id of the user
     const playerId = user.player_id;
-    
+
     // Check if the user is in both teams
-    if (startBattleDto.team1.includes(playerId) && startBattleDto.team2.includes(playerId)) {
+    if (
+      startBattleDto.team1.includes(playerId) &&
+      startBattleDto.team2.includes(playerId)
+    ) {
       return new APIError({
         reason: APIErrorReason.NOT_ALLOWED,
         message: 'User cannot be in both teams',
       });
     }
-    
+
     // are either of the teams empty?
-    if (startBattleDto.team1.length === 0 || startBattleDto.team2.length === 0) {
+    if (
+      startBattleDto.team1.length === 0 ||
+      startBattleDto.team2.length === 0
+    ) {
       return new APIError({
         reason: APIErrorReason.BAD_REQUEST,
         message: 'Both teams must have at least one player',
       });
     }
-    
+
     return this.service.registerBattle(startBattleDto);
   }
 

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -80,10 +80,40 @@ export class GameDataController {
     success: {
       status: 201,
     },
-    errors: [400, 401],
+    errors: [400, 401, 403],
   })
   @Post('battle/start')
-  async startBattle(@Body() startBattleDto: StartBattleDto) {
+  async startBattle(
+    @LoggedUser() user: User, // require logged-in user
+    @Body() startBattleDto: StartBattleDto) {
+    
+    // is the user is logged-in
+    if (!user) {
+      return new APIError({
+        reason: APIErrorReason.NOT_AUTHENTICATED,
+        message: 'User must be logged in to start a battle',
+      });
+    }
+    
+    // get the player_id of the user
+    const playerId = user.player_id;
+    
+    // Check if the user is in both teams
+    if (startBattleDto.team1.includes(playerId) && startBattleDto.team2.includes(playerId)) {
+      return new APIError({
+        reason: APIErrorReason.NOT_ALLOWED,
+        message: 'User cannot be in both teams',
+      });
+    }
+    
+    // are either of the teams empty?
+    if (startBattleDto.team1.length === 0 || startBattleDto.team2.length === 0) {
+      return new APIError({
+        reason: APIErrorReason.BAD_REQUEST,
+        message: 'Both teams must have at least one player',
+      });
+    }
+    
     return this.service.registerBattle(startBattleDto);
   }
 

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -83,6 +83,7 @@ export class GameDataController {
     errors: [400, 401, 403],
   })
   @Post('battle/start')
+  @UniformResponse()
   async startBattle(
     @LoggedUser() user: User, // require logged-in user
     @Body() startBattleDto: StartBattleDto,

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -120,7 +120,7 @@ export class GameDataController {
       });
     }
 
-    return this.service.registerBattle(startBattleDto);
+    return this.service.registerBattle(startBattleDto, playerId);
   }
 
   /**

--- a/src/gameData/gameData.module.ts
+++ b/src/gameData/gameData.module.ts
@@ -8,6 +8,7 @@ import { ClanModule } from '../clan/clan.module';
 import { ClanInventoryModule } from '../clanInventory/clanInventory.module';
 import { GameEventsHandlerModule } from '../gameEventsHandler/gameEventsHandler.module';
 import { EventEmitterCommonModule } from '../common/service/EventEmitterService/EventEmitterCommon.module';
+import { MatchmakingModule } from '../matchmaking/matchmaking.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { EventEmitterCommonModule } from '../common/service/EventEmitterService/
     ClanInventoryModule,
     GameEventsHandlerModule,
     EventEmitterCommonModule,
+    MatchmakingModule,
   ],
   providers: [GameDataService],
   controllers: [GameDataController],

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Game } from './game.schema';
 import { Model, Types } from 'mongoose';
@@ -25,6 +25,7 @@ import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { Environment } from '../common/enum/environment.enum';
 import { GameType } from './enum/gameType.enum';
+import { MatchmakingService } from '../matchmaking/matchmaking.service';
 
 @Injectable()
 export class GameDataService {
@@ -36,6 +37,8 @@ export class GameDataService {
     private readonly gameEventsBroker: GameEventsHandler,
     private readonly jwtService: JwtService,
     private readonly emitterService: EventEmitterService,
+    @Optional()
+    private readonly matchmakingService?: MatchmakingService,
   ) {
     this.basicService = new BasicService(model);
     this.refsInModel = [ModelName.STOCK];
@@ -421,6 +424,24 @@ export class GameDataService {
         field: 'matchId',
         message: 'Matchmaking battles require matchId.',
       });
+    }
+
+    if (dto.gameType === GameType.MATCHMAKING) {
+      if (!this.matchmakingService) {
+        return new ServiceError({
+          reason: SEReason.MISCONFIGURED,
+          message: 'Matchmaking service is not available.',
+        });
+      }
+
+      const matchmakingErrors =
+        await this.matchmakingService.validateBattleStart(
+          dto.matchId,
+          requesterPlayerId,
+          dto.team1,
+          dto.team2,
+        );
+      if (matchmakingErrors) return matchmakingErrors[0];
     }
 
     // create a new battle record in the database

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -463,6 +463,39 @@ export class GameDataService {
     const battle = await this.model.findById(dto.matchId);
     if (!battle) throw new Error('Match not found');
 
+    const isBattleParticipant =
+      battle.team1.some((id) => id.toString() === playerId) ||
+      battle.team2.some((id) => id.toString() === playerId);
+    if (!isBattleParticipant) {
+      return new ServiceError({
+        reason: SEReason.NOT_AUTHORIZED,
+        field: 'playerId',
+        value: playerId,
+        message: 'Only battle participants can submit battle results.',
+      });
+    }
+
+    if (battle.status === BattleStatus.COMPLETED) {
+      return new ServiceError({
+        reason: SEReason.NOT_ALLOWED,
+        field: 'status',
+        value: battle.status,
+        message: 'Completed battle cannot receive new results.',
+      });
+    }
+
+    const hasSubmittedResult = battle.receivedResults.some(
+      (result) => result.playerId.toString() === playerId,
+    );
+    if (hasSubmittedResult) {
+      return new ServiceError({
+        reason: SEReason.NOT_ALLOWED,
+        field: 'playerId',
+        value: playerId,
+        message: 'Player has already submitted a result for this battle.',
+      });
+    }
+
     battle.receivedResults.push({
       playerId,
       winnerTeam: dto.result,

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -346,16 +346,21 @@ export class GameDataService {
    * @param dto - The data required to start a battle, including the matchId and teams.
    * @returns A promise resolving to the created Battle document or service error
    */
-  async registerBattle(dto: StartBattleDto, requesterPlayerId: string): Promise<GameDocument | ServiceError> {
-    
+  async registerBattle(
+    dto: StartBattleDto,
+    requesterPlayerId: string,
+  ): Promise<GameDocument | ServiceError> {
     // is requester PlayerId in team1 or in team2?
-    if (!dto.team1.includes(requesterPlayerId) && !dto.team2.includes(requesterPlayerId)) {
+    if (
+      !dto.team1.includes(requesterPlayerId) &&
+      !dto.team2.includes(requesterPlayerId)
+    ) {
       return new ServiceError({
         reason: SEReason.NOT_AUTHORIZED,
         message: 'Requester player must be in one of the teams',
       });
     }
-    
+
     // are either of the teams empty?
     if (dto.team1.length === 0 || dto.team2.length === 0) {
       return new ServiceError({

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -404,7 +404,7 @@ export class GameDataService {
 
     // create a new battle record in the database
     const matchId = dto.matchId || new Types.ObjectId().toHexString();
-    
+
     // gameType is passed in the dto
     // gameType is one of these matchmaking | casual | custom
     const newBattle = new this.model({

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -24,6 +24,7 @@ import { SEReason } from '../common/service/basicService/SEReason';
 import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { Environment } from '../common/enum/environment.enum';
+import { GameType } from './enum/gameType.enum';
 
 @Injectable()
 export class GameDataService {
@@ -411,6 +412,14 @@ export class GameDataService {
       return new ServiceError({
         reason: SEReason.MISCONFIGURED,
         message: 'A player cannot be in both teams',
+      });
+    }
+
+    if (dto.gameType === GameType.MATCHMAKING && !dto.matchId) {
+      return new ServiceError({
+        reason: SEReason.REQUIRED,
+        field: 'matchId',
+        message: 'Matchmaking battles require matchId.',
       });
     }
 

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -404,9 +404,11 @@ export class GameDataService {
 
     // create a new battle record in the database
     const matchId = dto.matchId || new Types.ObjectId().toHexString();
+    
+    // gameType is passed in the dto
+    // gameType is one of these matchmaking | casual | custom
     const newBattle = new this.model({
       _id: matchId,
-      gameType: 'BATTLE',
       ...dto,
       status: BattleStatus.OPEN,
       receivedResults: [],

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException, Optional } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Game } from './game.schema';
 import { Model, Types } from 'mongoose';
@@ -37,8 +37,7 @@ export class GameDataService {
     private readonly gameEventsBroker: GameEventsHandler,
     private readonly jwtService: JwtService,
     private readonly emitterService: EventEmitterService,
-    @Optional()
-    private readonly matchmakingService?: MatchmakingService,
+    private readonly matchmakingService: MatchmakingService,
   ) {
     this.basicService = new BasicService(model);
     this.refsInModel = [ModelName.STOCK];
@@ -427,13 +426,6 @@ export class GameDataService {
     }
 
     if (dto.gameType === GameType.MATCHMAKING) {
-      if (!this.matchmakingService) {
-        return new ServiceError({
-          reason: SEReason.MISCONFIGURED,
-          message: 'Matchmaking service is not available.',
-        });
-      }
-
       const matchmakingErrors =
         await this.matchmakingService.validateBattleStart(
           dto.matchId,
@@ -447,11 +439,11 @@ export class GameDataService {
     // create a new battle record in the database
     const matchId = dto.matchId || new Types.ObjectId().toHexString();
 
-    // gameType is passed in the dto
-    // gameType is one of these matchmaking | casual | custom
     const newBattle = new this.model({
       _id: matchId,
-      ...dto,
+      gameType: dto.gameType,
+      team1: dto.team1,
+      team2: dto.team2,
       status: BattleStatus.OPEN,
       receivedResults: [],
     });

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -343,10 +343,66 @@ export class GameDataService {
   /**
    * Initializes a new battle record in the database.
    * Sets the initial status to OPEN.
-   * * @param dto - The data required to start a battle, including the matchId and teams.
-   * @returns A promise resolving to the created Battle document.
+   * @param dto - The data required to start a battle, including the matchId and teams.
+   * @returns A promise resolving to the created Battle document or service error
    */
-  async registerBattle(dto: StartBattleDto): Promise<GameDocument> {
+  async registerBattle(
+    dto: StartBattleDto,
+  ): Promise<GameDocument | ServiceError> {
+    // are either of the teams empty?
+    if (dto.team1.length === 0 || dto.team2.length === 0) {
+      return new ServiceError({
+        reason: SEReason.MISCONFIGURED,
+        message: 'Both teams must have at least one player',
+      });
+    }
+
+    // check, that the players in team1 exist in the database
+    const team1Results = await Promise.all(
+      dto.team1.map((playerId) => this.playerService.getPlayerById(playerId)),
+    );
+
+    const team1Errors = team1Results
+      .map(([, errors]) => errors)
+      .filter((errors): errors is ServiceError[] => Array.isArray(errors))
+      .flat();
+
+    if (team1Errors.length > 0) {
+      return new ServiceError({
+        reason: SEReason.NOT_FOUND,
+        message: 'One or more players in team 1 do not exist',
+      });
+    }
+
+    // check, that the players in team2 exist in the database
+    const team2Results = await Promise.all(
+      dto.team2.map((playerId) => this.playerService.getPlayerById(playerId)),
+    );
+
+    const team2Errors = team2Results
+      .map(([, errors]) => errors)
+      .filter((errors): errors is ServiceError[] => Array.isArray(errors))
+      .flat();
+
+    if (team2Errors.length > 0) {
+      return new ServiceError({
+        reason: SEReason.NOT_FOUND,
+        message: 'One or more players in team 2 do not exist',
+      });
+    }
+
+    // check is any player in both teams
+    const team1Set = new Set(dto.team1);
+    const team2Set = new Set(dto.team2);
+    const intersection = new Set([...team1Set].filter((x) => team2Set.has(x)));
+    if (intersection.size > 0) {
+      return new ServiceError({
+        reason: SEReason.MISCONFIGURED,
+        message: 'A player cannot be in both teams',
+      });
+    }
+
+    // create a new battle record in the database
     const matchId = dto.matchId || new Types.ObjectId().toHexString();
     const newBattle = new this.model({
       _id: matchId,

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -346,9 +346,16 @@ export class GameDataService {
    * @param dto - The data required to start a battle, including the matchId and teams.
    * @returns A promise resolving to the created Battle document or service error
    */
-  async registerBattle(
-    dto: StartBattleDto,
-  ): Promise<GameDocument | ServiceError> {
+  async registerBattle(dto: StartBattleDto, requesterPlayerId: string): Promise<GameDocument | ServiceError> {
+    
+    // is requester PlayerId in team1 or in team2?
+    if (!dto.team1.includes(requesterPlayerId) && !dto.team2.includes(requesterPlayerId)) {
+      return new ServiceError({
+        reason: SEReason.NOT_AUTHORIZED,
+        message: 'Requester player must be in one of the teams',
+      });
+    }
+    
     // are either of the teams empty?
     if (dto.team1.length === 0 || dto.team2.length === 0) {
       return new ServiceError({

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -349,6 +349,60 @@ export class MatchmakingService {
   }
 
   /**
+   * Validates that a battle/start request belongs to an active matchmaking match.
+   */
+  async validateBattleStart(
+    matchId: string,
+    requesterPlayerId: string,
+    team1: string[],
+    team2: string[],
+  ) {
+    const [match, matchErrors] = await this.readMatch(matchId);
+    if (matchErrors) return matchErrors;
+
+    if (match.status !== MatchStatus.ACTIVE) {
+      return [
+        new ServiceError({
+          reason: SEReason.NOT_ALLOWED,
+          field: 'matchId',
+          value: matchId,
+          message: 'Only active matchmaking matches can start battles.',
+        }),
+      ];
+    }
+
+    if (!this.matchHasPlayer(match, requesterPlayerId)) {
+      return [
+        new ServiceError({
+          reason: SEReason.NOT_AUTHORIZED,
+          field: 'playerId',
+          value: requesterPlayerId,
+          message: 'Only match participants can start a battle for the match.',
+        }),
+      ];
+    }
+
+    const [matchTeam1, matchTeam2] = match.teams.map((team) =>
+      this.getTeamPlayerIds(team),
+    );
+    if (
+      !this.haveSameMembers(matchTeam1, team1) ||
+      !this.haveSameMembers(matchTeam2, team2)
+    ) {
+      return [
+        new ServiceError({
+          reason: SEReason.VALIDATION,
+          field: 'teams',
+          message:
+            'Battle teams must match the active matchmaking match teams.',
+        }),
+      ];
+    }
+
+    return null;
+  }
+
+  /**
    * Routes READY invites into their mode-specific next step.
    *
    * RANDOM tries to pair any two ready teams, CLAN searches for another clan and
@@ -793,6 +847,13 @@ export class MatchmakingService {
     return team.participants.flatMap((participant) =>
       this.isBotParticipant(participant) ? [] : [participant.playerId],
     );
+  }
+
+  private haveSameMembers(first: string[], second: string[]) {
+    if (first.length !== second.length) return false;
+
+    const secondMembers = new Set(second);
+    return first.every((value) => secondMembers.has(value));
   }
 
   private matchHasPlayer(match: ActiveMatch, playerId: string) {


### PR DESCRIPTION
### Brief description

Fixes issue #896 

Fixes battle start/result validation so battle documents are created with the correct MongoId-backed match identity, matchmaking battles are tied to active matchmaking matches, and only valid participants can start or submit battle results.

### Change list

- Require MongoId-compatible `matchId` values in battle start/result DTOs when provided.
- Store battle `matchId` as the Game document `_id` and use `_id` for battle result/conflict lookups.
- Require `matchId` for `gameType: matchmaking`; keep server-generated ids for casual/custom battles.
- Validate matchmaking battle starts against active matchmaking matches.
- Prevent battle creation when requester/teams/players are invalid.
- Persist only explicit battle start fields instead of spreading the request DTO.
- Reject battle result submissions from non-participants, duplicate submitters, or completed battles.
- Add service and DTO tests for the battle lifecycle validation paths.