### PR TITLE
907 clarify matchmaking documentation

### DIFF
--- a/src/__tests__/authorization/rule/boxRules.test.ts
+++ b/src/__tests__/authorization/rule/boxRules.test.ts
@@ -6,7 +6,7 @@ import { boxRules } from '../../../authorization/rule/boxRules';
 import { BoxDto } from '../../../box/dto/box.dto';
 
 describe('boxRules() test suite', () => {
-  let boxId = 'boxid';
+  const boxId = 'boxid';
 
   let requestHelperService: RequestHelperService;
   let getModelInstanceById: jest.Mock;
@@ -14,7 +14,7 @@ describe('boxRules() test suite', () => {
   const boxUserBuilder = BoxBuilderFactory.getBuilder('BoxUser');
   const boxAdminUser = boxUserBuilder.setGroupAdmin(true).build();
 
-  beforeEach( async () => {
+  beforeEach(async () => {
     getModelInstanceById = jest.fn();
     requestHelperService = {
       getModelInstanceById,
@@ -32,7 +32,7 @@ describe('boxRules() test suite', () => {
       BoxDto,
       Action.read,
       { _id: boxId } as any,
-      requestHelperService
+      requestHelperService,
     );
 
     expect(ability.can(Action.read_request, BoxDto)).toBe(true);
@@ -41,14 +41,14 @@ describe('boxRules() test suite', () => {
 
   it('Should throw NotFoundException if the room does not exist', async () => {
     getModelInstanceById.mockResolvedValueOnce(null);
-    
+
     await expect(
       boxRules(
         boxAdminUser,
-      BoxDto,
-      Action.read,
-      { _id: boxId } as any,
-      requestHelperService
+        BoxDto,
+        Action.read,
+        { _id: boxId } as any,
+        requestHelperService,
       ),
     ).rejects.toThrow(NotFoundException);
   });
@@ -65,7 +65,7 @@ describe('boxRules() test suite', () => {
         BoxDto,
         Action.read,
         { _id: boxId } as any,
-        requestHelperService
+        requestHelperService,
       ),
     ).rejects.toThrow(ForbiddenException);
   });

--- a/src/__tests__/gameData/dto/startBattleDto.test.ts
+++ b/src/__tests__/gameData/dto/startBattleDto.test.ts
@@ -10,7 +10,7 @@ describe('StartBattleDto test suite', () => {
 
   function createDto(overrides: Partial<StartBattleDto> = {}) {
     const dto = new StartBattleDto();
-    dto.gameType = GameType.MATCHMAKING;
+    dto.gameType = GameType.CASUAL;
     dto.team1 = [player1Id];
     dto.team2 = [player2Id];
 
@@ -26,11 +26,20 @@ describe('StartBattleDto test suite', () => {
   });
 
   it('Should pass validation with a MongoId matchId', async () => {
-    const dto = createDto({ matchId });
+    const dto = createDto({ gameType: GameType.CUSTOM, matchId });
 
     const errors = await validate(dto);
 
     expect(errors).toHaveLength(0);
+  });
+
+  it('Should fail validation when gameType is matchmaking', async () => {
+    const dto = createDto({ gameType: GameType.MATCHMAKING as any });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('gameType');
   });
 
   it('Should fail validation with a non-MongoId matchId', async () => {

--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -11,21 +11,10 @@ describe('GameDataService battle lifecycle test suite', () => {
   const gameDataModel = GameDataModule.getGameModel();
 
   let gameDataService: GameDataService;
-  let matchmakingService: {
-    validateBattleStart: jest.Mock;
-  };
 
   beforeEach(async () => {
     await gameDataModel.deleteMany({});
     gameDataService = await GameDataModule.getGameDataService();
-    matchmakingService = {
-      validateBattleStart: jest.fn(async () => null),
-    };
-    (
-      gameDataService as unknown as {
-        matchmakingService: typeof matchmakingService;
-      }
-    ).matchmakingService = matchmakingService;
     jest
       .spyOn(gameDataService.playerService, 'getPlayerById')
       .mockImplementation(async (playerId: string) => [
@@ -43,7 +32,7 @@ describe('GameDataService battle lifecycle test suite', () => {
 
     const battle = await gameDataService.registerBattle(
       {
-        gameType: GameType.MATCHMAKING,
+        gameType: GameType.CUSTOM,
         team1: [team1PlayerId, team1SecondPlayerId],
         team2: [team2PlayerId, team2SecondPlayerId],
         matchId,
@@ -56,16 +45,10 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(battle).not.toBeInstanceOf(ServiceError);
     const battleDocument = battle as Exclude<typeof battle, ServiceError>;
     expect(battleDocument._id.toString()).toBe(matchId);
-    expect(battleDocument.gameType).toBe(GameType.MATCHMAKING);
+    expect(battleDocument.gameType).toBe(GameType.CUSTOM);
     expect(battleInDb?._id.toString()).toBe(matchId);
-    expect(battleInDb?.gameType).toBe(GameType.MATCHMAKING);
+    expect(battleInDb?.gameType).toBe(GameType.CUSTOM);
     expect(battleInDb?.status).toBe(BattleStatus.OPEN);
-    expect(matchmakingService.validateBattleStart).toHaveBeenCalledWith(
-      matchId,
-      team1PlayerId,
-      [team1PlayerId, team1SecondPlayerId],
-      [team2PlayerId, team2SecondPlayerId],
-    );
   });
 
   it('Should submit a battle result by finding the battle with matchId as _id', async () => {
@@ -75,7 +58,7 @@ describe('GameDataService battle lifecycle test suite', () => {
 
     await gameDataService.registerBattle(
       {
-        gameType: GameType.MATCHMAKING,
+        gameType: GameType.CASUAL,
         team1: [team1PlayerId],
         team2: [team2PlayerId],
         matchId,
@@ -215,7 +198,7 @@ describe('GameDataService battle lifecycle test suite', () => {
     const team2PlayerId = new Types.ObjectId().toHexString();
     const battle: Partial<Game> = {
       _id: matchId,
-      gameType: GameType.MATCHMAKING,
+      gameType: GameType.CASUAL,
       team1: [team1PlayerId],
       team2: [team2PlayerId],
       status: BattleStatus.PROCESSING,
@@ -246,45 +229,14 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(battleInDb?.finalWinner).toBe(1);
   });
 
-  it('Should return REQUIRED error when matchmaking battle is registered without matchId', async () => {
+  it('Should not register a matchmaking battle through battle start', async () => {
     const team1PlayerId = new Types.ObjectId().toHexString();
     const team2PlayerId = new Types.ObjectId().toHexString();
-
-    const result = await gameDataService.registerBattle(
-      {
-        gameType: GameType.MATCHMAKING,
-        team1: [team1PlayerId],
-        team2: [team2PlayerId],
-      },
-      team1PlayerId,
-    );
-
-    expect(result).toBeInstanceOf(ServiceError);
-    expect(result).toMatchObject({
-      reason: SEReason.REQUIRED,
-      field: 'matchId',
-      message: 'Matchmaking battles require matchId.',
-    });
-    expect(matchmakingService.validateBattleStart).not.toHaveBeenCalled();
-    expect(await gameDataModel.countDocuments()).toBe(0);
-  });
-
-  it('Should not register a matchmaking battle when matchmaking validation fails', async () => {
     const matchId = new Types.ObjectId().toHexString();
-    const team1PlayerId = new Types.ObjectId().toHexString();
-    const team2PlayerId = new Types.ObjectId().toHexString();
-    const validationError = new ServiceError({
-      reason: SEReason.VALIDATION,
-      field: 'teams',
-      message: 'Battle teams must match the active matchmaking match teams.',
-    });
-    matchmakingService.validateBattleStart.mockResolvedValueOnce([
-      validationError,
-    ]);
 
     const result = await gameDataService.registerBattle(
       {
-        gameType: GameType.MATCHMAKING,
+        gameType: GameType.MATCHMAKING as any,
         team1: [team1PlayerId],
         team2: [team2PlayerId],
         matchId,
@@ -292,8 +244,13 @@ describe('GameDataService battle lifecycle test suite', () => {
       team1PlayerId,
     );
 
-    expect(result).toBe(validationError);
-    expect(await gameDataModel.findById(matchId)).toBeNull();
+    expect(result).toBeInstanceOf(ServiceError);
+    expect(result).toMatchObject({
+      reason: SEReason.WRONG_ENUM,
+      field: 'gameType',
+      value: GameType.MATCHMAKING,
+    });
+    expect(await gameDataModel.countDocuments()).toBe(0);
   });
 
   it('Should not register a battle when requester is not in either team', async () => {

--- a/src/gameData/dto/startBattle.dto.ts
+++ b/src/gameData/dto/startBattle.dto.ts
@@ -1,13 +1,17 @@
-import { IsEnum, IsArray, IsMongoId, IsOptional } from 'class-validator';
+import { IsArray, IsIn, IsMongoId, IsOptional } from 'class-validator';
 import { GameType } from '../enum/gameType.enum';
 
 export class StartBattleDto {
   /**
    * Type of the game session
-   * @example "matchmaking"
+   * Allowed GameTypes: "custom" and "casual"
+   *
+   * Matchmaking is handled via MQTT events
+   *
+   * @example "casual"
    */
-  @IsEnum(GameType)
-  gameType: GameType;
+  @IsIn([GameType.CUSTOM, GameType.CASUAL])
+  gameType: GameType.CUSTOM | GameType.CASUAL;
 
   /**
    * List of player IDs for Team 1

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -82,7 +82,7 @@ export class GameDataController {
     },
     errors: [400, 401, 403],
   })
-  @Post('battle/start')
+  @Post('battle/start') // matchmaking is handled via MQTT only, not from this endpoint
   @UniformResponse()
   async startBattle(
     @LoggedUser() user: User, // require logged-in user

--- a/src/gameData/gameData.module.ts
+++ b/src/gameData/gameData.module.ts
@@ -8,8 +8,6 @@ import { ClanModule } from '../clan/clan.module';
 import { ClanInventoryModule } from '../clanInventory/clanInventory.module';
 import { GameEventsHandlerModule } from '../gameEventsHandler/gameEventsHandler.module';
 import { EventEmitterCommonModule } from '../common/service/EventEmitterService/EventEmitterCommon.module';
-import { MatchmakingModule } from '../matchmaking/matchmaking.module';
-
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Game.name, schema: GameSchema }]),
@@ -18,7 +16,6 @@ import { MatchmakingModule } from '../matchmaking/matchmaking.module';
     ClanInventoryModule,
     GameEventsHandlerModule,
     EventEmitterCommonModule,
-    MatchmakingModule,
   ],
   providers: [GameDataService],
   controllers: [GameDataController],

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -23,7 +23,6 @@ import { IServiceReturn } from '../common/service/basicService/IService';
 import { SEReason } from '../common/service/basicService/SEReason';
 import { Environment } from '../common/enum/environment.enum';
 import { GameType } from './enum/gameType.enum';
-import { MatchmakingService } from '../matchmaking/matchmaking.service';
 
 @Injectable()
 export class GameDataService {
@@ -34,7 +33,6 @@ export class GameDataService {
     public readonly roomService: RoomService,
     private readonly gameEventsBroker: GameEventsHandler,
     private readonly jwtService: JwtService,
-    private readonly matchmakingService: MatchmakingService,
   ) {
     this.basicService = new BasicService(model);
     this.refsInModel = [ModelName.STOCK];
@@ -345,6 +343,15 @@ export class GameDataService {
     dto: StartBattleDto,
     requesterPlayerId: string,
   ): Promise<GameDocument | ServiceError> {
+    if (![GameType.CASUAL, GameType.CUSTOM].includes(dto.gameType)) {
+      return new ServiceError({
+        reason: SEReason.WRONG_ENUM,
+        field: 'gameType',
+        value: dto.gameType,
+        message: 'Battle start supports only casual and custom game types.',
+      });
+    }
+
     // is requester PlayerId in team1 or in team2?
     if (
       !dto.team1.includes(requesterPlayerId) &&
@@ -407,25 +414,6 @@ export class GameDataService {
         reason: SEReason.MISCONFIGURED,
         message: 'A player cannot be in both teams',
       });
-    }
-
-    if (dto.gameType === GameType.MATCHMAKING && !dto.matchId) {
-      return new ServiceError({
-        reason: SEReason.REQUIRED,
-        field: 'matchId',
-        message: 'Matchmaking battles require matchId.',
-      });
-    }
-
-    if (dto.gameType === GameType.MATCHMAKING) {
-      const matchmakingErrors =
-        await this.matchmakingService.validateBattleStart(
-          dto.matchId,
-          requesterPlayerId,
-          dto.team1,
-          dto.team2,
-        );
-      if (matchmakingErrors) return matchmakingErrors[0];
     }
 
     // create a new battle record in the database


### PR DESCRIPTION
### Brief description

The title is a bit misleading, the point of this PR is to keep matchmaking flow handled via MQTT. Into `gameData.controller.ts` is added into comments, that matchmaking is handled through MQTT only.

Remove `matchmaking` as a supported `gameType` for `POST /gameData/battle/start`. Matchmaking battle flow now stays fully under the `/matchmaking` endpoints and MQTT events, while `casual` and `custom` battle starts remain unchanged.

Related issue: #907 Edit: In yesterday's meeting was ensured, that matchmaking is used via MQTT only on the backend.

### Change list

- Updated battle lifecycle tests to use `casual`/`custom` instead of `matchmaking` for `battle/start`.
- Added coverage to ensure `gameType="matchmaking"` does not create a battle through `battle/start`.
- Updated `StartBattleDto` validation tests to reject `matchmaking`.
- Restricted `StartBattleDto.gameType` runtime validation to `custom` and `casual`.
- Added service-level guard returning `WRONG_ENUM` for unsupported battle-start game types.
- Verified with `npm test -- gameData --runInBand` and `npm test -- matchmaking --runInBand`.

**Note**

I had to change in one older test file `let` to `const` to get any commits through.