### PR TITLE
903 feature request updated battlepoints and points from different tasks

### DIFF
--- a/src/__tests__/dailyTasks/dailyTaskProgressAmount.test.ts
+++ b/src/__tests__/dailyTasks/dailyTaskProgressAmount.test.ts
@@ -1,0 +1,70 @@
+import { DailyTaskProgressService } from '../../dailyTasks/dailyTaskProgress.service';
+
+describe('DailyTaskProgressService amount handling', () => {
+  it('treats amount as a completion requirement, not a points multiplier', async () => {
+    const notifier = {
+      taskUpdated: jest.fn(),
+      taskCompleted: jest.fn(),
+      taskCompletedForClan: jest.fn(),
+      milestoneReached: jest.fn(),
+    };
+    const playerRewarder = {
+      rewardForPlayerTask: jest.fn().mockResolvedValue([true, null]),
+    };
+    const clanRewarder = {
+      rewardClanForPlayerTask: jest
+        .fn()
+        .mockResolvedValue([{ _id: 'clan-1' }, null]),
+    };
+    const clanProgression = {
+      handleClanProgression: jest
+        .fn()
+        .mockResolvedValue([{ reachedMilestones: [] }, null]),
+    };
+    const session = {} as any;
+    const service = new DailyTaskProgressService(
+      notifier as any,
+      clanRewarder as any,
+      playerRewarder as any,
+      clanProgression as any,
+      {} as any,
+    );
+    const result = {
+      status: 'completed',
+      task: {
+        clan_id: 'clan-1',
+        player_id: 'player-1',
+        type: 'play_battle',
+        points: 10,
+        coins: 5,
+        amount: 5,
+      },
+      completedByPlayerId: 'player-1',
+      clanId: 'clan-1',
+      completedAmount: 5,
+      previousAmountLeft: 5,
+      currentAmountLeft: 0,
+    } as any;
+
+    const [handled, errors] = await service.handleProgress(result, session);
+
+    expect(errors).toBeNull();
+    expect(handled).toBe(result);
+    expect(playerRewarder.rewardForPlayerTask).toHaveBeenCalledWith(
+      'player-1',
+      result.task.points,
+      session,
+    );
+    expect(clanRewarder.rewardClanForPlayerTask).toHaveBeenCalledWith(
+      'clan-1',
+      result.task.points,
+      result.task.coins,
+      session,
+    );
+    expect(playerRewarder.rewardForPlayerTask).not.toHaveBeenCalledWith(
+      'player-1',
+      result.task.points * result.task.amount,
+      session,
+    );
+  });
+});

