### PR TITLE
908 bug calling post gamedatabattle causes runtime error

### DIFF
--- a/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
+++ b/src/__tests__/gameData/gameDataService/battleLifecycle.test.ts
@@ -6,6 +6,7 @@ import { GameType } from '../../../gameData/enum/gameType.enum';
 import { BattleStatus } from '../../../gameData/enum/battleStatus.enum';
 import ServiceError from '../../../common/service/basicService/ServiceError';
 import { SEReason } from '../../../common/service/basicService/SEReason';
+import { JwtService } from '@nestjs/jwt';
 
 describe('GameDataService battle lifecycle test suite', () => {
   const gameDataModel = GameDataModule.getGameModel();
@@ -29,9 +30,24 @@ describe('GameDataService battle lifecycle test suite', () => {
     jest
       .spyOn(gameDataService.playerService, 'getPlayerById')
       .mockImplementation(async (playerId: string) => [
-        { _id: playerId } as any,
+        {
+          _id: playerId,
+          clan_id: new Types.ObjectId().toHexString(),
+        } as any,
         null,
       ]);
+    jest.spyOn(gameDataService.clanService, 'readOneById').mockResolvedValue([
+      {
+        SoulHome: {
+          _id: new Types.ObjectId().toHexString(),
+        },
+      } as any,
+      null,
+    ]);
+    jest
+      .spyOn(gameDataService.roomService, 'readAllSoulHomeRooms')
+      .mockResolvedValue([[] as any, null]);
+    jest.spyOn(JwtService.prototype, 'signAsync').mockResolvedValue('token');
   });
 
   it('Should register a battle using the provided matchId as document _id', async () => {
@@ -54,7 +70,7 @@ describe('GameDataService battle lifecycle test suite', () => {
     const battleInDb = await gameDataModel.findById(matchId);
 
     expect(battle).not.toBeInstanceOf(ServiceError);
-    const battleDocument = battle as Exclude<typeof battle, ServiceError>;
+    const battleDocument = battle as any;
     expect(battleDocument._id.toString()).toBe(matchId);
     expect(battleDocument.gameType).toBe(GameType.MATCHMAKING);
     expect(battleInDb?._id.toString()).toBe(matchId);
@@ -93,13 +109,188 @@ describe('GameDataService battle lifecycle test suite', () => {
     );
 
     expect(battle).not.toBeInstanceOf(ServiceError);
-    const battleDocument = battle as Exclude<typeof battle, ServiceError>;
+    expect(battle).toMatchObject({
+      stealToken: 'token',
+      roomIds: [],
+    });
+    const battleDocument = (battle as any).battleDocument;
     expect(battleDocument._id.toString()).toBe(matchId);
     expect(battleDocument.receivedResults).toHaveLength(1);
     expect(battleDocument.receivedResults[0].playerId.toString()).toBe(
       team1PlayerId,
     );
     expect(battleDocument.status).toBe(BattleStatus.OPEN);
+  });
+
+  it('Should return steal data when matching results complete the battle for a winning player', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1ClanId = new Types.ObjectId().toHexString();
+    const team2ClanId = new Types.ObjectId().toHexString();
+    const loserSoulHomeId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team1SecondPlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    jest
+      .spyOn(gameDataService.playerService, 'getPlayerById')
+      .mockImplementation(async (playerId: string) => [
+        {
+          _id: playerId,
+          clan_id: playerId === team2PlayerId ? team2ClanId : team1ClanId,
+        } as any,
+        null,
+      ]);
+    jest.spyOn(gameDataService.clanService, 'readOneById').mockResolvedValue([
+      {
+        _id: team2ClanId,
+        SoulHome: {
+          _id: loserSoulHomeId,
+        },
+      } as any,
+      null,
+    ]);
+    jest
+      .spyOn(gameDataService.roomService, 'readAllSoulHomeRooms')
+      .mockResolvedValue([[{ _id: 'room-1' }, { _id: 'room-2' }] as any, null]);
+    const signAsyncSpy = jest
+      .spyOn(JwtService.prototype, 'signAsync')
+      .mockResolvedValue('steal-token');
+
+    await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId, team1SecondPlayerId],
+        team2: [team2PlayerId],
+        matchId,
+      },
+      team1PlayerId,
+    );
+
+    const firstResult = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      team1PlayerId,
+    );
+    const completedResult = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 115,
+        result: 1,
+      } as any,
+      team1SecondPlayerId,
+    );
+
+    expect(firstResult).not.toBeInstanceOf(ServiceError);
+    expect(firstResult).toMatchObject({
+      stealToken: 'steal-token',
+      soulHome_id: loserSoulHomeId,
+      roomIds: ['room-1', 'room-2'],
+    });
+    expect(completedResult).not.toBeInstanceOf(ServiceError);
+    expect(completedResult).toMatchObject({
+      stealToken: 'steal-token',
+      soulHome_id: loserSoulHomeId,
+      roomIds: ['room-1', 'room-2'],
+    });
+    expect((completedResult as any).battleDocument.status).toBe(
+      BattleStatus.COMPLETED,
+    );
+    expect((completedResult as any).battleDocument.finalWinner).toBe(1);
+    expect(signAsyncSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        playerId: team1PlayerId,
+        soulHomeId: loserSoulHomeId,
+      },
+      { expiresIn: '15m' },
+    );
+    expect(signAsyncSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        playerId: team1SecondPlayerId,
+        soulHomeId: loserSoulHomeId,
+      },
+      { expiresIn: '15m' },
+    );
+  });
+
+  it('Should return steal data when a losing player completes the battle', async () => {
+    const matchId = new Types.ObjectId().toHexString();
+    const team1ClanId = new Types.ObjectId().toHexString();
+    const team2ClanId = new Types.ObjectId().toHexString();
+    const loserSoulHomeId = new Types.ObjectId().toHexString();
+    const team1PlayerId = new Types.ObjectId().toHexString();
+    const team2PlayerId = new Types.ObjectId().toHexString();
+
+    jest
+      .spyOn(gameDataService.playerService, 'getPlayerById')
+      .mockImplementation(async (playerId: string) => [
+        {
+          _id: playerId,
+          clan_id: playerId === team2PlayerId ? team2ClanId : team1ClanId,
+        } as any,
+        null,
+      ]);
+    jest.spyOn(gameDataService.clanService, 'readOneById').mockResolvedValue([
+      {
+        _id: team2ClanId,
+        SoulHome: {
+          _id: loserSoulHomeId,
+        },
+      } as any,
+      null,
+    ]);
+    jest
+      .spyOn(gameDataService.roomService, 'readAllSoulHomeRooms')
+      .mockResolvedValue([[{ _id: 'room-1' }] as any, null]);
+    const signAsyncSpy = jest
+      .spyOn(JwtService.prototype, 'signAsync')
+      .mockResolvedValue('token');
+
+    await gameDataService.registerBattle(
+      {
+        gameType: GameType.CASUAL,
+        team1: [team1PlayerId],
+        team2: [team2PlayerId],
+        matchId,
+      },
+      team1PlayerId,
+    );
+
+    await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      team1PlayerId,
+    );
+    const losingPlayerResult = await gameDataService.handleBattleResult(
+      {
+        matchId,
+        duration: 120,
+        result: 1,
+      } as any,
+      team2PlayerId,
+    );
+    expect(losingPlayerResult).toMatchObject({
+      stealToken: 'token',
+      soulHome_id: loserSoulHomeId,
+      roomIds: ['room-1'],
+    });
+    expect((losingPlayerResult as any).battleDocument.status).toBe(
+      BattleStatus.COMPLETED,
+    );
+    expect(signAsyncSpy).toHaveBeenCalledWith(
+      {
+        playerId: team1PlayerId,
+        soulHomeId: loserSoulHomeId,
+      },
+      { expiresIn: '15m' },
+    );
   });
 
   it('Should reject battle result from a player outside the battle teams', async () => {
@@ -124,6 +315,7 @@ describe('GameDataService battle lifecycle test suite', () => {
       } as any,
       outsiderPlayerId,
     );
+
     const battleInDb = await gameDataModel.findById(matchId);
 
     expect(result).toBeInstanceOf(ServiceError);
@@ -133,6 +325,7 @@ describe('GameDataService battle lifecycle test suite', () => {
       value: outsiderPlayerId,
       message: 'Only battle participants can submit battle results.',
     });
+
     expect(battleInDb?.receivedResults).toHaveLength(0);
   });
 
