### PR TITLE
926 feature request send boolean info about existence of security question

### DIFF
--- a/src/__tests__/auth/AuthService/signIn.test.ts
+++ b/src/__tests__/auth/AuthService/signIn.test.ts
@@ -81,6 +81,7 @@ describe('AuthService.signIn() test suite', () => {
       tokenExpires,
       _id: existingProfile._id.toString(),
       username: existingProfile.username,
+      hasSecurityQuestion: false,
     };
 
     expect(clearedResult).toMatchObject({
@@ -90,6 +91,28 @@ describe('AuthService.signIn() test suite', () => {
     });
     expect(clearedPlayerResult).toEqual(playerDBFinal);
     expect(clearedClanResult).toEqual(clanDBFinal);
+  });
+
+  it('Should return hasSecurityQuestion true if profile has securityQuestion', async () => {
+    await profileModel.updateOne(
+      { _id: existingProfile._id },
+      { securityQuestion: 'What is your favorite color?' },
+    );
+    const player = playerBuilder.setProfileId(existingProfile._id).build();
+    await playerModel.create(player);
+
+    const result = await authService.signIn(validUsername, validPassword);
+
+    expect(result['hasSecurityQuestion']).toBe(true);
+  });
+
+  it('Should return hasSecurityQuestion false if profile does not have securityQuestion', async () => {
+    const player = playerBuilder.setProfileId(existingProfile._id).build();
+    await playerModel.create(player);
+
+    const result = await authService.signIn(validUsername, validPassword);
+
+    expect(result['hasSecurityQuestion']).toBe(false);
   });
 
   it('Should not return clan data if player is not in any clan', async () => {

--- a/src/__tests__/profile/ProfileService/getLoggedUserInfo.test.ts
+++ b/src/__tests__/profile/ProfileService/getLoggedUserInfo.test.ts
@@ -1,0 +1,57 @@
+import { ProfileService } from '../../../profile/profile.service';
+import ProfileBuilderFactory from '../data/profileBuilderFactory';
+import ProfileModule from '../modules/profile.module';
+import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
+import PlayerModule from '../../player/modules/player.module';
+import { Profile } from '../../../profile/profile.schema';
+import { Player } from '../../../player/schemas/player.schema';
+
+describe('ProfileService.getLoggedUserInfo() test suite', () => {
+  let profileService: ProfileService;
+  const profileBuilder = ProfileBuilderFactory.getBuilder('Profile');
+  let existingProfile: Profile;
+
+  const playerBuilder = PlayerBuilderFactory.getBuilder('CreatePlayerDto');
+  const playerModel = PlayerModule.getPlayerModel();
+  let existingPlayer: Player;
+
+  const profileModel = ProfileModule.getProfileModel();
+
+  beforeEach(async () => {
+    profileService = await ProfileModule.getProfileService();
+    const profileToCreate = profileBuilder.build();
+    const profileResp = await profileModel.create(profileToCreate);
+    existingProfile = profileResp.toObject();
+
+    const playerToCreate = playerBuilder
+      .setProfileId(existingProfile._id)
+      .build();
+    const playerResp = await playerModel.create(playerToCreate);
+    existingPlayer = playerResp.toObject();
+  });
+
+  it('Should return hasSecurityQuestion true if profile has securityQuestion', async () => {
+    await profileModel.updateOne(
+      { _id: existingProfile._id },
+      { securityQuestion: 'What is your favorite color?' },
+    );
+
+    const [profile, errors] = await profileService.getLoggedUserInfo(
+      existingProfile._id,
+      existingPlayer._id,
+    );
+
+    expect(errors).toBeNull();
+    expect(profile.hasSecurityQuestion).toBe(true);
+  });
+
+  it('Should return hasSecurityQuestion false if profile does not have securityQuestion', async () => {
+    const [profile, errors] = await profileService.getLoggedUserInfo(
+      existingProfile._id,
+      existingPlayer._id,
+    );
+
+    expect(errors).toBeNull();
+    expect(profile.hasSecurityQuestion).toBe(false);
+  });
+});

--- a/src/__tests__/profile/data/profile/profileDtoBuilder.ts
+++ b/src/__tests__/profile/data/profile/profileDtoBuilder.ts
@@ -8,6 +8,7 @@ export default class ProfileDtoBuilder implements IDataBuilder<ProfileDto> {
     _id: undefined,
     username: 'defaultUser',
     Player: undefined,
+    hasSecurityQuestion: undefined,
     environment: Environment.TEACHING_DEMO,
   };
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,8 +7,8 @@ import { AUTH_SERVICE } from './constant';
 import BoxAuthService from './box/BoxAuthService';
 import ApiResponseDescription from '../common/swagger/response/ApiResponseDescription';
 import { ModelName } from '../common/enum/modelName.enum';
-import { ProfileDto } from '../profile/dto/profile.dto';
 import { NoBoxIdFilter } from '../box/auth/decorator/NoBoxIdFilter.decorator';
+import { SignInResponseDto } from './dto/signInResponse.dto';
 
 @NoAuth()
 @Controller('auth')
@@ -28,10 +28,11 @@ export class AuthController {
   @ApiResponseDescription({
     success: {
       status: 201,
-      modelName: ModelName.PLAYER,
-      type: SignInDto,
+      modelName: ModelName.PROFILE,
+      dto: SignInResponseDto,
     },
     errors: [400, 401],
+    hasAuth: false,
   })
   @NoBoxIdFilter()
   @Post('/signIn')

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -72,6 +72,9 @@ export class AuthService {
       player_id: player?._id,
     };
 
+    // has the player set the security question?
+    const hasSecurityQuestion = !!profile.securityQuestion;
+     
     const accessToken = await this.jwtService.signAsync(payload);
     const decodedAccessToken: any = this.jwtService.decode(accessToken);
     // Extract the expiration time in Unix timestamp format
@@ -97,6 +100,7 @@ export class AuthService {
 
     return {
       ...serializedProfile,
+      hasSecurityQuestion,
       accessToken,
       tokenExpires,
     };

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -74,7 +74,7 @@ export class AuthService {
 
     // has the player set the security question?
     const hasSecurityQuestion = !!profile.securityQuestion;
-     
+    // generate the access token and get its expiration time
     const accessToken = await this.jwtService.signAsync(payload);
     const decodedAccessToken: any = this.jwtService.decode(accessToken);
     // Extract the expiration time in Unix timestamp format

--- a/src/auth/dto/signInResponse.dto.ts
+++ b/src/auth/dto/signInResponse.dto.ts
@@ -1,0 +1,38 @@
+import { Expose, Type } from 'class-transformer';
+import AddType from '../../common/base/decorator/AddType.decorator';
+import { ClanDto } from '../../clan/dto/clan.dto';
+import { ProfileDto } from '../../profile/dto/profile.dto';
+
+@AddType('SignInResponseDto')
+export class SignInResponseDto extends ProfileDto {
+  /**
+   * JWT access token used as a Bearer token in the Authorization header.
+   *
+   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+   */
+  @Expose()
+  accessToken: string;
+
+  /**
+   * Access token expiration time as a Unix timestamp.
+   *
+   * @example 1735689600
+   */
+  @Expose()
+  tokenExpires: number;
+
+  /**
+   * Whether the profile has configured a security question.
+   *
+   * @example true
+   */
+  @Expose()
+  hasSecurityQuestion: boolean;
+
+  /**
+   * Player's clan object, included when the player belongs to a clan.
+   */
+  @Type(() => ClanDto)
+  @Expose()
+  Clan?: ClanDto;
+}

--- a/src/profile/dto/profile.dto.ts
+++ b/src/profile/dto/profile.dto.ts
@@ -18,6 +18,9 @@ export class ProfileDto {
   Player: PlayerDto;
 
   @Expose()
+  hasSecurityQuestion: boolean;
+
+  @Expose()
   environment?: Environment;
 
   @Expose()

--- a/src/profile/profile.service.ts
+++ b/src/profile/profile.service.ts
@@ -244,6 +244,9 @@ export class ProfileService
       return [null, playerReadingErrors as ServiceError[]];
     profile.Player = player;
 
+    const hasSecurityQuestion: boolean = !!profile.securityQuestion;
+    profile.hasSecurityQuestion = hasSecurityQuestion;
+
     return [profile, null];
   }
 


### PR DESCRIPTION
### Brief description

Add `hasSecurityQuestion` (boolean) field to `POST /auth/signIn` and `GET /profile/info`.

Related issue #926 

### Testing with Postman

Postman test results in local environment:

`POST /auth/signIn`:

```
{
    "environment": 0,
    "_id": "69ef8b7332f46bd743f4c54c",
    "username": "backend",
    "isGuest": false,
    "__v": 0,
    "id": "69ef8b7332f46bd743f4c54c",
    "Player": {
       ...
    },
    "hasSecurityQuestion": false,
    "accessToken": ...",
    "tokenExpires": 1789896006
}
```

`GET /profile/info`:

```
{
    "data": {
        "Profile": {
            "_id": "69ef8b7332f46bd743f4c54c",
            "username": "backend",
            "Player": {
              ...
            },
            "hasSecurityQuestion": false,
            "environment": 0
        }
    },
    ...
}
```

### Change list

- Added hasSecurityQuestion boolean to profile responses.
- Included hasSecurityQuestion in GET /profile/info.
- Included hasSecurityQuestion in POST /auth/signIn.
- Added tests for both true and false cases.

**Note**

In one commit I accidentally wrote `hasSecurityAnswer`; should be `hasSecurityQuestion`.