### PR TITLE
Modified auth interceptor and added a test on top

### DIFF
--- a/src/__tests__/authorization/authorizationInterceptor.array.test.ts
+++ b/src/__tests__/authorization/authorizationInterceptor.array.test.ts
@@ -1,0 +1,77 @@
+import { AuthorizationInterceptor } from '../../authorization/authorization.interceptor';
+import { ExecutionContext } from '@nestjs/common';
+import { of } from 'rxjs';
+import { User } from '../../auth/user';
+import { createMongoAbility, AbilityBuilder } from '@casl/ability';
+
+describe('AuthorizationInterceptor - Array Payload Handling', () => {
+  let interceptor: AuthorizationInterceptor;
+  let mockCaslFactory: any;
+  let mockReflector: any;
+
+  // Define the DTO class for the test
+  class TestDto {
+    _id!: string;
+    name!: string;
+  }
+
+  beforeEach(() => {
+    const { can, build } = new AbilityBuilder(createMongoAbility);
+    
+    // Grant permissions here for the test user
+    can('update_request', TestDto);
+    const realAbility = build();
+
+    mockCaslFactory = {
+      createForUser: jest.fn().mockResolvedValue(realAbility),
+    };
+
+    mockReflector = {
+      get: jest.fn().mockReturnValue({
+        action: 'update',
+        subject: TestDto,
+      }),
+    };
+
+    interceptor = new AuthorizationInterceptor(mockCaslFactory, mockReflector);
+  });
+
+  it('should process array payloads without throwing 403 or stripping items', async () => {
+    const requestBody = [
+      { _id: 'room_1', name: 'Living Room' },
+      { _id: 'room_2', name: 'Bedroom' },
+    ];
+
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          user: mockUser,
+          body: requestBody,
+          params: {},
+        }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = {
+      handle: jest.fn().mockReturnValue(of({ data: 'ok' })),
+    };
+
+    const result$ = await interceptor.intercept(
+      mockExecutionContext,
+      mockCallHandler,
+    );
+
+    result$.subscribe({
+      next: () => {
+        const request = mockExecutionContext.switchToHttp().getRequest();
+        expect(Array.isArray(request.body)).toBe(true);
+        expect(request.body.length).toBe(2);
+        expect(request.body[0]._id).toBe('room_1');
+        expect(request.body[1]._id).toBe('room_2');
+      },
+    });
+  });
+});

--- a/src/__tests__/authorization/authorizationInterceptor.array.test.ts
+++ b/src/__tests__/authorization/authorizationInterceptor.array.test.ts
@@ -1,5 +1,9 @@
 import { AuthorizationInterceptor } from '../../authorization/authorization.interceptor';
