### PR TITLE
912 feature request delete chat messages after 3 days

### DIFF
--- a/src/chat/schema/chatMessage.schema.ts
+++ b/src/chat/schema/chatMessage.schema.ts
@@ -7,6 +7,8 @@ import { Reaction } from './reaction.schema';
 import { Feeling } from '../enum/feeling.enum';
 import { ObjectId } from 'mongodb';
 
+const CHATMESSAGE_TTL = 60 * 60 * 24 * 3;
+
 export type ChatMessageDocument = HydratedDocument<ChatMessage>;
 
 @Schema({
@@ -53,4 +55,7 @@ ChatMessageSchema.virtual('sender', {
   justOne: true,
 });
 
-ChatMessageSchema.index({ createdAt: 1 }, { expireAfterSeconds: 259200 });
+ChatMessageSchema.index(
+  { createdAt: 1 },
+  { expireAfterSeconds: CHATMESSAGE_TTL },
+);

--- a/src/chat/schema/chatMessage.schema.ts
+++ b/src/chat/schema/chatMessage.schema.ts
@@ -52,3 +52,5 @@ ChatMessageSchema.virtual('sender', {
   foreignField: '_id',
   justOne: true,
 });
+
+ChatMessageSchema.index({ createdAt: 1 }, { expireAfterSeconds: 259200 });


### PR DESCRIPTION
### Brief description
This PR makes new chat messages get deleted from the database automatically after 3 days.
We discussed that existing old documents in the chatMessages table in the production database could be removed with a script which in this case could be just running a query  in the production db like `db.chatMessages.deletemany({})` or something like this. This purge should be done after the next dev to main branch merge assumed this PR is merged into dev.

### Change list

- Updated `src/chat/schema/chatMessage.schema.ts`
  - Added TTL index for `createdAt` field (expire after 3 days)