@@ -163,6 +356,7 @@ describe('GameDataService battle lifecycle test suite', () => {
       } as any,
       team1PlayerId,
     );
+
     const battleInDb = await gameDataModel.findById(matchId);
 
     expect(result).toBeInstanceOf(ServiceError);
@@ -175,7 +369,7 @@ describe('GameDataService battle lifecycle test suite', () => {
     expect(battleInDb?.receivedResults).toHaveLength(1);
   });
 
-  it('Should reject battle result for a completed battle', async () => {
+  it('Should reject steal data request for a completed battle when the player has not submitted a result', async () => {
     const matchId = new Types.ObjectId().toHexString();
     const team1PlayerId = new Types.ObjectId().toHexString();
     const team2PlayerId = new Types.ObjectId().toHexString();
@@ -197,14 +391,15 @@ describe('GameDataService battle lifecycle test suite', () => {
       } as any,
       team1PlayerId,
     );
+
     const battleInDb = await gameDataModel.findById(matchId);
 
     expect(result).toBeInstanceOf(ServiceError);
     expect(result).toMatchObject({
       reason: SEReason.NOT_ALLOWED,
-      field: 'status',
-      value: BattleStatus.COMPLETED,
-      message: 'Completed battle cannot receive new results.',
+      field: 'playerId',
+      value: team1PlayerId,
+      message: 'Player must submit a result before receiving steal data.',
     });
     expect(battleInDb?.receivedResults).toHaveLength(0);
   });

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -152,7 +152,7 @@ export class GameDataController {
 
     return this.service.handleBattleResult(
       legacyDto as BattleResultDto,
-      user.player_id,
+      user,
     );
   }
 }

--- a/src/gameData/gameData.controller.ts
+++ b/src/gameData/gameData.controller.ts
@@ -150,9 +150,6 @@ export class GameDataController {
     legacyDto.result = SubmitResultDto.result;
     legacyDto.duration = SubmitResultDto.duration;
 
-    return this.service.handleBattleResult(
-      legacyDto as BattleResultDto,
-      user,
-    );
+    return this.service.handleBattleResult(legacyDto as BattleResultDto, user);
   }
 }

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -446,18 +446,46 @@ export class GameDataService {
   }
 
   /**
-   * Processes a result claim from a player.
-   * If results from both teams match, the battle is marked COMPLETED.
-   * If results don't match, the battle enters PROCESSING and triggers a timeout-based resolution.
-   * * @param dto - The result containing matchId, winning team, and duration.
-   * @param playerId - The ID of the player submitting the result.
-   * @returns A promise to the updated Battle document.
+   * Processes a result claim for an existing battle.
+   *
+   * A valid result from a player in the claimed winning team returns the steal
+   * token and target SoulHome data immediately. The first valid result keeps
+   * the battle OPEN. When at least two submitted results agree on the winning
+   * team, the battle is marked COMPLETED. If a losing player completes the
+   * battle, the token is generated for a winning player who has already
+   * submitted a matching result.
+   *
+   * If submitted results disagree, the battle enters PROCESSING and a
+   * timeout-based final call resolves the winner later.
+   *
+   * @param dto - The result containing matchId, winning team, and duration.
+   * @param userOrPlayerId - The authenticated user or submitting player ID.
+   * @returns The saved battle document, or a completed battle response with steal data for a winning player.
    * @throws Error if the matchId is not found in the database.
    */
