### PR TITLE
918 feature request include voting info in the mqtt payload

### DIFF
--- a/src/__tests__/voting/VotingNotifier/newVoting.test.ts
+++ b/src/__tests__/voting/VotingNotifier/newVoting.test.ts
@@ -39,7 +39,9 @@ describe('VotingNotifier.newVoting() test suite', () => {
         voting_id: votingDto._id.toString(),
         type: votingDto.type,
         entity: fleaMarketItem,
+        startedAt: votingDto.startedAt,
         organizer: playerDto,
+        endedAt: votingDto.endsOn,
       },
     });
 

--- a/src/__tests__/voting/VotingNotifier/votingCompleted.test.ts
+++ b/src/__tests__/voting/VotingNotifier/votingCompleted.test.ts
@@ -8,6 +8,7 @@ import { NotificationGroup } from '../../../common/service/notificator/enum/Noti
 import { MqttNotificationType } from '../../../common/service/notificator/enum/MqttNotificationType.enum';
 import FleaMarketBuilderFactory from '../../fleaMarket/data/fleaMarketBuilderFactory';
 import createMockMqttClient from '../../common/service/notificator/mocks/createMockMqttClient';
+import { VoteChoice } from '../../../voting/enum/choiceType.enum';
 
 jest.mock('mqtt', () => ({
   connect: jest.fn(),
@@ -25,7 +26,17 @@ describe('VotingNotifier.votingCompleted() test suite', () => {
   });
 
   it('should send a notification for a completed voting if input is valid', async () => {
-    const votingDto = votingBuilder.build();
+    const votes = [
+      {
+        player_id: '6630aa9994cd5ef001a1b1c2',
+        choice: VoteChoice.YES,
+      },
+      {
+        player_id: '6630aa9994cd5ef001a1b1c3',
+        choice: VoteChoice.NO,
+      },
+    ];
+    const votingDto = votingBuilder.setVotes(votes).build();
     const fleaMarketItem = fleaMarketBuilder.build();
     const expectedTopic = `/${NotificationGroup.CLAN}/${votingDto.organizer.clan_id}/${NotificationResource.VOTING}/${votingDto.type}/${NotificationStatus.END}`;
     const expectedPayload = JSON.stringify({
@@ -39,6 +50,7 @@ describe('VotingNotifier.votingCompleted() test suite', () => {
         entity: fleaMarketItem,
         startedAt: votingDto.startedAt,
         endedAt: votingDto.endedAt,
+        votes: votingDto.votes,
       },
     });
 

--- a/src/__tests__/voting/VotingNotifier/votingCompleted.test.ts
+++ b/src/__tests__/voting/VotingNotifier/votingCompleted.test.ts
@@ -37,6 +37,8 @@ describe('VotingNotifier.votingCompleted() test suite', () => {
         voting_id: votingDto._id.toString(),
         type: votingDto.type,
         entity: fleaMarketItem,
+        startedAt: votingDto.startedAt,
+        endedAt: votingDto.endedAt,
       },
     });
 

--- a/src/__tests__/voting/VotingNotifier/votingUpdated.test.ts
+++ b/src/__tests__/voting/VotingNotifier/votingUpdated.test.ts
@@ -10,6 +10,7 @@ import { MqttNotificationType } from '../../../common/service/notificator/enum/M
 import FleaMarketBuilderFactory from '../../fleaMarket/data/fleaMarketBuilderFactory';
 import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
 import createMockMqttClient from '../../common/service/notificator/mocks/createMockMqttClient';
+import { VoteChoice } from '../../../voting/enum/choiceType.enum';
 
 jest.mock('mqtt', () => ({
   connect: jest.fn(),
@@ -27,9 +28,11 @@ describe('VotingNotifier.votingUpdated() test suite', () => {
   });
 
   it('Should send a notification for a voting update if input is valid', async () => {
-    const votingDto = votingBuilder.build();
+    const playerId = '6630aa9994cd5ef001a1b1c2';
+    const vote = { player_id: playerId, choice: VoteChoice.YES };
+    const votingDto = votingBuilder.setVotes([vote]).build();
     const fleaMarketItem = fleaMarketBuilder.build();
-    const playerDto = playerBuilder.build();
+    const playerDto = playerBuilder.setId(playerId).build();
     const expectedTopic = `/${NotificationGroup.CLAN}/${votingDto.organizer.clan_id}/${NotificationResource.VOTING}/${votingDto.type}/${NotificationStatus.UPDATE}`;
     const expectedPayload = JSON.stringify({
       topic: 'voting',
@@ -42,6 +45,7 @@ describe('VotingNotifier.votingUpdated() test suite', () => {
         entity: fleaMarketItem,
         startedAt: votingDto.startedAt,
         voter: playerDto as PlayerDto,
+        choice: VoteChoice.YES,
       },
     });
 

--- a/src/__tests__/voting/VotingNotifier/votingUpdated.test.ts
+++ b/src/__tests__/voting/VotingNotifier/votingUpdated.test.ts
@@ -40,6 +40,7 @@ describe('VotingNotifier.votingUpdated() test suite', () => {
         voting_id: votingDto._id.toString(),
         type: votingDto.type,
         entity: fleaMarketItem,
+        startedAt: votingDto.startedAt,
         voter: playerDto as PlayerDto,
       },
     });

--- a/src/__tests__/voting/data/voting/VotingDtoBuilder.ts
+++ b/src/__tests__/voting/data/voting/VotingDtoBuilder.ts
@@ -19,7 +19,7 @@ export default class VotingDtoBuilder implements IDataBuilder<VotingDto> {
     endsOn: new Date(Date.now() + 1200000),
     type: VotingType.FLEA_MARKET_BUY_ITEM,
     player_ids: [new ObjectId().toString()],
-    minPercentage: 50,
+    minPercentage: 51,
     votes: [],
     fleaMarketItem_id: new ObjectId().toString(),
     shopItemName: undefined,

--- a/src/__tests__/voting/data/voting/createVotingDtoBuilder.ts
+++ b/src/__tests__/voting/data/voting/createVotingDtoBuilder.ts
@@ -15,7 +15,7 @@ export default class CreateVotingDtoBuilder
     },
     endsOn: new Date(Date.now() + 3600000),
     type: VotingType.FLEA_MARKET_BUY_ITEM,
-    minPercentage: 50,
+    minPercentage: 51,
     fleaMarketItem_id: new ObjectId().toString(),
     votes: [],
   };

--- a/src/voting/type/notifierPayload.type.ts
+++ b/src/voting/type/notifierPayload.type.ts
@@ -15,6 +15,7 @@ export type VotingPayload<TEntity = unknown> = {
   voter?: PlayerDto;
   organizer?: PlayerDto;
   votes?: Vote[];
+  choice?: string; // choice of the voter
   startedAt?: Date;
   endedAt?: Date;
 };

--- a/src/voting/type/notifierPayload.type.ts
+++ b/src/voting/type/notifierPayload.type.ts
@@ -15,5 +15,6 @@ export type VotingPayload<TEntity = unknown> = {
   voter?: PlayerDto;
   organizer?: PlayerDto;
   votes?: Vote[];
+  startedAt?: Date;
   endedAt?: Date;
 };

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -40,13 +40,13 @@ export default class VotingNotifier {
     };
 
     if (status === NotificationStatus.NEW) {
-        payload.organizer = player;
-        payload.endedAt = voting.endsOn;
+      payload.organizer = player;
+      payload.endedAt = voting.endsOn;
     }
     if (status === NotificationStatus.UPDATE) payload.voter = player;
 
     if (status === NotificationStatus.END) payload.endedAt = voting.endedAt;
-    
+
     return payload;
   }
 

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -45,7 +45,7 @@ export default class VotingNotifier {
     }
     if (status === NotificationStatus.UPDATE) {
       payload.voter = player;
-      const votes = voting.votes;
+      const votes = voting.votes ?? [];
 
       // find vote of the voter
       const voterVote = votes.find(

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -60,7 +60,7 @@ export default class VotingNotifier {
       payload.endedAt = voting.endedAt;
       payload.votes = voting.votes;
     }
-    
+
     return payload;
   }
 

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -46,9 +46,11 @@ export default class VotingNotifier {
     if (status === NotificationStatus.UPDATE) {
       payload.voter = player;
       const votes = voting.votes;
-      
+
       // find vote of the voter
-      const voterVote = votes.find((vote) => vote.player_id?.toString() === player?._id?.toString());
+      const voterVote = votes.find(
+        (vote) => vote.player_id?.toString() === player?._id?.toString(),
+      );
       if (voterVote) {
         payload.choice = voterVote.choice;
       }

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -36,11 +36,17 @@ export default class VotingNotifier {
       voting_id: voting._id.toString(),
       type: voting.type,
       entity,
+      startedAt: voting.startedAt,
     };
 
-    if (status === NotificationStatus.NEW) payload.organizer = player;
+    if (status === NotificationStatus.NEW) {
+        payload.organizer = player;
+        payload.endedAt = voting.endsOn;
+    }
     if (status === NotificationStatus.UPDATE) payload.voter = player;
 
+    if (status === NotificationStatus.END) payload.endedAt = voting.endedAt;
+    
     return payload;
   }
 

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -60,7 +60,7 @@ export default class VotingNotifier {
       payload.endedAt = voting.endedAt;
       payload.votes = voting.votes;
     }
-
+    
     return payload;
   }
 

--- a/src/voting/voting.notifier.ts
+++ b/src/voting/voting.notifier.ts
@@ -43,9 +43,21 @@ export default class VotingNotifier {
       payload.organizer = player;
       payload.endedAt = voting.endsOn;
     }
-    if (status === NotificationStatus.UPDATE) payload.voter = player;
+    if (status === NotificationStatus.UPDATE) {
+      payload.voter = player;
+      const votes = voting.votes;
+      
+      // find vote of the voter
+      const voterVote = votes.find((vote) => vote.player_id?.toString() === player?._id?.toString());
+      if (voterVote) {
+        payload.choice = voterVote.choice;
+      }
+    }
 
-    if (status === NotificationStatus.END) payload.endedAt = voting.endedAt;
+    if (status === NotificationStatus.END) {
+      payload.endedAt = voting.endedAt;
+      payload.votes = voting.votes;
+    }
 
     return payload;
   }


### PR DESCRIPTION
### Brief description

Adds voting notification payload fields so clients can log and display voting lifecycle timing and voting choices more accurately.

`VOTING_CREATED` now includes the voting start timestamp and the scheduled ending timestamp. When the voting is completed, `VOTING_ENDED` includes the actual `endedAt` timestamp, which may differ from the originally scheduled ending time.

Related issue #918 

### Change list

- Added optional `startedAt` to `VotingPayload`.
- Added optional `choice` to `VotingPayload`.
- Updated voting notification payload construction:
  - `VOTING_CREATED` includes `startedAt` and scheduled ending time via `endedAt: voting.endsOn`.
  - `VOTING_UPDATED` includes the current voter’s `choice`.
  - `VOTING_ENDED` includes the actual `endedAt` timestamp and all `votes`.
- Updated notifier tests to verify:
  - new voting notifications include start and scheduled end timestamps,
  - update notifications include the voter’s choice,
  - ended voting notifications include the actual end timestamp and final votes.