### PR TITLE
949 feature request daily task form an inner connection implementation

### DIFF
--- a/src/__tests__/dailyTasks/DailyTasksStartupRefreshService/startupRefresh.test.ts
+++ b/src/__tests__/dailyTasks/DailyTasksStartupRefreshService/startupRefresh.test.ts
@@ -165,8 +165,9 @@ describe('DailyTasksStartupRefreshService', () => {
       insertedTasks.every((task) =>
         [
           ...Object.keys(uiDailyTasks),
+          ServerTaskName.BANISH_THE_EARWORM,
           ServerTaskName.GO_TO_BATTLE,
-          ServerTaskName.WRITE_CHAT_MESSAGE,
+          ServerTaskName.FORM_AN_INNER_CONNECTION,
         ].includes(task.type),
       ),
     ).toBe(true);

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -92,7 +92,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     this.emitterService.EmitNewDailyTaskEvent(
       client.user.playerId,
-      ServerTaskName.WRITE_CHAT_MESSAGE_CLAN,
+      ServerTaskName.FORM_AN_INNER_CONNECTION,
     );
   }
 
@@ -128,11 +128,6 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     );
 
     if (error) return [null, error];
-
-    this.emitterService.EmitNewDailyTaskEvent(
-      client.user.playerId,
-      ServerTaskName.WRITE_CHAT_MESSAGE_GLOBAL,
-    );
   }
 
   @SubscribeMessage('globalMessageReaction')

