### PR TITLE
905 bug put room does not reject cross clan room updates

### DIFF
--- a/src/__tests__/authorization/rule/roomRules.test.ts
+++ b/src/__tests__/authorization/rule/roomRules.test.ts
@@ -1,0 +1,185 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { roomRules } from '../../../authorization/rule/roomRules';
+import { Action } from '../../../authorization/enum/action.enum';
+import { RequestHelperService } from '../../../requestHelper/requestHelper.service';
+import { RoomDto } from '../../../clanInventory/room/dto/room.dto';
+import { UpdateRoomDto } from '../../../clanInventory/room/dto/updateRoom.dto';
+import { SoulHomeDto } from '../../../clanInventory/soulhome/dto/soulhome.dto';
+import { Player } from '../../../player/schemas/player.schema';
+import AuthBuilderFactory from '../../auth/data/authBuilderFactory';
+
+describe('roomRules() test suite', () => {
+  const userBuilder = AuthBuilderFactory.getBuilder('User');
+
+  const roomId = 'room-id';
+  const soulHomeId = 'soulhome-id';
+  const playerId = 'player-id';
+  const clanId = 'clan-a-id';
+  const otherClanId = 'clan-b-id';
+
+  const user = userBuilder.setPlayerId(playerId).build();
+
+  let requestHelperService: RequestHelperService;
+  let getModelInstanceById: jest.Mock;
+
+  beforeEach(() => {
+    getModelInstanceById = jest.fn();
+    requestHelperService = {
+      getModelInstanceById,
+    } as any;
+  });
+
+  it('Should allow read actions without checking room ownership', async () => {
+    const ability = await roomRules(
+      user,
+      RoomDto,
+      Action.read,
+      null,
+      requestHelperService,
+    );
+
+    expect(ability.can(Action.read_request, RoomDto)).toBe(true);
+    expect(ability.can(Action.read_response, RoomDto)).toBe(true);
+    expect(getModelInstanceById).not.toHaveBeenCalled();
+  });
+
+  it('Should allow create actions without checking room ownership', async () => {
+    const ability = await roomRules(
+      user,
+      UpdateRoomDto,
+      Action.create,
+      null,
+      requestHelperService,
+    );
+
+    expect(ability.can(Action.create_request, UpdateRoomDto)).toBe(true);
+    expect(getModelInstanceById).not.toHaveBeenCalled();
+  });
+
+  it('Should throw NotFoundException if the room does not exist', async () => {
+    getModelInstanceById.mockResolvedValueOnce(null);
+
+    await expect(
+      roomRules(
+        user,
+        UpdateRoomDto,
+        Action.update,
+        { _id: roomId } as any,
+        requestHelperService,
+      ),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it("Should throw ForbiddenException if the room's SoulHome does not exist", async () => {
+    getModelInstanceById
+      .mockResolvedValueOnce({
+        _id: roomId,
+        soulHome_id: soulHomeId,
+      } as Partial<RoomDto>)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ clan_id: clanId } as Partial<Player>);
+
+    await expect(
+      roomRules(
+        user,
+        UpdateRoomDto,
+        Action.update,
+        { _id: roomId } as any,
+        requestHelperService,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('Should throw ForbiddenException if the logged-in player does not belong to any Clan', async () => {
+    getModelInstanceById
+      .mockResolvedValueOnce({
+        _id: roomId,
+        soulHome_id: soulHomeId,
+      } as Partial<RoomDto>)
+      .mockResolvedValueOnce({
+        _id: soulHomeId,
+        clan_id: clanId,
+      } as Partial<SoulHomeDto>)
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      roomRules(
+        user,
+        UpdateRoomDto,
+        Action.update,
+        { _id: roomId } as any,
+        requestHelperService,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it("Should throw ForbiddenException if the room's SoulHome belongs to a different Clan than the logged-in player (cross-clan update)", async () => {
+    getModelInstanceById
+      .mockResolvedValueOnce({
+        _id: roomId,
+        soulHome_id: soulHomeId,
+      } as Partial<RoomDto>)
+      .mockResolvedValueOnce({
+        _id: soulHomeId,
+        clan_id: otherClanId,
+      } as Partial<SoulHomeDto>)
+      .mockResolvedValueOnce({ clan_id: clanId } as Partial<Player>);
+
+    await expect(
+      roomRules(
+        user,
+        UpdateRoomDto,
+        Action.update,
+        { _id: roomId } as any,
+        requestHelperService,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it("Should throw ForbiddenException on delete if the room's SoulHome belongs to a different Clan than the logged-in player", async () => {
+    getModelInstanceById
+      .mockResolvedValueOnce({
+        _id: roomId,
+        soulHome_id: soulHomeId,
+      } as Partial<RoomDto>)
+      .mockResolvedValueOnce({
+        _id: soulHomeId,
+        clan_id: otherClanId,
+      } as Partial<SoulHomeDto>)
+      .mockResolvedValueOnce({ clan_id: clanId } as Partial<Player>);
+
+    await expect(
+      roomRules(
+        user,
+        RoomDto,
+        Action.delete,
+        { _id: roomId } as any,
+        requestHelperService,
+      ),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it("Should allow update and delete if the room's SoulHome belongs to the logged-in player's Clan", async () => {
+    getModelInstanceById
+      .mockResolvedValueOnce({
+        _id: roomId,
+        soulHome_id: soulHomeId,
+      } as Partial<RoomDto>)
+      .mockResolvedValueOnce({
+        _id: soulHomeId,
+        clan_id: clanId,
+      } as Partial<SoulHomeDto>)
+      .mockResolvedValueOnce({ clan_id: clanId } as Partial<Player>);
+
+    const ability = await roomRules(
+      user,
+      UpdateRoomDto,
+      Action.update,
+      { _id: roomId } as any,
+      requestHelperService,
+    );
+
+    expect(ability.can(Action.update_request, UpdateRoomDto)).toBe(true);
+    expect(ability.can(Action.delete_request, UpdateRoomDto)).toBe(true);
+  });
+});

--- a/src/__tests__/authorization/rule/roomRules.test.ts
+++ b/src/__tests__/authorization/rule/roomRules.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
-import { roomRules } from '../../../authorization/rule/roomRules';
 import { Action } from '../../../authorization/enum/action.enum';
+import { roomRules } from '../../../authorization/rule/roomRules';
 import { RequestHelperService } from '../../../requestHelper/requestHelper.service';
 import { RoomDto } from '../../../clanInventory/room/dto/room.dto';
 import { UpdateRoomDto } from '../../../clanInventory/room/dto/updateRoom.dto';

--- a/src/__tests__/clanInventory/room/RoomService/updateSoulHomeRooms.test.ts
+++ b/src/__tests__/clanInventory/room/RoomService/updateSoulHomeRooms.test.ts
@@ -81,6 +81,28 @@ describe('Room.updateSoulHomeRooms() test suite', () => {
     expect(room.floor).toEqual(update.floor);
   });
 
+  it('Should update Room values successfully when furniture is omitted from the payload', async () => {
+    const updateWithoutFurniture: UpdateRoomDto = {
+      _id: existingRoom._id,
+      roomColour: 'red',
+      floor: 'stone',
+      wallpaper: 'painted',
+    };
+
+    const [result, error] = await roomService.updateSoulHomeRooms(
+      updateWithoutFurniture,
+    );
+
+    expect(result).toBeTruthy();
+    expect(error).toBeNull();
+
+    const [room, roomErrors] = await roomService.readOneById(existingRoom._id);
+
+    expect(roomErrors).toBeNull();
+    expect(room.roomColour).toEqual(updateWithoutFurniture.roomColour);
+    expect(room.floor).toEqual(updateWithoutFurniture.floor);
+  });
+
   it('Should update Room furniture successfully and update value in Clan', async () => {
     const [item] = await itemService.createOne(existingItem);
 

--- a/src/authorization/rule/roomRules.ts
+++ b/src/authorization/rule/roomRules.ts
@@ -12,6 +12,8 @@ import { NotFoundException } from '@nestjs/common';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { MongooseError } from 'mongoose';
 import { RoomDto } from '../../clanInventory/room/dto/room.dto';
+import { SoulHomeDto } from '../../clanInventory/soulhome/dto/soulhome.dto';
+import { getClan_id } from '../util/getClan_id';
 
 type Subjects = InferSubjects<any>;
 type Ability = MongoAbility<[AllowedAction | Action.manage, Subjects | 'all']>;
@@ -41,8 +43,25 @@ export const roomRules: RulesSetterAsync<Ability, Subjects> = async (
       throw new NotFoundException(
         'Can not check ownership, room with that id not found',
       );
-    // if(room.player_id !== user.player_id)
-    //     throw new NotFoundException("PlayerID does not match owner")
+
+    const soulHome = await requestHelperService.getModelInstanceById(
+      ModelName.SOULHOME,
+      room.soulHome_id,
+      SoulHomeDto,
+    );
+
+    const clan_id = await getClan_id(user, requestHelperService);
+
+    if (
+      !soulHome ||
+      soulHome instanceof MongooseError ||
+      !clan_id ||
+      soulHome.clan_id !== clan_id
+    )
+      // alternatively could return ServiceError with 403 status code
+      throw new NotFoundException(
+        'Room does not belong to the logged-in user Clan',
+      );
 
     can(Action.update_request, subject);
     can(Action.delete_request, subject);

--- a/src/authorization/rule/roomRules.ts
+++ b/src/authorization/rule/roomRules.ts
@@ -14,6 +14,8 @@ import { MongooseError } from 'mongoose';
 import { RoomDto } from '../../clanInventory/room/dto/room.dto';
 import { SoulHomeDto } from '../../clanInventory/soulhome/dto/soulhome.dto';
 import { getClan_id } from '../util/getClan_id';
+import ServiceError from '../../common/service/basicService/ServiceError';
+import { SEReason } from '../../common/service/basicService/SEReason';
 
 type Subjects = InferSubjects<any>;
 type Ability = MongoAbility<[AllowedAction | Action.manage, Subjects | 'all']>;
@@ -58,10 +60,10 @@ export const roomRules: RulesSetterAsync<Ability, Subjects> = async (
       !clan_id ||
       soulHome.clan_id !== clan_id
     )
-      // alternatively could return ServiceError with 403 status code
-      throw new NotFoundException(
-        'Room does not belong to the logged-in user Clan',
-      );
+      throw new ServiceError({
+        reason: SEReason.NOT_AUTHORIZED,
+        message: "Room does not belong to logged-in player's Clan",
+      });
 
     can(Action.update_request, subject);
     can(Action.delete_request, subject);

--- a/src/authorization/rule/roomRules.ts
+++ b/src/authorization/rule/roomRules.ts
@@ -8,7 +8,7 @@ import {
 } from '@casl/ability';
 import { Action } from '../enum/action.enum';
 import { RulesSetterAsync } from '../type/RulesSetter.type';
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { ModelName } from '../../common/enum/modelName.enum';
 import { MongooseError } from 'mongoose';
 import { RoomDto } from '../../clanInventory/room/dto/room.dto';
@@ -58,8 +58,7 @@ export const roomRules: RulesSetterAsync<Ability, Subjects> = async (
       !clan_id ||
       soulHome.clan_id !== clan_id
     )
-      // alternatively could return ServiceError with 403 status code
-      throw new NotFoundException(
+      throw new ForbiddenException(
         'Room does not belong to the logged-in user Clan',
       );
 

--- a/src/authorization/rule/roomRules.ts
+++ b/src/authorization/rule/roomRules.ts
@@ -14,8 +14,6 @@ import { MongooseError } from 'mongoose';
 import { RoomDto } from '../../clanInventory/room/dto/room.dto';
 import { SoulHomeDto } from '../../clanInventory/soulhome/dto/soulhome.dto';
 import { getClan_id } from '../util/getClan_id';
-import ServiceError from '../../common/service/basicService/ServiceError';
-import { SEReason } from '../../common/service/basicService/SEReason';
 
 type Subjects = InferSubjects<any>;
 type Ability = MongoAbility<[AllowedAction | Action.manage, Subjects | 'all']>;
@@ -60,10 +58,10 @@ export const roomRules: RulesSetterAsync<Ability, Subjects> = async (
       !clan_id ||
       soulHome.clan_id !== clan_id
     )
-      throw new ServiceError({
-        reason: SEReason.NOT_AUTHORIZED,
-        message: "Room does not belong to logged-in player's Clan",
-      });
+      // alternatively could return ServiceError with 403 status code
+      throw new NotFoundException(
+        'Room does not belong to the logged-in user Clan',
+      );
 
     can(Action.update_request, subject);
     can(Action.delete_request, subject);

--- a/src/clanInventory/room/room.service.ts
+++ b/src/clanInventory/room/room.service.ts
@@ -261,11 +261,13 @@ export class RoomService {
     const itemBulk = [];
     const roomIds = rooms.map((room) => room._id);
     const itemIds = rooms.flatMap((room) =>
-      room.furniture.map((item) => item._id),
+      (room.furniture ?? []).map((item) => item._id),
     );
 
     for (const room of rooms) {
-      const { _id, furniture, ...roomFields } = room;
+      const { _id, ...roomFields } = room;
+
+      const furniture = room.furniture ?? [];
 
       roomBulk.push({
         updateOne: {


### PR DESCRIPTION
### Brief description

This PR should fix two bugs:

1. Cross clan room updates (PUT /room)
2. Endpoint PUT /room returning internal server error 500 if furniture is not in the payload.

### Change list

- updated `roomRules.ts`
  - throw 403 ForbiddenException if SoulHome.clan_id and logged in user's clan ID do not match
- updated `room.service.ts`
  - check that `furniture` exists otherwise fallback to empty list
- updated `updateSoulHomeRooms.test.ts`
  - add new test that checks Room values is updated successfully if furniture is excluded from the payload
- added new test suite `roomRules.test.ts` 