-  async handleBattleResult(dto: BattleResultDto, playerId: string) {
+  async handleBattleResult(
+    dto: BattleResultDto,
+    userOrPlayerId: User | string,
+  ): Promise<GameDocument | object | ServiceError> {
     const battle = await this.model.findById(dto.matchId);
     if (!battle) throw new Error('Match not found');
 
+    // Accept the old playerId call shape used by tests while supporting the controller's User object.
+    const user =
+      typeof userOrPlayerId === 'string'
+        ? ({ player_id: userOrPlayerId } as User)
+        : userOrPlayerId;
+    const playerId = user.player_id;
+    if (!playerId) {
+      return new ServiceError({
+        reason: SEReason.NOT_AUTHORIZED,
+        field: 'playerId',
+        value: playerId,
+        message: 'Player ID is required to submit battle results.',
+      });
+    }
+
+    // Only battle participants may affect the result tally.
     const isBattleParticipant =
       battle.team1.some((id) => id.toString() === playerId) ||
       battle.team2.some((id) => id.toString() === playerId);
@@ -470,18 +498,19 @@ export class GameDataService {
       });
     }
 
-    if (battle.status === BattleStatus.COMPLETED) {
-      return new ServiceError({
-        reason: SEReason.NOT_ALLOWED,
-        field: 'status',
-        value: battle.status,
-        message: 'Completed battle cannot receive new results.',
-      });
-    }
-
+    // A player may submit only once, so later consensus is built from separate players' claims.
     const hasSubmittedResult = battle.receivedResults.some(
       (result) => result.playerId.toString() === playerId,
     );