-import { ExecutionContext } from '@nestjs/common';
+import {
+  ExecutionContext,
+  ForbiddenException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { of } from 'rxjs';
 import { User } from '../../auth/user';
 import { createMongoAbility, AbilityBuilder } from '@casl/ability';
@@ -9,7 +13,6 @@ describe('AuthorizationInterceptor - Array Payload Handling', () => {
   let mockCaslFactory: any;
   let mockReflector: any;
 
-  // Define the DTO class for the test
   class TestDto {
     _id!: string;
     name!: string;
@@ -17,9 +20,10 @@ describe('AuthorizationInterceptor - Array Payload Handling', () => {
 
   beforeEach(() => {
     const { can, build } = new AbilityBuilder(createMongoAbility);
-    
-    // Grant permissions here for the test user
     can('update_request', TestDto);
+    can('read_request', TestDto);
+    can('read_response', TestDto);
+    can('update_response', TestDto);
     const realAbility = build();
 
     mockCaslFactory = {
@@ -36,6 +40,30 @@ describe('AuthorizationInterceptor - Array Payload Handling', () => {
     interceptor = new AuthorizationInterceptor(mockCaslFactory, mockReflector);
   });
 
+  it('should process single object payloads correctly', async () => {
+    const requestBody = { _id: 'room_1', name: 'Living Room' };
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: requestBody, params: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = { handle: jest.fn().mockReturnValue(of({ data: 'ok' })) };
+
+    const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+    result$.subscribe({
+      next: () => {
+        const request = mockExecutionContext.switchToHttp().getRequest();
+        expect(Array.isArray(request.body)).toBe(false);
+        expect(request.body._id).toBe('room_1');
+      },
+    });
+  });
+
   it('should process array payloads without throwing 403 or stripping items', async () => {
     const requestBody = [
       { _id: 'room_1', name: 'Living Room' },
@@ -46,18 +74,12 @@ describe('AuthorizationInterceptor - Array Payload Handling', () => {
 
     const mockExecutionContext = {
       switchToHttp: () => ({
-        getRequest: () => ({
-          user: mockUser,
-          body: requestBody,
-          params: {},
-        }),
+        getRequest: () => ({ user: mockUser, body: requestBody, params: {} }),
       }),
       getHandler: () => ({}),
     } as unknown as ExecutionContext;
 
-    const mockCallHandler = {
-      handle: jest.fn().mockReturnValue(of({ data: 'ok' })),
-    };
+    const mockCallHandler = { handle: jest.fn().mockReturnValue(of({ data: 'ok' })) };
 
     const result$ = await interceptor.intercept(
       mockExecutionContext,
@@ -73,5 +95,122 @@ describe('AuthorizationInterceptor - Array Payload Handling', () => {
         expect(request.body[1]._id).toBe('room_2');
       },
     });
+  });
+
+  it('should throw ForbiddenException when an item in an array payload fails a permission check', async () => {
+    const { build } = new AbilityBuilder(createMongoAbility);
+    const restrictAbility = build(); // No permissions granted
+
+    mockCaslFactory.createForUser.mockResolvedValueOnce(restrictAbility);
+
+    const requestBody = [{ _id: 'room_1', name: 'Living Room' }];
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: requestBody, params: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = { handle: jest.fn() };
+
+    await expect(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should throw ForbiddenException when a single object payload fails a permission check', async () => {
+    const { build } = new AbilityBuilder(createMongoAbility);
+    const restrictAbility = build(); // No permissions granted
+
+    mockCaslFactory.createForUser.mockResolvedValueOnce(restrictAbility);
+
+    const requestBody = { _id: 'room_1', name: 'Living Room' };
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: requestBody, params: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = { handle: jest.fn() };
+
+    await expect(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('should handle non-update actions', async () => {
+    mockReflector.get.mockReturnValueOnce({
+      action: 'read',
+      subject: TestDto,
+    });
+
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: {}, params: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = { handle: jest.fn().mockReturnValue(of({ _id: 'room_1', name: 'Test' })) };
+
+    const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+    result$.subscribe({
+      next: (res) => {
+        expect(res).toBeDefined();
+      },
+    });
+  });
+
+  it('should process response mapping logic for array responses', async () => {
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: [], params: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const responseData = [
+      { _id: 'room_1', name: 'Living Room' },
+      { _id: 'room_2', name: 'Bedroom' },
+    ];
+
+    const mockCallHandler = { handle: jest.fn().mockReturnValue(of(responseData)) };
+
+    const result$ = await interceptor.intercept(mockExecutionContext, mockCallHandler);
+
+    result$.subscribe({
+      next: (data) => {
+        expect(data).toBeDefined();
+      },
+    });
+  });
+
+  it('should throw InternalServerErrorException if no permission metadata is defined on route', async () => {
+    mockReflector.get.mockReturnValueOnce(undefined);
+
+    const mockUser = new User('mock_profile_id', 'mock_player_id', 'mock_clan_id');
+
+    const mockExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => ({ user: mockUser, body: {} }),
+      }),
+      getHandler: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const mockCallHandler = { handle: jest.fn() };
+
+    await expect(
+      interceptor.intercept(mockExecutionContext, mockCallHandler),
+    ).rejects.toThrow(InternalServerErrorException);
   });
 });

--- a/src/authorization/authorization.interceptor.ts
+++ b/src/authorization/authorization.interceptor.ts
@@ -159,10 +159,14 @@ export class AuthorizationInterceptor implements NestInterceptor {
     //Filter out all fields that logged user can not update
     //Basically create a new request body
     if (action === Action.update) {
-      //@ts-expect-error: The `plainToInstance` function may not strictly match the expected type of `subject` at runtime
-      const dataClass: typeof subject = plainToInstance(subject, request.body);
-      if (!userAbility.can(requestAction, dataClass))
+    if (Array.isArray(request.body)) {
+    // 1. Process Array Payloads
+      const items = request.body.map((item) => {
+      const dataClass = plainToInstance(subject, item);
+      
+      if (!userAbility.can(requestAction, dataClass)) {
         throw requestForbiddenError;
+      }
 
       const allowedFields = this.getAllowedFields(
         userAbility,
@@ -170,13 +174,38 @@ export class AuthorizationInterceptor implements NestInterceptor {
         dataClass,
         subject,
       );
-      //Add _id field, because it may not appear in case it is not specified in rule => it will be excluded from body
       allowedFields.push('_id');
-      if (!allowedFields || allowedFields.length === 0)
-        throw requestForbiddenError;
 
-      request.body = pick(dataClass, allowedFields);
+      if (!allowedFields || allowedFields.length === 0) {
+        throw requestForbiddenError;
+      }
+
+      return pick(dataClass, allowedFields);
+    });
+
+    request.body = items;
+  } else {
+    // 2. Process Single Object Payloads (Original Logic)
+    const dataClass = plainToInstance(subject, request.body);
+    if (!userAbility.can(requestAction, dataClass)) {
+      throw requestForbiddenError;
     }
+
+    const allowedFields = this.getAllowedFields(
+      userAbility,
+      requestAction,
+      dataClass,
+      subject,
+    );
+    allowedFields.push('_id');
+
+    if (!allowedFields || allowedFields.length === 0) {
+      throw requestForbiddenError;
+    }
+
+    request.body = pick(dataClass, allowedFields);
+  }
+  }
 
     return next.handle().pipe(
       map(async (data: any) => {


### PR DESCRIPTION
### Brief description

Issue #955 

I added a test to check that the behavior doesn't repeat again on top of doing the changes to the file. The functionality in the authorization interceptor file is now split into two use cases: the single object logic that was present originally, and the array logic that's added as a new addition on top of that. 

### Change list

- Updated `AuthorizationInterceptor` (`src/authorization/authorization.interceptor.ts`) to detect top-level array payloads `(Array.isArray(request.body))` during `UPDATE` requests.

- Refactored permission evaluation to iterate over array items individually with `plainToInstance()`, ensuring CASL checks permissions against individual DTO instances rather than the outer Array container type.

- Applied `lodash.pick()` per item in array bodies to prevent field stripping and maintain correct array structure.

- Preserved original single-object handling logic for standard non-array update payloads.

- Added a new unit test suite (`src/__tests__/authorization/authorizationInterceptor.array.test.ts`) to provide testing coverage for top-level array updates passing through the authorization interceptor.
