### PR TITLE
Mongoose CVE mitigated

### DIFF
--- a/src/__tests__/common/function/validateMongoUpdate.test.ts
+++ b/src/__tests__/common/function/validateMongoUpdate.test.ts
@@ -1,0 +1,32 @@
+import { hasUnsafeMongoUpdateKey } from '../../../common/function/validateMongoUpdate';
+
+describe('validateMongoUpdate', () => {
+  it('should allow clean update payloads', () => {
+    const validPayload = { $set: { name: 'John', age: 25 } };
+    expect(hasUnsafeMongoUpdateKey(validPayload)).toBe(false);
+  });
+
+  it('should block __proto__ keys', () => {
+    expect(hasUnsafeMongoUpdateKey({ $set: { '__proto__.polluted': true } })).toBe(true);
+
+    const jsonPayload = JSON.parse('{"__proto__": {"polluted": true}}');
+    expect(hasUnsafeMongoUpdateKey(jsonPayload)).toBe(true);
+  });
+
+  it('should block constructor.prototype keys', () => {
+    expect(hasUnsafeMongoUpdateKey({ $set: { 'constructor.prototype.polluted': true } })).toBe(true);
+  });
+
+  it('should catch deeply nested unsafe keys', () => {
+    const nestedPayload = {
+      $set: {
+        profile: {
+          nested: {
+            '__proto__.admin': true,
+          },
+        },
+      },
+    };
+    expect(hasUnsafeMongoUpdateKey(nestedPayload)).toBe(true);
+  });
+});

--- a/src/common/base/decorator/AddBasicService.decorator.ts
+++ b/src/common/base/decorator/AddBasicService.decorator.ts
@@ -12,6 +12,9 @@ import {
   PostReadAllHookFunction,
   PostReadOneHookFunction,
 } from '../../interface/IHookImplementer';