--- a/src/__tests__/dailyTasks/dailyTaskScoringValues.test.ts
+++ b/src/__tests__/dailyTasks/dailyTaskScoringValues.test.ts
@@ -1,0 +1,35 @@
+import { defaultPredefinedDailyTasks } from '../../box/dailyTask/defaultPredefinedDailyTasks';
+import { Score } from '../../common/values/scoring.values';
+import { TaskGeneratorService } from '../../dailyTasks/taskGenerator.service';
+import { uiDailyTasks } from '../../dailyTasks/uiDailyTasks/uiDailyTasks';
+
+describe('daily task scoring values', () => {
+  it('uses the shared completed daily task score for generated server tasks', () => {
+    const generator = new TaskGeneratorService();
+
+    const task = generator.createTaskRandomValues();
+
+    expect(task.points).toBe(Score.DAILY_TASK.COMPLETED);
+  });
+
+  it('uses the shared completed daily task score for default predefined tasks', () => {
+    expect(defaultPredefinedDailyTasks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ points: Score.DAILY_TASK.COMPLETED }),
+      ]),
+    );
+    expect(
+      defaultPredefinedDailyTasks.every(
+        (task) => task.points === Score.DAILY_TASK.COMPLETED,
+      ),
+    ).toBe(true);
+  });
+
+  it('uses the shared completed daily task score for UI daily tasks', () => {
+    expect(
+      Object.values(uiDailyTasks).every(
+        (task) => task.points === Score.DAILY_TASK.COMPLETED,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/gameData/gameDataService/handleResultType.test.ts
+++ b/src/__tests__/gameData/gameDataService/handleResultType.test.ts
@@ -13,7 +13,6 @@ import ClanBuilderFactory from '../../clan/data/clanBuilderFactory';
 import GameDataBuilderFactory from '../data/gameDataBuilderFactory';
 import AuthBuilderFactory from '../../auth/data/authBuilderFactory';
 import { ObjectId } from 'mongodb';
-import EventEmitterService from '../../../common/service/EventEmitterService/EventEmitter.service';
 import { JwtService } from '@nestjs/jwt';
 import { Game } from '../../../gameData/game.schema';
 import { BattleResultDto } from '../../../gameData/dto/battleResult.dto';
@@ -38,7 +37,6 @@ describe('GameDataService.handleResultType() test suite', () => {
   let roomService: RoomService;
   let gameEventsHandler: GameEventsHandler;
   let gameDataService: GameDataService;
-  let eventEmitterService: EventEmitterService;
   let battleResultDto: BattleResultDto;
   let game: Game;
 
@@ -114,8 +112,6 @@ describe('GameDataService.handleResultType() test suite', () => {
     roomService = await GameDataModule.getRoomService();
     gameEventsHandler = await GameDataModule.getGameEventHandler();
 
-    eventEmitterService = await GameDataModule.getEventEmitterService();
-
     jest.spyOn(JwtService.prototype, 'signAsync').mockResolvedValue('token');
 
     jest
@@ -123,9 +119,6 @@ describe('GameDataService.handleResultType() test suite', () => {
       .mockResolvedValue([[roomDto1, roomDto2], null]);
 
     jest.spyOn(gameEventsHandler, 'handleEvent').mockImplementation();
-    jest
-      .spyOn(eventEmitterService, 'EmitNewDailyTaskEvent')
-      .mockImplementation();
 
     jest
       .spyOn(playerService, 'getPlayerById')

--- a/src/__tests__/gameEventsHandler/GameEventsHandler/battleDailyTaskEvents.test.ts
+++ b/src/__tests__/gameEventsHandler/GameEventsHandler/battleDailyTaskEvents.test.ts
@@ -1,0 +1,86 @@
+import { ServerTaskName } from '../../../dailyTasks/enum/serverTaskName.enum';
+import { GameEventType } from '../../../gameEventsHandler/enum/GameEventType.enum';
+import { GameEventsHandler } from '../../../gameEventsHandler/gameEventsHandler';
+import { ClanEvent } from '../../../rewarder/clanRewarder/enum/ClanEvent.enum';
+import { PlayerEvent } from '../../../rewarder/playerRewarder/enum/PlayerEvent.enum';
+
+describe('GameEventsHandler battle daily task events', () => {
+  const createHandler = () => {
+    const playerEventHandler = {
+      handlePlayerEvent: jest.fn(async () => [true, null]),
+    };
+    const clanEventHandler = {
+      handleClanEvent: jest.fn(async () => [true, null]),
+      handlePlayerTask: jest.fn(async () => [true, null]),
+    };
+    const emitterService = {
+      EmitNewDailyTaskEvent: jest.fn(async () => undefined),
+    };
+    const handler = new GameEventsHandler(
+      playerEventHandler as any,
+      clanEventHandler as any,
+      emitterService as any,
+    );
+
+    return { clanEventHandler, emitterService, handler, playerEventHandler };
+  };
+
+  it('emits play and win daily task events for a won battle', async () => {
+    const { clanEventHandler, emitterService, handler, playerEventHandler } =
+      createHandler();
+
+    const [result, errors] = await handler.handleEvent(
+      'player-1',
+      GameEventType.PLAYER_WIN_BATTLE,
+    );
+
+    expect(errors).toBeNull();
+    expect(result).toBe(true);
+    expect(playerEventHandler.handlePlayerEvent).toHaveBeenCalledWith(
+      'player-1',
+      PlayerEvent.BATTLE_WON,
+    );
+    expect(clanEventHandler.handleClanEvent).toHaveBeenCalledWith(
+      'player-1',
+      ClanEvent.BATTLE_WON,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.WIN_BATTLE,
+      true,
+    );
+  });
+
+  it('emits only the play daily task event for a lost battle', async () => {
+    const { clanEventHandler, emitterService, handler, playerEventHandler } =
+      createHandler();
+
+    const [result, errors] = await handler.handleEvent(
+      'player-1',
+      GameEventType.PLAYER_LOSE_BATTLE,
+    );
+
+    expect(errors).toBeNull();
+    expect(result).toBe(true);
+    expect(playerEventHandler.handlePlayerEvent).toHaveBeenCalledWith(
+      'player-1',
+      PlayerEvent.BATTLE_LOSE,
+    );
+    expect(clanEventHandler.handleClanEvent).toHaveBeenCalledWith(
+      'player-1',
+      ClanEvent.BATTLE_LOSE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).not.toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.WIN_BATTLE,
+    );
+  });
+});

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -1181,6 +1181,59 @@ describe('MatchmakingService flow', () => {
     );
   });
 
+  it('finishes a match even when daily task event emission fails', async () => {
+    const { redis, emitterService, notifier, service } = createService();
+    const match: ActiveMatch = {
+      id: 'match-daily-task-error',
+      matchType: MatchType.RANDOM,
+      status: MatchStatus.ACTIVE,
+      teamSize: 1,
+      teams: [
+        {
+          side: TeamSide.A,
+          participants: [{ playerId: 'player-1', isBot: false }],
+        },
+        {
+          side: TeamSide.B,
+          participants: [{ playerId: 'player-2', isBot: false }],
+        },
+      ],
+      startedAt: '2026-07-06T08:00:00.000Z',
+    };
+    emitterService.EmitNewDailyTaskEvent.mockRejectedValueOnce(
+      new Error('daily task emit failed'),
+    );
+    await redis.set(
+      'matchmaking:match:match-daily-task-error',
+      JSON.stringify(match),
+    );
+
+    const [finishedMatch, errors] = await service.finishMatch(
+      'match-daily-task-error',
+      'player-1',
+      { winningSide: TeamSide.A },
+    );
+
+    const storedMatch = JSON.parse(
+      await redis.get('matchmaking:match:match-daily-task-error'),
+    ) as ActiveMatch;
+
+    expect(errors).toBeNull();
+    expect(finishedMatch).toMatchObject({
+      id: 'match-daily-task-error',
+      status: MatchStatus.FINISHED,
+    });
+    expect(storedMatch.status).toBe(MatchStatus.FINISHED);
+    expect(notifier.matchEvent).toHaveBeenCalledWith(
+      'match-daily-task-error',
+      'MATCH_FINISHED',
+      expect.objectContaining({
+        id: 'match-daily-task-error',
+        status: MatchStatus.FINISHED,
+      }),
+    );
+  });
+
   it('returns service errors when player leaderboard update fails while finishing a match', async () => {
     const { redis, playerService, clanService, notifier, service } =
       createService();

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -8,6 +8,7 @@ import { MatchmakingService } from '../../../matchmaking/matchmaking.service';
 import { ActiveMatch } from '../../../matchmaking/type/activeMatch.type';
 import { SEReason } from '../../../common/service/basicService/SEReason';
 import ServiceError from '../../../common/service/basicService/ServiceError';
+import { Score } from '../../../common/values/scoring.values';
 
 class InMemoryRedisService {
   readonly values = new Map<string, string>();
@@ -1040,14 +1041,14 @@ describe('MatchmakingService flow', () => {
     });
     expect(playerService.updatePlayerById).toHaveBeenCalledWith('player-1', {
       $inc: {
-        battlePoints: 50,
+        battlePoints: Score.BATTLE.WIN,
         'gameStatistics.playedBattles': 1,
         'gameStatistics.wonBattles': 1,
       },
     });
     expect(playerService.updatePlayerById).toHaveBeenCalledWith('player-2', {
       $inc: {
-        battlePoints: 10,
+        battlePoints: Score.BATTLE.LOSS,
         'gameStatistics.playedBattles': 1,
       },
     });
@@ -1105,13 +1106,13 @@ describe('MatchmakingService flow', () => {
     expect(finishedMatch.result).toEqual({ winningSide: TeamSide.B });
     expect(playerService.updatePlayerById).toHaveBeenCalledWith('player-1', {
       $inc: {
-        battlePoints: 10,
+        battlePoints: Score.BATTLE.LOSS,
         'gameStatistics.playedBattles': 1,
       },
     });
     expect(playerService.updatePlayerById).toHaveBeenCalledWith('player-2', {
       $inc: {
-        battlePoints: 50,
+        battlePoints: Score.BATTLE.WIN,
         'gameStatistics.playedBattles': 1,
         'gameStatistics.wonBattles': 1,
       },
@@ -1119,13 +1120,13 @@ describe('MatchmakingService flow', () => {
     expect(clanService.basicService.updateOneById).toHaveBeenCalledWith(
       'clan-1',
       {
-        $inc: { battlePoints: 10 },
+        $inc: { battlePoints: Score.BATTLE.LOSS },
       },
     );
     expect(clanService.basicService.updateOneById).toHaveBeenCalledWith(
       'clan-2',
       {
-        $inc: { battlePoints: 50 },
+        $inc: { battlePoints: Score.BATTLE.WIN },
       },
     );
   });

--- a/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
+++ b/src/__tests__/matchmaking/MatchmakingService/flow.test.ts
@@ -9,6 +9,7 @@ import { ActiveMatch } from '../../../matchmaking/type/activeMatch.type';
 import { SEReason } from '../../../common/service/basicService/SEReason';
 import ServiceError from '../../../common/service/basicService/ServiceError';
 import { Score } from '../../../common/values/scoring.values';
+import { ServerTaskName } from '../../../dailyTasks/enum/serverTaskName.enum';
 
 class InMemoryRedisService {
   readonly values = new Map<string, string>();
@@ -91,6 +92,9 @@ type TestDeps = {
     matchFound: jest.Mock;
     matchEvent: jest.Mock;
   };
+  emitterService: {
+    EmitNewDailyTaskEvent: jest.Mock;
+  };
   queue: {
     scheduleClanOpponentTimeout: jest.Mock;
   };
@@ -137,6 +141,9 @@ const createService = (
     matchFound: jest.fn(async () => undefined),
     matchEvent: jest.fn(async () => undefined),
   };
+  const emitterService = {
+    EmitNewDailyTaskEvent: jest.fn(async () => undefined),
+  };
   const queue = {
     scheduleClanOpponentTimeout: jest.fn(async () => undefined),
   };
@@ -145,6 +152,7 @@ const createService = (
     playerService as any,
     clanService as any,
     notifier as any,
+    emitterService as any,
     queue as any,
   );
 
@@ -153,6 +161,7 @@ const createService = (
     playerService,
     clanService,
     notifier,
+    emitterService,
     queue,
     service,
   } satisfies TestDeps;
@@ -1004,8 +1013,14 @@ describe('MatchmakingService flow', () => {
   });
 
   it('finishes a RANDOM match with personal leaderboard updates only', async () => {
-    const { redis, playerService, clanService, notifier, service } =
-      createService();
+    const {
+      redis,
+      playerService,
+      clanService,
+      notifier,
+      emitterService,
+      service,
+    } = createService();
     const match: ActiveMatch = {
       id: 'match-1',
       matchType: MatchType.RANDOM,
@@ -1053,6 +1068,23 @@ describe('MatchmakingService flow', () => {
       },
     });
     expect(clanService.basicService.updateOneById).not.toHaveBeenCalled();
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.WIN_BATTLE,
+      true,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-2',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).not.toHaveBeenCalledWith(
+      'player-2',
+      ServerTaskName.WIN_BATTLE,
+    );
     expect(redis.expire).toHaveBeenCalledWith(
       'matchmaking:match-player:player-1',
       600,
@@ -1074,7 +1106,8 @@ describe('MatchmakingService flow', () => {
   });
 
   it('finishes a CLAN match with personal and clan leaderboard updates', async () => {
-    const { redis, playerService, clanService, service } = createService();
+    const { redis, playerService, clanService, emitterService, service } =
+      createService();
     const match: ActiveMatch = {
       id: 'match-2',
       matchType: MatchType.CLAN,
@@ -1128,6 +1161,23 @@ describe('MatchmakingService flow', () => {
       {
         $inc: { battlePoints: Score.BATTLE.WIN },
       },
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).not.toHaveBeenCalledWith(
+      'player-1',
+      ServerTaskName.WIN_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-2',
+      ServerTaskName.PLAY_BATTLE,
+    );
+    expect(emitterService.EmitNewDailyTaskEvent).toHaveBeenCalledWith(
+      'player-2',
+      ServerTaskName.WIN_BATTLE,
+      true,
     );
   });
 

--- a/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
+++ b/src/__tests__/rewarder/ClanRewarder/rewardForClanEvent.test.ts
@@ -6,6 +6,7 @@ import { Player } from '../../../player/schemas/player.schema';
 import ClanBuilderFactory from '../../clan/data/clanBuilderFactory';
 import { Clan } from '../../../clan/clan.schema';
 import ClanModule from '../../clan/modules/clan.module';
+import { Score } from '../../../common/values/scoring.values';
 
 describe('ClanRewarder.rewardForClanEvent() test suite', () => {
   let rewarder: ClanRewarder;
@@ -48,7 +49,9 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
 
     const clanAfter = await clanModel.findById(createdClan._id);
     expect(clanAfter.points).toBe(clanBefore.points);
-    expect(clanAfter.battlePoints).toBe(130);
+    expect(clanAfter.battlePoints).toBe(
+      clanBefore.battlePoints + Score.BATTLE.WIN,
+    );
     expect(isSuccess).toBe(true);
     expect(errors).toBeNull();
   });
@@ -66,7 +69,9 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
 
     const clanAfter = await clanModel.findById(createdClan._id);
     expect(clanAfter.points).toBe(clanBefore.points);
-    expect(clanAfter.battlePoints).toBe(10);
+    expect(clanAfter.battlePoints).toBe(
+      clanBefore.battlePoints + Score.BATTLE.LOSS,
+    );
     expect(isSuccess).toBe(true);
     expect(errors).toBeNull();
   });
@@ -79,7 +84,7 @@ describe('ClanRewarder.rewardForClanEvent() test suite', () => {
     existingClan = clanBuilder
       .setName('loserClan')
       .setPoints(0)
-      .setBattlePoints(10)
+      .setBattlePoints(3)
       .build();
 
     const createdClan = await clanModel.create(existingClan);

--- a/src/__tests__/rewarder/PlayerRewarder/rewardForPlayerEvent.test.ts
+++ b/src/__tests__/rewarder/PlayerRewarder/rewardForPlayerEvent.test.ts
@@ -3,6 +3,7 @@ import { PlayerRewarder } from '../../../rewarder/playerRewarder/playerRewarder.
 import PlayerBuilderFactory from '../../player/data/playerBuilderFactory';
 import PlayerModule from '../../player/modules/player.module';
 import { Player } from '../../../player/schemas/player.schema';
+import { Score } from '../../../common/values/scoring.values';
 
 describe('PlayerRewarder.rewardForPlayerEvent() test suite', () => {
   let rewarder: PlayerRewarder;
@@ -31,7 +32,9 @@ describe('PlayerRewarder.rewardForPlayerEvent() test suite', () => {
 
     const playerAfter = await playerModel.findById(existingPlayer._id);
     expect(playerAfter.points).toBe(playerBefore.points);
-    expect(playerAfter.battlePoints).toBe(130);
+    expect(playerAfter.battlePoints).toBe(
+      playerBefore.battlePoints + Score.BATTLE.WIN,
+    );
     expect(isSuccess).toBe(true);
     expect(errors).toBeNull();
   });
@@ -49,7 +52,9 @@ describe('PlayerRewarder.rewardForPlayerEvent() test suite', () => {
 
     const playerAfter = await playerModel.findById(existingPlayer._id);
     expect(playerAfter.points).toBe(playerBefore.points);
-    expect(playerAfter.battlePoints).toBe(10);
+    expect(playerAfter.battlePoints).toBe(
+      playerBefore.battlePoints + Score.BATTLE.LOSS,
+    );
     expect(isSuccess).toBe(true);
     expect(errors).toBeNull();
   });
@@ -61,7 +66,7 @@ describe('PlayerRewarder.rewardForPlayerEvent() test suite', () => {
       .setName('loserPlayer')
       .setUniqueIdentifier('loserIdentifier')
       .setPoints(0)
-      .setBattlePoints(10)
+      .setBattlePoints(3)
       .build();
 
     const createdPlayer = await playerModel.create(existingPlayer);

--- a/src/box/dailyTask/defaultPredefinedDailyTasks.ts
+++ b/src/box/dailyTask/defaultPredefinedDailyTasks.ts
@@ -1,5 +1,6 @@
 import { ServerTaskName } from '../../dailyTasks/enum/serverTaskName.enum';
 import { CreatePredefinedDailyTaskDto } from './dto/createPredefinedDailyTask.dto';
+import { Score } from '../../common/values/scoring.values';
 
 /**
  * Daily tasks to use as default in box schema.
@@ -9,7 +10,7 @@ export const defaultPredefinedDailyTasks: CreatePredefinedDailyTaskDto[] = [
     type: ServerTaskName.PLAY_BATTLE,
     title: 'Pelaa otteluita',
     amount: 5,
-    points: 10,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     timeLimitMinutes: 60,
   },
@@ -17,7 +18,7 @@ export const defaultPredefinedDailyTasks: CreatePredefinedDailyTaskDto[] = [
     type: ServerTaskName.WIN_BATTLE,
     title: 'Voita otteluita',
     amount: 3,
-    points: 15,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 15,
     timeLimitMinutes: 60,
   },

--- a/src/common/values/scoring.values.ts
+++ b/src/common/values/scoring.values.ts
@@ -1,0 +1,16 @@
+export const Score = {
+    
+    // battlepoints
+    BATTLE: {
+        WIN: 10,    // battle win (all kinds of battles)
+        LOSS: -5,   // battle loss (all kinds of battles)
+    },
+    
+    // points from daily tasks
+    DAILY_TASK: {
+        COMPLETED: 10,
+        COMPLETED_WITH_HINT: 5,
+        CANCELED: 0,
+    }
+    
+}

--- a/src/common/values/scoring.values.ts
+++ b/src/common/values/scoring.values.ts
@@ -1,16 +1,14 @@
 export const Score = {
-    
-    // battlepoints
-    BATTLE: {
-        WIN: 10,    // battle win (all kinds of battles)
-        LOSS: -5,   // battle loss (all kinds of battles)
-    },
-    
-    // points from daily tasks
-    DAILY_TASK: {
-        COMPLETED: 10,
-        COMPLETED_WITH_HINT: 5,
-        CANCELED: 0,
-    }
-    
-}
+  // battlepoints
+  BATTLE: {
+    WIN: 10, // battle win (all kinds of battles)
+    LOSS: -5, // battle loss (all kinds of battles)
+  },
+
+  // points from daily tasks
+  DAILY_TASK: {
+    COMPLETED: 10,
+    COMPLETED_WITH_HINT: 5,
+    CANCELED: 0,
+  },
+};

--- a/src/dailyTasks/taskGenerator.service.ts
+++ b/src/dailyTasks/taskGenerator.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ServerTaskName } from './enum/serverTaskName.enum';
 import { TASK_CONSTS } from './consts/taskConstants';
 import { TaskTitle } from './type/taskTitle.type';
+import { Score } from '../common/values/scoring.values';
 
 type TaskInfo = {
   title: TaskTitle;
@@ -63,7 +64,7 @@ export class TaskGeneratorService {
       Math.floor(
         Math.random() * (TASK_CONSTS.AMOUNT.MAX - TASK_CONSTS.AMOUNT.MIN + 1),
       ) + TASK_CONSTS.AMOUNT.MIN;
-    const points = 100;
+    const points = Score.DAILY_TASK.COMPLETED;
     const coins = Math.floor(points * TASK_CONSTS.COINS.FACTOR);
     const taskType = this.getRandomTaskType();
     const titleString = this.getTaskTitle(taskType, amount);

--- a/src/dailyTasks/uiDailyTasks/uiDailyTasks.ts
+++ b/src/dailyTasks/uiDailyTasks/uiDailyTasks.ts
@@ -1,5 +1,6 @@
 import { UITaskName } from '../enum/uiTaskName.enum';
 import { TaskTitle } from '../type/taskTitle.type';
+import { Score } from '../../common/values/scoring.values';
 
 /**
  * UI daily task basic information
@@ -22,7 +23,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'etsi käyttöliittymän kannalta mielestäsi 3 tärkeintä painiketta',
     },
     type: UITaskName.FIND_3_IMPORTANT_BUTTONS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -30,7 +31,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.EXPLODE_CHARACTER_BATTLE]: {
     title: { fi: 'räjäytä hahmosi ryöstössä' },
     type: UITaskName.EXPLODE_CHARACTER_BATTLE,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -38,7 +39,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WHAT_IS_MISSING]: {
     title: { fi: 'Mitä puuttuu?' },
     type: UITaskName.WHAT_IS_MISSING,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -46,7 +47,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.FIND_BUG]: {
     title: { fi: 'Etsi bugi!' },
     type: UITaskName.FIND_BUG,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -54,7 +55,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.FIND_ALL_INSTRUCTION_WINDOWS]: {
     title: { fi: 'löydä kaikki pelin ohjeistusikkunat ja paina niitä' },
     type: UITaskName.FIND_ALL_INSTRUCTION_WINDOWS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -62,7 +63,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.FIND_VARIABLE_VALUE_IN_GAME]: {
     title: { fi: 'Löydä muuttuja toiminnassa!' },
     type: UITaskName.FIND_VARIABLE_VALUE_IN_GAME,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -70,7 +71,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.MAKE_MUSIC_WITH_BUTTONS]: {
     title: { fi: 'tee näppäimillä musiikkia' },
     type: UITaskName.MAKE_MUSIC_WITH_BUTTONS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -78,7 +79,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.INFLUENCE_OPPONENT_GAME_CHAT_EMOJI]: {
     title: { fi: 'vaikuta vastustajan peliin viestimällä emojeita' },
     type: UITaskName.INFLUENCE_OPPONENT_GAME_CHAT_EMOJI,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -86,7 +87,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_3_SYMBOL_FURNITURE]: {
     title: { fi: 'paina kolmea symboliikkaa sisältävää huonekalua' },
     type: UITaskName.PRESS_3_SYMBOL_FURNITURE,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -96,7 +97,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'TUNNETEHTÄVÄ > klikkaa alkutarinasta sinusta vaikuttavinta ruutua',
     },
     type: UITaskName.PRESS_STORY_MOST_IMPRESSIVE_PANELS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -104,7 +105,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WHERE_GAME_HAPPENS]: {
     title: { fi: 'missä peli tarinan mukaan tapahtuu?' },
     type: UITaskName.WHERE_GAME_HAPPENS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -112,7 +113,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_STORY_TELLING_INSTRUCTIONS]: {
     title: { fi: 'klikkaa tarinaa kertovia ohjeistuksia' },
     type: UITaskName.PRESS_STORY_TELLING_INSTRUCTIONS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -121,7 +122,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_CHARACTER_DESCRIPTION]: {
     title: { fi: 'lue ja paina pelihahmon kuvausta' },
     type: UITaskName.PRESS_CHARACTER_DESCRIPTION,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -129,7 +130,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.RECOGNIZE_CHARACTER_MECHANIC]: {
     title: { fi: 'tunnista pelihahmon tarinallinen mekaniikka' },
     type: UITaskName.RECOGNIZE_CHARACTER_MECHANIC,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -137,7 +138,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.CONTINUE_CLAN_STORY]: {
     title: { fi: 'jatka klaanin tarinaa' },
     type: UITaskName.CONTINUE_CLAN_STORY,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -145,7 +146,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.RECOGNIZE_GRAPHIC_HINTS]: {
     title: { fi: 'tunnista graafiset vihjeet' },
     type: UITaskName.RECOGNIZE_GRAPHIC_HINTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -153,7 +154,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.RECOGNIZE_AUDIO_HINTS]: {
     title: { fi: 'tunnista äänimaailman vihjeet' },
     type: UITaskName.RECOGNIZE_AUDIO_HINTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -161,7 +162,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WRITE_BATTLE_DIALOG]: {
     title: { fi: 'kirjoita battlen dialogi' },
     type: UITaskName.WRITE_BATTLE_DIALOG,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -169,7 +170,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.FIND_UI_SYMBOLIC_GRAPHICS]: {
     title: { fi: 'löydä käyttöliittymästä symbolista grafiikkaa' },
     type: UITaskName.FIND_UI_SYMBOLIC_GRAPHICS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -177,7 +178,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.CHOOSE_FAVORITE_INTERIOR_SERIES]: {
     title: { fi: 'valitse lemppari sisustus-sarjasi' },
     type: UITaskName.CHOOSE_FAVORITE_INTERIOR_SERIES,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -185,7 +186,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_YOURSELF_IDENTIFYING_STORIES]: {
     title: { fi: 'klikkaa tarinoita joihin pystyt samastumaan' },
     type: UITaskName.PRESS_YOURSELF_IDENTIFYING_STORIES,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -194,7 +195,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WHAT_IS_GAME_STORY]: {
     title: { fi: 'mikä on pelin viesti? mistä peli kertoo?' },
     type: UITaskName.WHAT_IS_GAME_STORY,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -204,7 +205,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'etsi ja klikkaa pelin tarinaa laajentavia asioita nettisivuilta',
     },
     type: UITaskName.PRESS_STORY_EXPANDING_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -214,7 +215,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'klikkaa tunnettuihin teoksiin, ideoihin tai ihmisiin viittaavia asioita',
     },
     type: UITaskName.PRESS_FAMOUS_THINGS_REFERRING_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -224,7 +225,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'etsi ja klikkaa graafisia elementtejä, jotka viittaavat muihin taiteenlajeihin',
     },
     type: UITaskName.PRESS_OTHER_GRAPHIC_STYLE_ELEMENTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -232,7 +233,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WHAT_STYLE_TYPES_GAME_HAS]: {
     title: { fi: 'mitä lajityyppiä (tai useampaa) peli sinulle edustaa?' },
     type: UITaskName.WHAT_STYLE_TYPES_GAME_HAS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -240,7 +241,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_FAMOUS_CHARACTER]: {
     title: { fi: 'klikkaa pelihahmoa josta tulee mieleen joku tunnettu hahmo' },
     type: UITaskName.PRESS_FAMOUS_CHARACTER,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -248,7 +249,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.WHAT_FAMOUS_GAME_REMINDING]: {
     title: { fi: 'mitä tunnettua peliä tämä peli muistuttaa?' },
     type: UITaskName.WHAT_FAMOUS_GAME_REMINDING,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -256,7 +257,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.CHOOSE_CULTURAL_GUIDELINE_CLAN_DESCRIPTION]: {
     title: { fi: 'valitse klaanin kuvaukseen toimintakulttuurinen ohje' },
     type: UITaskName.CHOOSE_CULTURAL_GUIDELINE_CLAN_DESCRIPTION,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -266,7 +267,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'katso kieliasetukset ja klikkaa kohtia jotka muuttuvat eri kielien välillä',
     },
     type: UITaskName.CHANGE_LANGUAGE,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -274,7 +275,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_MONEY_STUFF]: {
     title: { fi: 'klikkaa asioita, joissa voi käyttää rahaa' },
     type: UITaskName.PRESS_MONEY_STUFF,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -285,7 +286,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'käytä matsin aikana vain positiivisia ja kannustavia eleitä',
     },
     type: UITaskName.USE_ONLY_POSITIVE_GESTURES_IN_BATTLE,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -293,7 +294,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.USE_ONLY_NEGATIVE_GESTURES_IN_BATTLE]: {
     title: { fi: 'käytä matsin aikana vain negatiivisia eleitä' },
     type: UITaskName.USE_ONLY_NEGATIVE_GESTURES_IN_BATTLE,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -303,7 +304,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
       fi: 'tunnista ja paina kohtia, joissa peli palkitsee sinua jotenkin',
     },
     type: UITaskName.PRESS_PRIZE_GIVING_ITEMS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -311,7 +312,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_ACCESSIBILITY_SETTINGS]: {
     title: { fi: 'etsi ja klikkaa kaikkia saavutettavuus-asetuksia' },
     type: UITaskName.PRESS_ACCESSIBILITY_SETTINGS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -319,7 +320,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_ETHIC_QUESTIONABLE_OBJECTS]: {
     title: { fi: 'etsi ja klikkaa eettisesti arveluttavia asioita' },
     type: UITaskName.PRESS_ETHIC_QUESTIONABLE_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -327,7 +328,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_RESPONSIBILITY_OBJECTS]: {
     title: { fi: 'etsi ja klikkaa vastuullisuuteen liittyviä asioita' },
     type: UITaskName.PRESS_RESPONSIBILITY_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -335,7 +336,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_SUSTAINABLE_CONSUMPTION_OBJECTS]: {
     title: { fi: 'etsi ja klikkaa kestävään kuluttamiseen liittyviä asioita' },
     type: UITaskName.PRESS_SUSTAINABLE_CONSUMPTION_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,
@@ -343,7 +344,7 @@ export const uiDailyTasks: Record<UITaskName, UIDailyTaskData> = {
   [UITaskName.PRESS_VALUES_OBJECTS]: {
     title: { fi: 'etsi ja klikkaa arvoihin liittyviä asioita' },
     type: UITaskName.PRESS_VALUES_OBJECTS,
-    points: 100,
+    points: Score.DAILY_TASK.COMPLETED,
     coins: 10,
     amount: 1,
     timeLimitMinutes: 60,

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -21,8 +21,6 @@ import { GameEventsHandler } from '../gameEventsHandler/gameEventsHandler';
 import { GameEventType } from '../gameEventsHandler/enum/GameEventType.enum';
 import { IServiceReturn } from '../common/service/basicService/IService';
 import { SEReason } from '../common/service/basicService/SEReason';
-import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
-import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
 import { Environment } from '../common/enum/environment.enum';
 import { GameType } from './enum/gameType.enum';
 import { MatchmakingService } from '../matchmaking/matchmaking.service';
@@ -36,7 +34,6 @@ export class GameDataService {
     public readonly roomService: RoomService,
     private readonly gameEventsBroker: GameEventsHandler,
     private readonly jwtService: JwtService,
-    private readonly emitterService: EventEmitterService,
     private readonly matchmakingService: MatchmakingService,
   ) {
     this.basicService = new BasicService(model);
@@ -94,11 +91,6 @@ export class GameDataService {
     if (teamIdsErrors) return [null, teamIdsErrors];
 
     this.createGameIfNotExists(battleResult, teamIds, currentTime);
-
-    this.emitterService.EmitNewDailyTaskEvent(
-      user.player_id,
-      ServerTaskName.PLAY_BATTLE,
-    );
 
     return this.generateResponse(
       battleResult,

--- a/src/gameEventsHandler/gameEventsHandler.ts
+++ b/src/gameEventsHandler/gameEventsHandler.ts
@@ -48,7 +48,12 @@ export class GameEventsHandler {
       PlayerEvent.BATTLE_WON,
     );
 
-    this.emitterService.EmitNewDailyTaskEvent(
+    await this.emitterService.EmitNewDailyTaskEvent(
+      player_id,
+      ServerTaskName.PLAY_BATTLE,
+    );
+
+    await this.emitterService.EmitNewDailyTaskEvent(
       player_id,
       ServerTaskName.WIN_BATTLE,
       true,
@@ -73,6 +78,11 @@ export class GameEventsHandler {
     );
 
     if (playerErrors) return [null, playerErrors];
+
+    await this.emitterService.EmitNewDailyTaskEvent(
+      player_id,
+      ServerTaskName.PLAY_BATTLE,
+    );
 
     const [, clanEventErrors] = await this.clanEventHandler.handleClanEvent(
       player_id,

--- a/src/matchmaking/matchmaking.controller.ts
+++ b/src/matchmaking/matchmaking.controller.ts
@@ -126,8 +126,8 @@ export class MatchmakingController {
   }
 
   /**
-   * Finishes an active match, updates leaderboards, and keeps the finished match
-   * in Redis for a short read-after-finish window.
+   * Finishes an active match, updates battlePoints leaderboards, and keeps the
+   * finished match in Redis for a short read-after-finish window.
    */
   @Post('matches/:matchId/finish')
   @UniformResponse(undefined, MatchmakingMatchDto)

--- a/src/matchmaking/matchmaking.module.ts
+++ b/src/matchmaking/matchmaking.module.ts
@@ -2,6 +2,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { Module } from '@nestjs/common';
 import { ClanModule } from '../clan/clan.module';
 import { RedisModule } from '../common/service/redis/redis.module';
+import { EventEmitterCommonModule } from '../common/service/EventEmitterService/EventEmitterCommon.module';
 import { PlayerModule } from '../player/player.module';
 import { MatchmakingController } from './matchmaking.controller';
 import { MatchmakingNotifier } from './matchmaking.notifier';
@@ -24,6 +25,7 @@ import { MatchmakingService } from './matchmaking.service';
     RedisModule,
     PlayerModule,
     ClanModule,
+    EventEmitterCommonModule,
     BullModule.registerQueue({ name: MATCHMAKING_QUEUE }),
   ],
   controllers: [MatchmakingController],

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -1092,19 +1092,37 @@ export class MatchmakingService {
       const playerIds = this.getTeamPlayerIds(team);
 
       for (const playerId of playerIds) {
-        await this.emitterService.EmitNewDailyTaskEvent(
-          playerId,
-          ServerTaskName.PLAY_BATTLE,
-        );
+        await this.tryEmitDailyTaskEvent(playerId, ServerTaskName.PLAY_BATTLE);
 
         if (outcome === 'WIN') {
-          await this.emitterService.EmitNewDailyTaskEvent(
+          await this.tryEmitDailyTaskEvent(
             playerId,
             ServerTaskName.WIN_BATTLE,
             true,
           );
         }
       }
+    }
+  }
+
+  private async tryEmitDailyTaskEvent(
+    playerId: string,
+    taskName: ServerTaskName,
+    needsClanReward = false,
+  ) {
+    try {
+      if (needsClanReward) {
+        await this.emitterService.EmitNewDailyTaskEvent(
+          playerId,
+          taskName,
+          true,
+        );
+        return;
+      }
+
+      await this.emitterService.EmitNewDailyTaskEvent(playerId, taskName);
+    } catch {
+      return;
     }
   }
 

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -447,8 +447,9 @@ export class MatchmakingService {
   }
 
   /**
-   * Finishes an active match once, updates the correct leaderboards, and keeps
-   * the completed match briefly available in Redis for clients that refresh.
+   * Finishes an active match once, updates the correct battlePoints
+   * leaderboards, and keeps the completed match briefly available in Redis for
+   * clients that refresh.
    */
   async finishMatch(
     matchId: string,
@@ -1025,8 +1026,8 @@ export class MatchmakingService {
   }
 
   /**
-   * Updates personal leaderboards for all modes and clan leaderboards for CLAN
-   * matches only.
+   * Updates personal battlePoints leaderboards for all modes and clan
+   * battlePoints leaderboards for CLAN matches only.
    */
   private async updateLeaderboardsForFinishedMatch(match: ActiveMatch) {
     const playerErrors =

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -45,6 +45,8 @@ import {
 import { MatchmakingTeam } from './type/matchmakingTeam.type';
 import { Clan } from '../clan/clan.schema';
 import { Score } from '../common/values/scoring.values';
+import EventEmitterService from '../common/service/EventEmitterService/EventEmitter.service';
+import { ServerTaskName } from '../dailyTasks/enum/serverTaskName.enum';
 
 /**
  * Orchestrates matchmaking state transitions.
@@ -73,6 +75,7 @@ export class MatchmakingService {
     private readonly playerService: PlayerService,
     private readonly clanService: ClanService,
     private readonly notifier: MatchmakingNotifier,
+    private readonly emitterService: EventEmitterService,
     @Inject(forwardRef(() => MatchmakingQueue))
     private readonly queue: MatchmakingQueue,
   ) {}
@@ -508,6 +511,8 @@ export class MatchmakingService {
     const leaderboardErrors =
       await this.updateLeaderboardsForFinishedMatch(finishedMatch);
     if (leaderboardErrors) return [null, leaderboardErrors];
+
+    await this.emitDailyTaskEventsForFinishedMatch(finishedMatch);
 
     await this.saveFinishedMatch(finishedMatch);
     await this.invalidateLeaderboardCaches();
@@ -1079,6 +1084,28 @@ export class MatchmakingService {
     }
 
     return null;
+  }
+
+  private async emitDailyTaskEventsForFinishedMatch(match: ActiveMatch) {
+    for (const team of match.teams) {
+      const outcome = this.getTeamOutcome(team, match.result.winningSide);
+      const playerIds = this.getTeamPlayerIds(team);
+
+      for (const playerId of playerIds) {
+        await this.emitterService.EmitNewDailyTaskEvent(
+          playerId,
+          ServerTaskName.PLAY_BATTLE,
+        );
+
+        if (outcome === 'WIN') {
+          await this.emitterService.EmitNewDailyTaskEvent(
+            playerId,
+            ServerTaskName.WIN_BATTLE,
+            true,
+          );
+        }
+      }
+    }
   }
 
   private getTeamOutcome(

--- a/src/matchmaking/matchmaking.service.ts
+++ b/src/matchmaking/matchmaking.service.ts
@@ -44,6 +44,7 @@ import {
 } from './type/matchmakingParticipant.type';
 import { MatchmakingTeam } from './type/matchmakingTeam.type';
 import { Clan } from '../clan/clan.schema';
+import { Score } from '../common/values/scoring.values';
 
 /**
  * Orchestrates matchmaking state transitions.
@@ -58,8 +59,6 @@ export class MatchmakingService {
   private readonly INVITE_TTL_S = 5 * 60;
   private readonly CANCELLED_INVITE_TTL_S = 60;
   private readonly FINISHED_MATCH_TTL_S = 10 * 60;
-  private readonly WIN_BATTLE_POINTS = 50;
-  private readonly LOSS_BATTLE_POINTS = 10;
   private readonly CLAN_OPPONENT_TIMEOUT_S = 30;
   private readonly INVITE_KEY_PREFIX = 'matchmaking:invite';
   private readonly PLAYER_INVITE_KEY_PREFIX = 'matchmaking:player-invite';
@@ -1090,9 +1089,9 @@ export class MatchmakingService {
   }
 
   private getBattlePointsForOutcome(outcome: 'WIN' | 'LOSS') {
-    if (outcome === 'WIN') return this.WIN_BATTLE_POINTS;
+    if (outcome === 'WIN') return Score.BATTLE.WIN;
 
-    return this.LOSS_BATTLE_POINTS;
+    return Score.BATTLE.LOSS;
   }
 
   private getTeamPlayerIds(team: MatchmakingTeam) {

--- a/src/rewarder/clanRewarder/clanRewarder.service.ts
+++ b/src/rewarder/clanRewarder/clanRewarder.service.ts
@@ -31,12 +31,12 @@ export class ClanRewarder {
   clanMaxPoints = 2000;
 
   /**
-   * Increases specified clan points and coins amounts.
+   * Increases specified clan's regular points and coins amounts.
    *
-   * Notice that clan can have 2000 points at max
+   * Notice that clan can have 2000 regular points at max.
    *
    * @param clan_id clan _id for which to increase
-   * @param points amount of points to add, default 0
+   * @param points amount of regular points to add
    * @param coins amount of coins to add, default 0
    * @param session optional client session for transaction
    * @throws ServiceError if clan can not be found during the clan data fetching
@@ -96,9 +96,9 @@ export class ClanRewarder {
   }
 
   /**
-   * Rewards specified clan for an event happen
-   * @param player_id player _id that belongs to the clan to reward
-   * @param clanEvent clan event that happened
+   * Updates a player's clan battlePoints for a battle-related event.
+   * @param player_id player _id that belongs to the clan to update
+   * @param clanEvent battle event that happened
    * @throws MongooseError if any occurred
    * @returns true if clan was rewarded successfully
    */
@@ -106,8 +106,8 @@ export class ClanRewarder {
     player_id: string,
     clanEvent: ClanEvent,
   ): Promise<IServiceReturn<boolean>> {
-    const pointAmount = points[clanEvent];
-    if (pointAmount === undefined)
+    const battlePointAmount = points[clanEvent];
+    if (battlePointAmount === undefined)
       return [
         null,
         [
@@ -137,13 +137,13 @@ export class ClanRewarder {
       ];
     }
 
-    return this.updateClanBattlePoints(player.clan_id, pointAmount);
+    return this.updateClanBattlePoints(player.clan_id, battlePointAmount);
   }
 
   /**
-   * Update specified clan battle points amount
+   * Updates specified clan's battlePoints amount.
    * @param clan_id clan _id
-   * @param battlePoints amount of battle points to increase
+   * @param battlePoints battlePoints delta to apply
    * @throws MongooseError if any occurred
    * @returns true if clan was rewarded successfully
    */

--- a/src/rewarder/clanRewarder/points.ts
+++ b/src/rewarder/clanRewarder/points.ts
@@ -1,6 +1,7 @@
 import { ClanEvent } from './enum/ClanEvent.enum';
+import { Score } from '../../common/values/scoring.values';
 
 export const points: Record<ClanEvent, number> = {
-  [ClanEvent.BATTLE_WON]: 100,
-  [ClanEvent.BATTLE_LOSE]: -20,
+  [ClanEvent.BATTLE_WON]: Score.BATTLE.WIN,
+  [ClanEvent.BATTLE_LOSE]: Score.BATTLE.LOSS,
 };

--- a/src/rewarder/playerRewarder/playerRewarder.service.ts
+++ b/src/rewarder/playerRewarder/playerRewarder.service.ts
@@ -21,9 +21,9 @@ export class PlayerRewarder {
   }
 
   /**
-   * Rewards specified player for an event happen
-   * @param player_id player _id to reward
-   * @param playerEvent happen event
+   * Updates a player's battlePoints for a battle-related event.
+   * @param player_id player _id to update
+   * @param playerEvent battle event that happened
    * @throws MongooseError if any occurred
    * @returns true if player was rewarded successfully
    */
@@ -31,8 +31,8 @@ export class PlayerRewarder {
     player_id: string,
     playerEvent: PlayerEvent,
   ): Promise<IServiceReturn<boolean>> {
-    const pointAmount = points[playerEvent];
-    if (pointAmount === undefined)
+    const battlePointAmount = points[playerEvent];
+    if (battlePointAmount === undefined)
       return [
         null,
         [
@@ -45,13 +45,13 @@ export class PlayerRewarder {
         ],
       ];
 
-    return this.updatePlayerBattlePoints(player_id, pointAmount);
+    return this.updatePlayerBattlePoints(player_id, battlePointAmount);
   }
 
   /**
-   * Rewards specified player for a completed player task
+   * Rewards specified player with regular points for a completed player task.
    * @param player_id player _id to reward
-   * @param points amount of points to reward
+   * @param points amount of regular points to reward
    * @clientSession session to use for transaction
    * @throws MongooseError if any occurred
    * @returns true if player was rewarded successfully
@@ -78,9 +78,9 @@ export class PlayerRewarder {
   }
 
   /**
-   * Increases specified player points amount
+   * Increases specified player's regular points amount.
    * @param player_id player _id
-   * @param points amount of points to increase
+   * @param points amount of regular points to increase
    * @param session optional client session for transaction
    * @throws MongooseError if any occurred
    * @returns true if player was rewarded successfully
@@ -102,9 +102,9 @@ export class PlayerRewarder {
   }
 
   /**
-   * Update specified player battle points amount
+   * Updates specified player's battlePoints amount.
    * @param player_id player _id
-   * @param battlePoints amount of battle points to increase
+   * @param battlePoints battlePoints delta to apply
    * @throws MongooseError if any occurred
    * @returns true if player was rewarded successfully
    */

--- a/src/rewarder/playerRewarder/points.ts
+++ b/src/rewarder/playerRewarder/points.ts
@@ -1,6 +1,7 @@
 import { PlayerEvent } from './enum/PlayerEvent.enum';
+import { Score } from '../../common/values/scoring.values';
 
 export const points: Record<PlayerEvent, number> = {
-  [PlayerEvent.BATTLE_WON]: 100,
-  [PlayerEvent.BATTLE_LOSE]: -20,
+  [PlayerEvent.BATTLE_WON]: Score.BATTLE.WIN,
+  [PlayerEvent.BATTLE_LOSE]: Score.BATTLE.LOSS,
 };


### PR DESCRIPTION
### Brief description

Centralizes battle and daily task scoring around shared `Score` values, updates battle daily task progress handling for both regular battle and matchmaking flows, and makes matchmaking completion resilient to daily task event failures.

Related issue #903 

### Change list

- Use `Score.BATTLE.WIN` and `Score.BATTLE.LOSS` for player, clan, and matchmaking battle point updates.
- Use `Score.DAILY_TASK.COMPLETED` for generated server tasks, default predefined tasks, and UI daily tasks.
- Keep daily task `amount` as a completion requirement only; task points are awarded once on completion.
- Emit `PLAY_BATTLE` daily task progress for both won and lost battles.
- Emit `WIN_BATTLE` daily task progress only for battle winners.
- Add matchmaking daily task progress emission when a match is finished.
- Make matchmaking daily task event emission best-effort so emit failures do not block match completion.
- Add and update tests for shared scoring values, battle point updates, matchmaking leaderboard updates, daily task event emission, and multi-amount task completion behavior.
- Clarify comments and variable naming to distinguish battlePoints updates from regular daily task points.

**Note**

- also scoring in box-session is touched in predefined daily tasks