--- a/src/dailyTasks/dailyTasksStartupRefresh.service.ts
+++ b/src/dailyTasks/dailyTasksStartupRefresh.service.ts
@@ -14,8 +14,9 @@ const LOCK_ID = 'daily-tasks-startup-refresh';
 const LOCK_TTL_MS = 30 * 60 * 1000;
 const SERVER_TASKS_PER_CLAN = 11;
 const TEMP_SERVER_TASK_TYPES = [
+  ServerTaskName.BANISH_THE_EARWORM,
   ServerTaskName.GO_TO_BATTLE,
-  ServerTaskName.WRITE_CHAT_MESSAGE,
+  ServerTaskName.FORM_AN_INNER_CONNECTION,
 ];
 
 type MaintenanceLock = {
@@ -229,10 +230,12 @@ export class DailyTasksStartupRefreshService implements OnApplicationBootstrap {
 
   private getServerTaskTitle(type: ServerTaskName, amount: number) {
     switch (type) {
+      case ServerTaskName.BANISH_THE_EARWORM:
+        return { fi: `Karkoita korvamato ${amount} kertaa` };
       case ServerTaskName.GO_TO_BATTLE:
         return { fi: `Pelaa ${amount} taistelua` };
-      case ServerTaskName.WRITE_CHAT_MESSAGE:
-        return { fi: `Lähetä ${amount} viestiä chattiin` };
+      case ServerTaskName.FORM_AN_INNER_CONNECTION:
+        return { fi: `Lähetä ${amount} viesti klaanichattiin` };
     }
   }
 }

--- a/src/dailyTasks/enum/oldTaskNames.enum.ts
+++ b/src/dailyTasks/enum/oldTaskNames.enum.ts
@@ -32,7 +32,10 @@ export enum OldTaskName {
   WATCH_REPLAY_REACT_FEELING = 'watch_reply_react_feeling',
   DEFINE_PLAYER_TYPE = 'define_player_type',
   CREATE_CLAN_PLAYLIST = 'create_clan_playlist',
-
+  WRITE_CHAT_MESSAGE = 'write_chat_message',
+  WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
+  WRITE_CHAT_MESSAGE_CLAN = 'write_chat_message_clan',
+  
   // old UI tasks
   FIND_3_IMPORTANT_BUTTONS = 'find_3_important_buttons',
   EXPLODE_CHARACTER_BATTLE = 'explode_character_battle',

--- a/src/dailyTasks/enum/oldTaskNames.enum.ts
+++ b/src/dailyTasks/enum/oldTaskNames.enum.ts
@@ -35,7 +35,7 @@ export enum OldTaskName {
   WRITE_CHAT_MESSAGE = 'write_chat_message',
   WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
   WRITE_CHAT_MESSAGE_CLAN = 'write_chat_message_clan',
-  
+
   // old UI tasks
   FIND_3_IMPORTANT_BUTTONS = 'find_3_important_buttons',
   EXPLODE_CHARACTER_BATTLE = 'explode_character_battle',

--- a/src/dailyTasks/enum/serverTaskName.enum.ts
+++ b/src/dailyTasks/enum/serverTaskName.enum.ts
@@ -34,7 +34,7 @@ export enum ServerTaskName {
 
   LETTING_GO_OF_THE_OLD = 'letting_go_of_the_old',
 
-  RECYCLING_EXPERIENCES = 'recycling_expericnes',
+  RECYCLING_EXPERIENCES = 'recycling_experiences',
 
   INNER_VOICE = 'inner_voice',
 
@@ -47,7 +47,7 @@ export enum ServerTaskName {
   /* Some of the older tasks are commented out,
    some have been kept to keep the server code running at the moment */
 
-  WRITE_CHAT_MESSAGE = 'write_chat_message',
+  // WRITE_CHAT_MESSAGE = 'write_chat_message',
 
   //Why?
   /**
@@ -147,13 +147,13 @@ export enum ServerTaskName {
   /**
    * laita viesti klaanissa
    */
-  WRITE_CHAT_MESSAGE_CLAN = 'write_chat_message_clan',
+  // WRITE_CHAT_MESSAGE_CLAN = 'write_chat_message_clan',
 
   //Server
   /**
    * laita viesti globalissa
    */
-  WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
+  // WRITE_CHAT_MESSAGE_GLOBAL = 'write_chat_message_global',
 
   /**
    * laita privaviesti toiselle pelaajalle

--- a/src/dailyTasks/taskGenerator.service.ts
+++ b/src/dailyTasks/taskGenerator.service.ts
@@ -13,8 +13,9 @@ type TaskInfo = {
 };
 
 const GENERATED_SERVER_TASK_TYPES = [
+  ServerTaskName.BANISH_THE_EARWORM,
   ServerTaskName.GO_TO_BATTLE,
-  ServerTaskName.WRITE_CHAT_MESSAGE,
+  ServerTaskName.FORM_AN_INNER_CONNECTION,
 ];
 
 @Injectable()
@@ -43,10 +44,12 @@ export class TaskGeneratorService {
    */
   getTaskTitle(type: ServerTaskName, amount: number): TaskTitle {
     switch (type) {
+      case ServerTaskName.BANISH_THE_EARWORM:
+        return { fi: `Karkoita korvamato ${amount} kertaa` };
       case ServerTaskName.GO_TO_BATTLE:
         return { fi: `Pelaa ${amount} taistelua` };
-      case ServerTaskName.WRITE_CHAT_MESSAGE:
-        return { fi: `Lähetä ${amount} viestiä chattiin` };
+      case ServerTaskName.FORM_AN_INNER_CONNECTION:
+        return { fi: `Lähetä ${amount} viesti klaanichattiin` };
       default:
         throw new Error('Unknown task type');
     }


### PR DESCRIPTION
### Brief description

New daily task FORM_AN_INNER_CONNECTION implemented. Its behavior is similar to old WRITE_CLAN_MESSAGE.

Sending global and private chat messages still works as earlier. They are are just not daily tasks anymore.

Related issue #949 

### Change list

- old chat related daily tasks moved to `oldTaskNames.enum.ts`
- implemented FORM_AN_INNER_CONNECTION as WRITE_CLAN_MESSAGE
- corrected typo from one server task
- updated daily task refresh service to include this new task and BANISH_THE_EARWORM, too