+
+    if (battle.status === BattleStatus.COMPLETED) {
+      return await this.generateCompletedBattleResponse(
+        battle,
+        user,
+        hasSubmittedResult,
+      );
+    }
+
     if (hasSubmittedResult) {
       return new ServiceError({
         reason: SEReason.NOT_ALLOWED,
@@ -497,6 +526,7 @@ export class GameDataService {
       duration: dto.duration,
     });
 
+    // Two matching submissions are enough to finalize the battle immediately.
     if (battle.receivedResults.length >= 2) {
       const results = battle.receivedResults.map((r) => r.winnerTeam);
       const allMatch = results.every((val) => val === results[0]);
@@ -504,17 +534,153 @@ export class GameDataService {
       if (allMatch) {
         battle.status = BattleStatus.COMPLETED;
         battle.finalWinner = results[0];
-        await battle.save();
-        return await this.generateRaidTokens(battle);
+        const battleDocument = await battle.save();
+
+        // Return steal data in the same PUT response that completes the battle.
+        return await this.generateCompletedBattleResponse(
+          battleDocument,
+          user,
+          true,
+          true,
+        );
       } else {
         battle.status = BattleStatus.PROCESSING;
         this.startFinalCallTimer(battle._id.toString());
       }
     } else {
+      // Keep the battle open until another participant submits a matching or conflicting result.
       battle.status = BattleStatus.OPEN;
     }
 
-    return await battle.save();
+    const battleDocument = await battle.save();
+
+    const claimedWinningTeam = dto.result === 1 ? battle.team1 : battle.team2;
+    const playerInClaimedWinningTeam = claimedWinningTeam.some(
+      (id) => id.toString() === playerId,
+    );
+
+    if (playerInClaimedWinningTeam) {
+      return await this.generateBattleStealResponse(
+        battleDocument,
+        dto.result,
+        user,
+        playerId,
+      );
+    }
+
+    return battleDocument;
+  }
+
+  private async generateCompletedBattleResponse(
+    battle: GameDocument,
+    user: User,
+    hasSubmittedResult: boolean,
+    allowSubmittedWinnerFallback = false,
+  ): Promise<object | ServiceError> {
+    const battleDocument = battle;
+    const playerId = user.player_id;
+
+    // Losing players can complete the battle, but they must not receive a steal token.
+    const winningTeam = battle.finalWinner === 1 ? battle.team1 : battle.team2;
+    const playerInWinningTeam = winningTeam.some(
+      (id) => id.toString() === playerId,
+    );
+
+    const tokenPlayerId = playerInWinningTeam
+      ? playerId
+      : this.getSubmittedWinningPlayerId(battle);
+
+    if (!playerInWinningTeam && !allowSubmittedWinnerFallback) {
+      return {
+        battleDocument,
+      };
+    }
+
+    if (!tokenPlayerId) {
+      return {
+        battleDocument,
+      };
+    }
+
+    if (playerInWinningTeam && !hasSubmittedResult) {
+      return new ServiceError({
+        reason: SEReason.NOT_ALLOWED,
+        field: 'playerId',
+        value: playerId,
+        message: 'Player must submit a result before receiving steal data.',
+      });
+    }
+
+    return await this.generateBattleStealResponse(
+      battleDocument,
+      battle.finalWinner,
+      user,
+      tokenPlayerId,
+    );
+  }
+
+  private async generateBattleStealResponse(
+    battle: GameDocument,
+    winnerTeam: number,
+    user: User,
+    tokenPlayerId: string,
+  ): Promise<object | ServiceError> {
+    // Use the legacy response builder so PUT returns the same steal payload as POST.
+    const [teamIds, teamIdsErrors] = await this.getClanIdForTeams([
+      battle.team1[0].toString(),
+      battle.team2[0].toString(),
+    ]);
+
+    if (teamIdsErrors) {
+      return new ServiceError({
+        reason: SEReason.NOT_FOUND,
+        field: 'teamIds',
+        value: [battle.team1[0].toString(), battle.team2[0].toString()],
+        message: 'One or both teams do not exist.',
+        additional: teamIdsErrors,
+      });
+    }
+
+    const [battleResponse, battleResponseErrors] = await this.generateResponse(
+      {
+        matchId: battle._id.toString(),
+        team1: battle.team1.map((id) => id.toString()),
+        team2: battle.team2.map((id) => id.toString()),
+        result: winnerTeam,
+        duration: 0,
+      } as BattleResultDto,
+      teamIds.team1Id,
+      teamIds.team2Id,
+      { ...user, player_id: tokenPlayerId },
+    );
+
+    // Surface token/room lookup failures as service errors after the battle has been finalized.
+    if (battleResponseErrors) {
+      return new ServiceError({
+        reason: SEReason.UNEXPECTED,
+        field: 'battleResponse',
+        value: battleResponse,
+        message: 'Unexpected error while generating battle response.',
+        additional: battleResponseErrors,
+      });
+    }
+
+    return {
+      battleDocument: battle,
+      ...battleResponse,
+    };
+  }
+
+  private getSubmittedWinningPlayerId(battle: GameDocument): string | null {
+    const winningTeam = battle.finalWinner === 1 ? battle.team1 : battle.team2;
+
+    const winningPlayerResult = battle.receivedResults.find((result) =>
+      winningTeam.some(
+        (playerId) => playerId.toString() === result.playerId.toString(),
+      ),
+    );
+
+    return winningPlayerResult?.playerId.toString() ?? null;
   }
 
   /**

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -208,6 +208,9 @@ export class GameDataService {
 
     if (!game) return false;
 
+    // return false, if endedAt doesn't exist to avoid run time crash
+    if (!game.endedAt) return false;
+    
     if (game.endedAt.getTime() < currentTime.getTime() - 30 * 1000)
       return false;
 

--- a/src/gameData/gameData.service.ts
+++ b/src/gameData/gameData.service.ts
@@ -210,7 +210,7 @@ export class GameDataService {
 
     // return false, if endedAt doesn't exist to avoid run time crash
     if (!game.endedAt) return false;
-    
+
     if (game.endedAt.getTime() < currentTime.getTime() - 30 * 1000)
       return false;
 


### PR DESCRIPTION
### Brief description

Handle case, where `endedAt` (`gameAlreadyExists` function in `gameData.service.ts`) field is not found and add `stealToken` support to the new `PUT /gameData/battle/result` flow.

### Postman testing

After adding code line `if (!game.endedAt) return false;`

```
{
    "data": {
        "Object": {
            "stealToken": "...",
            "soulHome_id": "6a06dc34058c7fd326e2b31b",
            "roomIds": [
                "6a06dc34058c7fd326e2b31d",
                "6a06dc34058c7fd326e2b31f",
				...
				]
```

Was: run time error.

`PUT /gameData/battle/result`: (1 vs. 1)

```
{
    "battleDocument": {
        "_id": "6a8ebce5f76e9f4af9642c32",
        "team1": [
            "69ef8b7332f46bd743f4c54e"
        ],
        "team2": [
            "69f485c5fbe1d439c999ac6a"
        ],
        "gameType": "casual",
        "status": "OPEN",
        "receivedResults": [
            {
                "playerId": "69ef8b7332f46bd743f4c54e",
                "winnerTeam": 1,
                "duration": 120,
                "_id": "6a8ebd00f76e9f4af9642c38",
                "receivedAt": "2026-08-26T10:16:32.469Z",
                "id": "6a8ebd00f76e9f4af9642c38"
            }
        ],
        "__v": 1,
        "id": "6a8ebce5f76e9f4af9642c32"
    },
    "stealToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwbGF5ZXJJZCI6IjY5ZWY4YjczMzJmNDZiZDc0M2Y0YzU0ZSIsInNvdWxIb21lSWQiOiI2YTA2ZGMzNDA1OGM3ZmQzMjZlMmIzMWIiLCJpYXQiOjE3ODc3MzkzOTIsImV4cCI6MTc4Nzc0MDI5Mn0.ABvXAEqPS9xvgivy-IFjYsooy0gOEr4I7vz_IgfmZuA",
    "soulHome_id": "6a06dc34058c7fd326e2b31b",
    "roomIds": [
        "6a06dc34058c7fd326e2b31d",
        "6a06dc34058c7fd326e2b31f",
```


### Change list

- Updated `handleBattleResult` to return steal data for valid winning result submissions.
- Added completed-battle response handling that includes `stealToken`, `soulHome_id`, and `roomIds`.
- Reused the legacy battle response generation logic for consistent steal payload behavior.
- Added fallback token generation when a losing player completes the battle, using a submitted winning player as the token owner.
- Updated JSDoc and inline comments for the new result/steal-token behavior.
- Updated `battleLifecycle.test.ts` to cover steal-token responses from `PUT /gameData/battle/result`.