+import { hasUnsafeMongoUpdateKey } from '../../function/validateMongoUpdate';
+import ServiceError from '../../../common/service/basicService/ServiceError';
+import { SEReason } from '../../../common/service/basicService/SEReason';
 
 export type ClearCollectionReferences = (
   _id: any,
@@ -120,6 +123,17 @@ export const AddBasicService = () => {
       public updateOneById = async (
         input: any,
       ): Promise<object | boolean | MongooseError> => {
+        if (hasUnsafeMongoUpdateKey(input)) {
+          return [
+            null,
+            [
+              new ServiceError({
+                reason: SEReason.VALIDATION,
+                message: 'Dangerous or invalid key path detected in update object',
+              }),
+            ],
+          ];
+        }
         if (!this.updateOnePostHook)
           return this.model.updateOne({ _id: input._id }, input, {
             raw: true,

--- a/src/common/function/validateMongoUpdate.ts
+++ b/src/common/function/validateMongoUpdate.ts
@@ -1,0 +1,42 @@
+// Helper function to mitigate CVE-2026-73562 (Mongoose prototype pollution vulnerability)
+import { BadRequestException } from '@nestjs/common';
+
+export function validateMongoUpdate(value: unknown): void {
+  if (hasUnsafeMongoUpdateKey(value)) {
+    throw new BadRequestException('Invalid or dangerous update key detected');
+  }
+}
+
+export function hasUnsafeMongoUpdateKey(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+
+  const proto = Object.getPrototypeOf(value);
+  const isPlainObjectOrArray =
+    Array.isArray(value) ||
+    proto === null ||
+    proto === Object.prototype;
+
+  if (!isPlainObjectOrArray) return false;
+
+  const keys = Array.isArray(value)
+    ? []
+    : Object.getOwnPropertyNames(value);
+
+  for (const key of keys) {
+    if (
+      key === '__proto__' ||
+      key.startsWith('__proto__.') ||
+      key.includes('.__proto__.') ||
+      key === 'constructor.prototype' ||
+      key.startsWith('constructor.prototype.')
+    ) {
+      return true;
+    }
+
+    if (hasUnsafeMongoUpdateKey((value as Record<string, unknown>)[key])) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/common/service/basicService/BasicService.ts
+++ b/src/common/service/basicService/BasicService.ts
@@ -23,6 +23,7 @@ import {
 } from './IService';
 import ServiceError from './ServiceError';
 import { SEReason } from './SEReason';
+import { hasUnsafeMongoUpdateKey } from '../../function/validateMongoUpdate';
 
 /**
  * Provides all basic operations with DB.
@@ -164,6 +165,17 @@ export default class BasicService implements IService {
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<boolean>> {
     try {
+      if (hasUnsafeMongoUpdateKey(input)) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.VALIDATION,
+              message: 'Dangerous or invalid key path detected in update object',
+            }),
+          ],
+        ];
+      }
       const resp = await this.model.updateOne({ _id }, input, options);
       if (resp.matchedCount === 0)
         return [
@@ -191,6 +203,17 @@ export default class BasicService implements IService {
     options: TIServiceUpdateOneOptions,
   ): Promise<IServiceReturn<boolean>> {
     try {
+      if (hasUnsafeMongoUpdateKey(input)) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.VALIDATION,
+              message: 'Dangerous or invalid key path detected in update object',
+            }),
+          ],
+        ];
+      }
       const { filter, session } = options ? options : { filter: undefined };
       const filterToApply = Array.isArray(filter) ? { $or: filter } : filter;
 
@@ -225,6 +248,17 @@ export default class BasicService implements IService {
     options: TIServiceUpdateManyOptions,
   ): Promise<IServiceReturn<boolean>> {
     try {
+      if (hasUnsafeMongoUpdateKey(input)) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.VALIDATION,
+              message: 'Dangerous or invalid key path detected in update object',
+            }),
+          ],
+        ];
+      }
       const { filter, session } = options ? options : { filter: undefined };
       const filterToApply = Array.isArray(filter) ? { $or: filter } : filter;
 
@@ -259,6 +293,17 @@ export default class BasicService implements IService {
     options?: TIServiceUpdateByIdOptions,
   ): Promise<IServiceReturn<T>> {
     try {
+      if (hasUnsafeMongoUpdateKey(input)) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.VALIDATION,
+              message: 'Dangerous or invalid key path detected in update object',
+            }),
+          ],
+        ];
+      }
       const resp = await this.model.findByIdAndUpdate(_id, input, {
         returnDocument: 'after',
         ...options,
@@ -289,6 +334,17 @@ export default class BasicService implements IService {
     options: TIServiceFindOneAndUpdate,
   ): Promise<IServiceReturn<T>> {
     try {
+      if (hasUnsafeMongoUpdateKey(input)) {
+        return [
+          null,
+          [
+            new ServiceError({
+              reason: SEReason.VALIDATION,
+              message: 'Dangerous or invalid key path detected in update object',
+            }),
+          ],
+        ];
+      }
       const { filter, session, sort } = options
         ? options
         : { filter: undefined };

--- a/src/requestHelper/requestHelper.service.ts
+++ b/src/requestHelper/requestHelper.service.ts
@@ -5,6 +5,9 @@ import { ReferenceToNullType } from './type/ReferenceToNull.type';
 import { IgnoreReferencesType } from '../common/type/ignoreReferences.type';
 import { ModelName } from '../common/enum/modelName.enum';
 import { ClassConstructor, plainToInstance } from 'class-transformer';
+import { hasUnsafeMongoUpdateKey } from '../common/function/validateMongoUpdate';
+import { SEReason } from '../common/service/basicService/SEReason';
+import ServiceError from '../common/service/basicService/ServiceError';
 
 @Injectable()
 export class RequestHelperService {
@@ -119,6 +122,12 @@ export class RequestHelperService {
     _id: string | Types.ObjectId,
     updateObject: object,
   ) => {
+    if (hasUnsafeMongoUpdateKey(updateObject)) {
+      throw new ServiceError({
+        reason: SEReason.VALIDATION,
+        message: 'Dangerous or invalid key path detected in update object',
+      });
+    }
     return this.connection.model(modelName).updateOne({ _id }, updateObject);
   };
 


### PR DESCRIPTION
### Brief description

Closes issue #925 

Added/Adds validation checks to prevent and mitigate MongoDB updates (CVE-2026-73562)


### Change list

- Added `hasUnsafeMongoUpdateKey` and `validateMongoUpdate` utility functions to sanitize update payloads

- Updated `BasicService` to filter out unsafe keys like `__proto__` and `constructor.prototype`

- Added a new unit test to verify prototype pollution attack vector protection

Tested out by passing all unit tests locally on build and test, then with the usual terminal output dump tool: 

```
[capomk@lianli Altzone-Server]$ npx ts-node -e "
import { hasUnsafeMongoUpdateKey, validateMongoUpdate } from './src/common/function/validateMongoUpdate';

const cleanPayload = { \$set: { name: 'PlayerOne', level: 10 } };
const prototypeAttack = JSON.parse('{\"__proto__\": {\"admin\": true}}');
const dotNotationAttack = { \$set: { '__proto__.admin': true } };
const nestedAttack = { \$set: { profile: { 'constructor.prototype.role': 'admin' } } };

console.log('--- CVE-2026-73562 Validation Tests ---');
console.log('1. Clean Payload (Expected: false) ->', hasUnsafeMongoUpdateKey(cleanPayload));
console.log('2. JSON Prototype Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(prototypeAttack));
console.log('3. Dot Notation Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(dotNotationAttack));
console.log('4. Deeply Nested Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(nestedAttack));

try {
  validateMongoUpdate(dotNotationAttack);
} catch (err: any) {
  console.log('5. Exception Handler Test -> Caught expected error:', err.message);
}
"
npm notice run altzone-server@1.0.0 npx
npm notice run 'ts-node' -e 
npm notice run import { hasUnsafeMongoUpdateKey, validateMongoUpdate } from './src/common/function/validateMongoUpdate';
npm notice run
npm notice run const cleanPayload = { $set: { name: 'PlayerOne', level: 10 } };
npm notice run const prototypeAttack = JSON.parse('{"__proto__": {"admin": true}}');
npm notice run const dotNotationAttack = { $set: { '__proto__.admin': true } };
npm notice run const nestedAttack = { $set: { profile: { 'constructor.prototype.role': 'admin' } } };
npm notice run
npm notice run console.log('--- CVE-2026-73562 Validation Tests ---');
npm notice run console.log('1. Clean Payload (Expected: false) ->', hasUnsafeMongoUpdateKey(cleanPayload));
npm notice run console.log('2. JSON Prototype Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(prototypeAttack));
npm notice run console.log('3. Dot Notation Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(dotNotationAttack));
npm notice run console.log('4. Deeply Nested Attack (Expected: true) ->', hasUnsafeMongoUpdateKey(nestedAttack));
npm notice run
npm notice run try {
npm notice run   validateMongoUpdate(dotNotationAttack);
npm notice run } catch (err: any) {
npm notice run   console.log('5. Exception Handler Test -> Caught expected error:', err.message);
npm notice run }
--- CVE-2026-73562 Validation Tests ---
1. Clean Payload (Expected: false) -> false
2. JSON Prototype Attack (Expected: true) -> true
3. Dot Notation Attack (Expected: true) -> true
4. Deeply Nested Attack (Expected: true) -> true
5. Exception Handler Test -> Caught expected error: Invalid or dangerous update key detected
[capomk@lianli Altzone-Server]$
```
